### PR TITLE
Use profile push names for sender resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format follows Keep a Changelog, and this project uses Semantic Versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve WhatsApp Desktop group sender-name resolution with profile push names
+  while preserving readable message-level push-name fallbacks (#7, thanks
+  @michalparkola).
+
 ## [0.2.4] - 2026-05-08
 
 ### Fixed

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -355,8 +355,10 @@ func readChats(ctx context.Context, path, sourceRoot string, names map[string]st
 func readProfilePushNameRows(ctx context.Context, db *sql.DB) (map[string]string, error) {
 	rows, err := db.QueryContext(ctx, `select coalesce(ZJID,''), coalesce(ZPUSHNAME,'') from ZWAPROFILEPUSHNAME`)
 	if err != nil {
-		// Older or fixture databases may not have this table.
-		return map[string]string{}, nil
+		if strings.Contains(err.Error(), "no such table: ZWAPROFILEPUSHNAME") {
+			return map[string]string{}, nil
+		}
+		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
 	names := map[string]string{}
@@ -594,8 +596,17 @@ func sender(fromMe bool, chatJID, fromJID, toJID, pushName, memberJID, memberNam
 		return firstNonEmpty(toJID), "me"
 	}
 	jid := firstNonEmpty(memberJID, fromJID, chatJID)
-	name := firstNonEmpty(memberName, names[jid], names[strings.TrimSuffix(jid, "@lid")], memberFirst, pushName, jid)
+	name := firstNonEmpty(memberName, resolvedName(jid, names), memberFirst, pushName, jid)
 	return jid, name
+}
+
+func resolvedName(jid string, names map[string]string) string {
+	for _, key := range []string{jid, strings.TrimSuffix(jid, "@lid")} {
+		if name := strings.TrimSpace(names[key]); name != "" && name != key && name != jid {
+			return name
+		}
+	}
+	return ""
 }
 
 func chatKind(jid string, raw int) string {

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -328,6 +328,11 @@ func readChats(ctx context.Context, path, sourceRoot string, names map[string]st
 		return nil, nil, nil, nil, 0, err
 	}
 	defer closeFn()
+	profileNames, err := readProfilePushNameRows(ctx, db)
+	if err != nil {
+		return nil, nil, nil, nil, 0, err
+	}
+	mergeMissingNames(names, profileNames)
 	chats, err := readChatRows(ctx, db)
 	if err != nil {
 		return nil, nil, nil, nil, 0, err
@@ -345,6 +350,34 @@ func readChats(ctx context.Context, path, sourceRoot string, names map[string]st
 		return nil, nil, nil, nil, 0, err
 	}
 	return chats, groups, participants, messages, mediaCount, nil
+}
+
+func readProfilePushNameRows(ctx context.Context, db *sql.DB) (map[string]string, error) {
+	rows, err := db.QueryContext(ctx, `select coalesce(ZJID,''), coalesce(ZPUSHNAME,'') from ZWAPROFILEPUSHNAME`)
+	if err != nil {
+		// Older or fixture databases may not have this table.
+		return map[string]string{}, nil
+	}
+	defer func() { _ = rows.Close() }()
+	names := map[string]string{}
+	for rows.Next() {
+		var jid, name string
+		if err := rows.Scan(&jid, &name); err != nil {
+			return nil, err
+		}
+		if jid != "" && name != "" {
+			names[jid] = name
+		}
+	}
+	return names, rows.Err()
+}
+
+func mergeMissingNames(dst, src map[string]string) {
+	for jid, name := range src {
+		if strings.TrimSpace(dst[jid]) == "" {
+			dst[jid] = name
+		}
+	}
 }
 
 func readChatRows(ctx context.Context, db *sql.DB) ([]store.Chat, error) {
@@ -561,7 +594,7 @@ func sender(fromMe bool, chatJID, fromJID, toJID, pushName, memberJID, memberNam
 		return firstNonEmpty(toJID), "me"
 	}
 	jid := firstNonEmpty(memberJID, fromJID, chatJID)
-	name := firstNonEmpty(memberName, memberFirst, pushName, names[jid], names[strings.TrimSuffix(jid, "@lid")], jid)
+	name := firstNonEmpty(memberName, names[jid], names[strings.TrimSuffix(jid, "@lid")], memberFirst, pushName, jid)
 	return jid, name
 }
 

--- a/internal/whatsappdb/desktop_test.go
+++ b/internal/whatsappdb/desktop_test.go
@@ -125,6 +125,59 @@ insert into ZWAGROUPMEMBER values (2, 2, '222@lid', 'Alice Duplicate', 'Alicia',
 	}
 }
 
+func TestImportDesktopUsesProfilePushNames(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createFixtureDBs(t, source)
+
+	chatDB, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, chatDB, `
+create table ZWAPROFILEPUSHNAME (Z_PK integer primary key, ZJID varchar, ZPUSHNAME varchar);
+insert into ZWAPROFILEPUSHNAME values (1, '333@s.whatsapp.net', 'Profile Pat');
+insert into ZWAGROUPMEMBER values (2, 2, '333@s.whatsapp.net', '', '+EAA=', 0, 1);
+insert into ZWAMESSAGE values (5, 2, 2, null, 'profile-name', 0, 700000004, 'profile-backed sender', 0, 0, '123@g.us', '', '+EAA=');
+`)
+	if err := chatDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	archive, err := store.Open(ctx, filepath.Join(t.TempDir(), "wacrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = archive.Close() }()
+
+	if _, err := Import(ctx, archive, source); err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, err := archive.Messages(ctx, store.MessageFilter{ChatJID: "123@g.us", Limit: 10, Asc: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found store.Message
+	for _, msg := range msgs {
+		if msg.MessageID == "profile-name" {
+			found = msg
+			break
+		}
+	}
+	if found.SenderJID != "333@s.whatsapp.net" || found.SenderName != "Profile Pat" {
+		t.Fatalf("profile push name was not used for sender: %+v", found)
+	}
+
+	results, err := archive.Search(ctx, store.MessageFilter{Query: "Profile Pat", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].MessageID != "profile-name" {
+		t.Fatalf("profile push name was not indexed for search: %+v", results)
+	}
+}
+
 func TestImportDesktopCopyMedia(t *testing.T) {
 	ctx := context.Background()
 	source := t.TempDir()

--- a/internal/whatsappdb/desktop_test.go
+++ b/internal/whatsappdb/desktop_test.go
@@ -178,6 +178,15 @@ insert into ZWAMESSAGE values (5, 2, 2, null, 'profile-name', 0, 700000004, 'pro
 	}
 }
 
+func TestSenderSkipsResolvedJIDFallback(t *testing.T) {
+	jid, name := sender(false, "123@g.us", "444@s.whatsapp.net", "", "Readable Push", "", "", "", map[string]string{
+		"444@s.whatsapp.net": "444@s.whatsapp.net",
+	})
+	if jid != "444@s.whatsapp.net" || name != "Readable Push" {
+		t.Fatalf("sender used JID fallback before readable push name: jid=%q name=%q", jid, name)
+	}
+}
+
 func TestImportDesktopCopyMedia(t *testing.T) {
 	ctx := context.Background()
 	source := t.TempDir()
@@ -388,6 +397,19 @@ func TestExtractReportsBrokenChatSchema(t *testing.T) {
 	defer func() { _ = os.RemoveAll(snap.Root) }()
 	if _, err := Extract(ctx, snap); err == nil {
 		t.Fatal("expected broken schema error")
+	}
+}
+
+func TestReadProfilePushNamesReportsBrokenOptionalSchema(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), chatDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	mustExec(t, db, `create table ZWAPROFILEPUSHNAME (Z_PK integer primary key);`)
+	if _, err := readProfilePushNameRows(ctx, db); err == nil {
+		t.Fatal("expected broken profile push name schema error")
 	}
 }
 


### PR DESCRIPTION
## Summary

- read `ZWAPROFILEPUSHNAME` from the WhatsApp Desktop chat database during import
- merge profile push names into the existing sender name map
- prefer that name map before less reliable group-member/message push-name fields
- add a regression test covering sender names recovered from `ZWAPROFILEPUSHNAME` and indexed by search

Fixes #6.

## Rationale

Some local WhatsApp Desktop archives have group sender fields such as `ZWAGROUPMEMBER.ZFIRSTNAME` or `ZWAMESSAGE.ZPUSHNAME` populated with opaque values. `ZWAPROFILEPUSHNAME` provides another local, read-only JID-to-name source that can improve the existing `messages.sender_name` value without changing the archive schema.

Because `messages.sender_name` is already indexed into FTS, this also improves sender-name search for the recovered names.

## Testing

```sh
go test ./...
```
