### PR TITLE
Merge duplicate chat rows by JID

### DIFF
--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -248,7 +248,7 @@ func readChatRows(ctx context.Context, db *sql.DB) ([]store.Chat, error) {
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	var out []store.Chat
+	merged := map[string]store.Chat{}
 	for rows.Next() {
 		var c store.Chat
 		var last sql.NullFloat64
@@ -264,10 +264,39 @@ func readChatRows(ctx context.Context, db *sql.DB) ([]store.Chat, error) {
 		c.Archived = archived != 0
 		c.Removed = removed != 0
 		c.Hidden = hidden != 0
-		out = append(out, c)
+		if existing, ok := merged[c.JID]; ok {
+			merged[c.JID] = mergeChatRows(existing, c)
+			continue
+		}
+		merged[c.JID] = c
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	out := make([]store.Chat, 0, len(merged))
+	for _, chat := range merged {
+		out = append(out, chat)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].LastMessageAt.After(out[j].LastMessageAt) })
-	return out, rows.Err()
+	return out, nil
+}
+
+func mergeChatRows(existing, candidate store.Chat) store.Chat {
+	merged := existing
+	older := candidate
+	if merged.LastMessageAt.Before(candidate.LastMessageAt) {
+		merged = candidate
+		older = existing
+	}
+	merged.MessageCount += older.MessageCount
+	if merged.Name == "" {
+		merged.Name = older.Name
+	}
+	if merged.RawSessionType == 0 && older.RawSessionType != 0 {
+		merged.RawSessionType = older.RawSessionType
+		merged.Kind = chatKind(merged.JID, merged.RawSessionType)
+	}
+	return merged
 }
 
 func readGroupRows(ctx context.Context, db *sql.DB) ([]store.Group, error) {

--- a/internal/whatsappdb/desktop_test.go
+++ b/internal/whatsappdb/desktop_test.go
@@ -69,6 +69,57 @@ func TestImportDesktopCoreDataShape(t *testing.T) {
 	}
 }
 
+func TestImportDesktopDuplicateChatJID(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createFixtureDBs(t, source)
+
+	chatDB, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, chatDB, `
+insert into ZWACHATSESSION values (3, '111@s.whatsapp.net', 'Bob New', 700000030, 5, 1, 0, 0, 0);
+insert into ZWAMESSAGE values (5, 3, null, null, 'dm-new', 0, 700000030, 'newest message', 0, 0, '111@s.whatsapp.net', '', 'Bob New');
+`)
+	if err := chatDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	archive, err := store.Open(ctx, filepath.Join(t.TempDir(), "wacrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = archive.Close() }()
+
+	stats, err := Import(ctx, archive, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Chats != 2 || stats.Messages != 5 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+
+	status, err := archive.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Chats != 2 || status.Messages != 5 {
+		t.Fatalf("unexpected status: %+v", status)
+	}
+
+	chats, err := archive.ListChats(ctx, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chats) != 2 {
+		t.Fatalf("expected 2 chats, got %d", len(chats))
+	}
+	if chats[0].JID != "111@s.whatsapp.net" || chats[0].Name != "Bob New" || chats[0].UnreadCount != 5 || !chats[0].Archived || chats[0].MessageCount != 4 {
+		t.Fatalf("duplicate chat rows were not merged correctly: %+v", chats[0])
+	}
+}
+
 func TestDiscoverAndHelpers(t *testing.T) {
 	ctx := context.Background()
 	source := t.TempDir()


### PR DESCRIPTION
0. Solving: https://github.com/steipete/wacrawl/issues/3
1. Handle duplicate chat rows from the desktop DB by keying chats by JID and merging entries instead of appending.

2. Adds mergeChatRows to prefer the row with the latest LastMessageAt, sum MessageCount, preserve a non-empty Name, and set RawSessionType/Kind if missing. readChatRows now collects rows into a map, checks rows.Err(), builds a slice, sorts by LastMessageAt, and returns it.

3. Adds TestImportDesktopDuplicateChatJID to verify duplicates are merged and import stats/status reflect the merged result.