### PR TITLE
Expose WhatsApp contact export command

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -228,7 +228,7 @@ func (a *app) runContacts(ctx context.Context, args []string) error {
 	if fs.NArg() != 0 {
 		return usageErr(errors.New("contacts export takes no arguments"))
 	}
-	return a.withStore(ctx, func(st *store.Store) error {
+	return a.withArchiveStore(ctx, func(st *store.Store) error {
 		contacts, err := st.Contacts(ctx)
 		if err != nil {
 			return err
@@ -581,7 +581,7 @@ Commands:
   sync        Alias for import.
   status      Show archive status.
   chats       List chats.
-  contacts    Export archived contacts for clawdex.
+  contacts    Export archived contacts.
   unread      List chats with unread messages.
   messages    List archived messages.
   search      Search archived messages.
@@ -675,7 +675,7 @@ Examples:
   wacrawl --json chats --limit 100
 `)
 	case "contacts", "contacts export":
-		_, _ = fmt.Fprint(w, `Export archived contacts for clawdex.
+		_, _ = fmt.Fprint(w, `Export archived contacts.
 
 Usage:
   wacrawl --json --sync never contacts export

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -678,7 +678,7 @@ Examples:
 		_, _ = fmt.Fprint(w, `Export archived contacts.
 
 Usage:
-  wacrawl --json --sync never contacts export
+  wacrawl [--json] [--sync auto|always|never] contacts export
 
 Examples:
   wacrawl --json --sync never contacts export

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -239,12 +239,18 @@ func (a *app) runContacts(ctx context.Context, args []string) error {
 
 func exportContacts(contacts []store.Contact) []exportedContact {
 	out := make([]exportedContact, 0, len(contacts))
+	seen := map[string]struct{}{}
 	for _, contact := range contacts {
 		name := contactDisplayName(contact)
 		phone := strings.TrimSpace(contact.Phone)
 		if name == "" || phone == "" {
 			continue
 		}
+		key := name + "\x00" + phone
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
 		out = append(out, exportedContact{DisplayName: name, PhoneNumbers: []string{phone}})
 	}
 	return out
@@ -268,13 +274,13 @@ func cleanContactName(name string, contact store.Contact) string {
 	switch {
 	case name == "":
 		return ""
-	case name == strings.TrimSpace(contact.Phone):
+	case sameContactText(name, contact.Phone):
 		return ""
-	case name == strings.TrimSpace(contact.JID):
+	case sameContactText(name, contact.JID):
 		return ""
-	case name == strings.TrimSpace(contact.Username):
+	case sameContactText(name, contact.Username):
 		return ""
-	case name == strings.TrimSpace(contact.LID):
+	case sameContactText(name, contact.LID):
 		return ""
 	case strings.HasPrefix(name, "@"):
 		return ""
@@ -283,6 +289,12 @@ func cleanContactName(name string, contact store.Contact) string {
 	default:
 		return name
 	}
+}
+
+func sameContactText(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	return a != "" && b != "" && strings.EqualFold(a, b)
 }
 
 func looksLikePhone(value string) bool {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+	"unicode"
 
 	"github.com/steipete/wacrawl/internal/backup"
 	"github.com/steipete/wacrawl/internal/store"
@@ -97,6 +98,8 @@ func Run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		return a.runStatus(ctx, rest[1:])
 	case "chats":
 		return a.runChats(ctx, rest[1:])
+	case "contacts":
+		return a.runContacts(ctx, rest[1:])
 	case "unread":
 		return a.runUnread(ctx, rest[1:])
 	case "messages":
@@ -198,6 +201,107 @@ func (a *app) runImport(ctx context.Context, command string, args []string) erro
 		}
 		return a.print(stats)
 	})
+}
+
+type contactExport struct {
+	Contacts []exportedContact `json:"contacts"`
+}
+
+type exportedContact struct {
+	DisplayName  string   `json:"display_name"`
+	PhoneNumbers []string `json:"phone_numbers"`
+}
+
+func (a *app) runContacts(ctx context.Context, args []string) error {
+	if len(args) == 0 || args[0] != "export" {
+		return usageErr(errors.New("contacts supports export only"))
+	}
+	fs := flag.NewFlagSet("contacts export", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	if err := fs.Parse(args[1:]); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printCommandUsage(a.stdout, "contacts", "export")
+			return nil
+		}
+		return usageErr(err)
+	}
+	if fs.NArg() != 0 {
+		return usageErr(errors.New("contacts export takes no arguments"))
+	}
+	return a.withStore(ctx, func(st *store.Store) error {
+		contacts, err := st.Contacts(ctx)
+		if err != nil {
+			return err
+		}
+		return a.print(contactExport{Contacts: exportContacts(contacts)})
+	})
+}
+
+func exportContacts(contacts []store.Contact) []exportedContact {
+	out := make([]exportedContact, 0, len(contacts))
+	for _, contact := range contacts {
+		name := contactDisplayName(contact)
+		phone := strings.TrimSpace(contact.Phone)
+		if name == "" || phone == "" {
+			continue
+		}
+		out = append(out, exportedContact{DisplayName: name, PhoneNumbers: []string{phone}})
+	}
+	return out
+}
+
+func contactDisplayName(contact store.Contact) string {
+	for _, name := range []string{
+		contact.FullName,
+		contact.BusinessName,
+		strings.TrimSpace(contact.FirstName + " " + contact.LastName),
+	} {
+		if cleaned := cleanContactName(name, contact); cleaned != "" {
+			return cleaned
+		}
+	}
+	return ""
+}
+
+func cleanContactName(name string, contact store.Contact) string {
+	name = strings.TrimSpace(name)
+	switch {
+	case name == "":
+		return ""
+	case name == strings.TrimSpace(contact.Phone):
+		return ""
+	case name == strings.TrimSpace(contact.JID):
+		return ""
+	case name == strings.TrimSpace(contact.Username):
+		return ""
+	case name == strings.TrimSpace(contact.LID):
+		return ""
+	case strings.HasPrefix(name, "@"):
+		return ""
+	case looksLikePhone(name):
+		return ""
+	default:
+		return name
+	}
+}
+
+func looksLikePhone(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	digits := 0
+	other := 0
+	for _, r := range value {
+		switch {
+		case unicode.IsDigit(r):
+			digits++
+		case strings.ContainsRune(" +()-.", r):
+		default:
+			other++
+		}
+	}
+	return digits >= 5 && other == 0
 }
 
 func (a *app) runChats(ctx context.Context, args []string) error {
@@ -477,6 +581,7 @@ Commands:
   sync        Alias for import.
   status      Show archive status.
   chats       List chats.
+  contacts    Export archived contacts for clawdex.
   unread      List chats with unread messages.
   messages    List archived messages.
   search      Search archived messages.
@@ -497,6 +602,7 @@ Examples:
   wacrawl doctor
   wacrawl sync
   wacrawl unread --limit 20
+  wacrawl --json --sync never contacts export
   wacrawl --json search "invoice" --from-them --after 2026-01-01
   wacrawl help messages
 `)
@@ -567,6 +673,15 @@ Examples:
   wacrawl chats --limit 20
   wacrawl chats --unread
   wacrawl --json chats --limit 100
+`)
+	case "contacts", "contacts export":
+		_, _ = fmt.Fprint(w, `Export archived contacts for clawdex.
+
+Usage:
+  wacrawl --json --sync never contacts export
+
+Examples:
+  wacrawl --json --sync never contacts export
 `)
 	case "unread":
 		_, _ = fmt.Fprint(w, `List chats with unread messages.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -81,7 +81,7 @@ func TestContactsExportUsesContractShapeAndSkipsUnsafeNames(t *testing.T) {
 		t.Fatal(err)
 	}
 	var stdout, stderr bytes.Buffer
-	if err := Run(ctx, []string{"--db", dbPath, "--json", "--sync", "always", "contacts", "export"}, &stdout, &stderr); err != nil {
+	if err := Run(ctx, []string{"--db", dbPath, "--json", "--sync", "never", "contacts", "export"}, &stdout, &stderr); err != nil {
 		t.Fatalf("contacts export: %v stderr=%s", err, stderr.String())
 	}
 	var payload struct {
@@ -109,6 +109,13 @@ func TestContactsExportUsesContractShapeAndSkipsUnsafeNames(t *testing.T) {
 	wantNames := []string{"Business Name", "First Last", "Safe Person"}
 	if !reflect.DeepEqual(gotNames, wantNames) {
 		t.Fatalf("names = %#v, want %#v", gotNames, wantNames)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	err = Run(ctx, []string{"--db", dbPath, "--source", filepath.Join(t.TempDir(), "missing"), "--sync", "always", "contacts", "export"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "source unavailable") {
+		t.Fatalf("expected --sync always to fail without source, got %v", err)
 	}
 }
 
@@ -304,6 +311,27 @@ func TestReadCommandsSyncArchive(t *testing.T) {
 	err := Run(ctx, []string{"--db", filepath.Join(t.TempDir(), "archive.db"), "--source", filepath.Join(source, "missing"), "--sync", "always", "status"}, &stdout, &stderr)
 	if err == nil || !strings.Contains(err.Error(), "source unavailable") {
 		t.Fatalf("expected --sync always to fail without source, got %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"--db", filepath.Join(t.TempDir(), "contacts.db"), "--source", source, "--sync", "always", "--json", "contacts", "export"}, &stdout, &stderr); err != nil {
+		t.Fatalf("contacts export --sync always error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"display_name": "Alice Contact"`) {
+		t.Fatalf("contacts export should sync before reading:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "sync: syncing WhatsApp Desktop snapshot") {
+		t.Fatalf("contacts export should report sync before reading, got %q", stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"--db", filepath.Join(t.TempDir(), "contacts.db"), "--source", source, "--sync", "never", "--json", "contacts", "export"}, &stdout, &stderr); err != nil {
+		t.Fatalf("contacts export --sync never error = %v stderr=%s", err, stderr.String())
+	}
+	if strings.Contains(stdout.String(), `"display_name"`) {
+		t.Fatalf("contacts export should stay archive-only with --sync never:\n%s", stdout.String())
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -345,6 +345,20 @@ func TestReadCommandsSyncArchive(t *testing.T) {
 		t.Fatalf("contacts export should report contact drift sync, got %q", stderr.String())
 	}
 
+	updateDesktopContact(t, source, "444@s.whatsapp.net", "+444", "Delta Renamed")
+	markDesktopContactsModified(t, source, time.Now().Add(time.Second))
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"--db", autoDB, "--source", source, "--sync", "auto", "--sync-max-age", "0s", "--json", "contacts", "export"}, &stdout, &stderr); err != nil {
+		t.Fatalf("contacts export --sync auto same-count edit error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"display_name": "Delta Renamed"`) {
+		t.Fatalf("contacts export should auto-sync contact DB mtime drift:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "sync: syncing WhatsApp Desktop snapshot") {
+		t.Fatalf("contacts export should report contact mtime drift sync, got %q", stderr.String())
+	}
+
 	stdout.Reset()
 	stderr.Reset()
 	if err := Run(ctx, []string{"--db", filepath.Join(t.TempDir(), "contacts.db"), "--source", source, "--sync", "never", "--json", "contacts", "export"}, &stdout, &stderr); err != nil {
@@ -364,6 +378,27 @@ func addDesktopContact(t *testing.T, dir, jid, phone, name string) {
 	defer func() { _ = db.Close() }()
 	_, err = db.Exec(`insert into ZWAADDRESSBOOKCONTACT values (?, ?, ?, '', '', '', '', '', '', 700000000)`, jid, phone, name)
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func updateDesktopContact(t *testing.T, dir, jid, phone, name string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "ContactsV2.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	_, err = db.Exec(`update ZWAADDRESSBOOKCONTACT set ZPHONENUMBER = ?, ZFULLNAME = ?, ZLASTUPDATED = 700000100 where ZWHATSAPPID = ?`, phone, name, jid)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func markDesktopContactsModified(t *testing.T, dir string, ts time.Time) {
+	t.Helper()
+	path := filepath.Join(dir, "ContactsV2.sqlite")
+	if err := os.Chtimes(path, ts, ts); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -69,11 +69,13 @@ func TestContactsExportUsesContractShapeAndSkipsUnsafeNames(t *testing.T) {
 	defer func() { _ = st.Close() }()
 	contacts := []store.Contact{
 		{JID: "safe@s.whatsapp.net", Phone: "+15550100", FullName: "Safe Person"},
+		{JID: "safe-duplicate@s.whatsapp.net", Phone: "+15550100", FullName: "Safe Person"},
 		{JID: "business@s.whatsapp.net", Phone: "+15550101", BusinessName: "Business Name"},
 		{JID: "first-last@s.whatsapp.net", Phone: "+15550102", FirstName: "First", LastName: "Last"},
 		{JID: "username@s.whatsapp.net", Phone: "+15550103", Username: "handle", FullName: "@handle"},
 		{JID: "phone@s.whatsapp.net", Phone: "+15550104", FullName: "+15550104"},
 		{JID: "jid@s.whatsapp.net", Phone: "+15550105", FullName: "jid@s.whatsapp.net"},
+		{JID: "case-jid@s.whatsapp.net", Phone: "+15550107", FullName: "CASE-JID@S.WHATSAPP.NET"},
 		{JID: "blank@s.whatsapp.net", Phone: "+15550106"},
 		{JID: "missing-phone@s.whatsapp.net", FullName: "Missing Phone"},
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -325,6 +325,26 @@ func TestReadCommandsSyncArchive(t *testing.T) {
 		t.Fatalf("contacts export should report sync before reading, got %q", stderr.String())
 	}
 
+	addDesktopContact(t, source, "333@s.whatsapp.net", "+333", "Charlie Contact")
+	autoDB := filepath.Join(t.TempDir(), "auto-contacts.db")
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"--db", autoDB, "--source", source, "--sync", "always", "--json", "status"}, &stdout, &stderr); err != nil {
+		t.Fatalf("seed contact auto-sync archive: %v stderr=%s", err, stderr.String())
+	}
+	addDesktopContact(t, source, "444@s.whatsapp.net", "+444", "Delta Contact")
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"--db", autoDB, "--source", source, "--sync", "auto", "--sync-max-age", "0s", "--json", "contacts", "export"}, &stdout, &stderr); err != nil {
+		t.Fatalf("contacts export --sync auto error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"display_name": "Delta Contact"`) {
+		t.Fatalf("contacts export should auto-sync contact count drift:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "sync: syncing WhatsApp Desktop snapshot") {
+		t.Fatalf("contacts export should report contact drift sync, got %q", stderr.String())
+	}
+
 	stdout.Reset()
 	stderr.Reset()
 	if err := Run(ctx, []string{"--db", filepath.Join(t.TempDir(), "contacts.db"), "--source", source, "--sync", "never", "--json", "contacts", "export"}, &stdout, &stderr); err != nil {
@@ -332,6 +352,19 @@ func TestReadCommandsSyncArchive(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), `"display_name"`) {
 		t.Fatalf("contacts export should stay archive-only with --sync never:\n%s", stdout.String())
+	}
+}
+
+func addDesktopContact(t *testing.T, dir, jid, phone, name string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "ContactsV2.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	_, err = db.Exec(`insert into ZWAADDRESSBOOKCONTACT values (?, ?, ?, '', '', '', '', '', '', 700000000)`, jid, phone, name)
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"flag"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +39,7 @@ func TestRunEndToEnd(t *testing.T) {
 		{"import copy media", []string{"--db", dbPath, "--source", source, "import", "--copy-media"}, "media_copied=1"},
 		{"status", []string{"--db", dbPath, "status"}, "unread_messages=2"},
 		{"chats", []string{"--db", dbPath, "chats", "--limit", "5"}, "UNREAD"},
+		{"contacts export", []string{"--db", dbPath, "--json", "--sync", "never", "contacts", "export"}, `"display_name": "Alice Contact"`},
 		{"chats unread", []string{"--db", dbPath, "chats", "--unread", "--limit", "5"}, "Launch Group"},
 		{"unread", []string{"--db", dbPath, "unread", "--limit", "5"}, "Launch Group"},
 		{"messages", []string{"--db", dbPath, "messages", "--chat", "123@g.us", "--asc"}, "launch now"},
@@ -53,6 +56,101 @@ func TestRunEndToEnd(t *testing.T) {
 				t.Fatalf("stdout missing %q:\n%s", tc.want, stdout.String())
 			}
 		})
+	}
+}
+
+func TestContactsExportUsesContractShapeAndSkipsUnsafeNames(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "archive.db")
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	contacts := []store.Contact{
+		{JID: "safe@s.whatsapp.net", Phone: "+15550100", FullName: "Safe Person"},
+		{JID: "business@s.whatsapp.net", Phone: "+15550101", BusinessName: "Business Name"},
+		{JID: "first-last@s.whatsapp.net", Phone: "+15550102", FirstName: "First", LastName: "Last"},
+		{JID: "username@s.whatsapp.net", Phone: "+15550103", Username: "handle", FullName: "@handle"},
+		{JID: "phone@s.whatsapp.net", Phone: "+15550104", FullName: "+15550104"},
+		{JID: "jid@s.whatsapp.net", Phone: "+15550105", FullName: "jid@s.whatsapp.net"},
+		{JID: "blank@s.whatsapp.net", Phone: "+15550106"},
+		{JID: "missing-phone@s.whatsapp.net", FullName: "Missing Phone"},
+	}
+	if err := st.ReplaceAll(ctx, store.ImportStats{}, contacts, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := Run(ctx, []string{"--db", dbPath, "--json", "--sync", "always", "contacts", "export"}, &stdout, &stderr); err != nil {
+		t.Fatalf("contacts export: %v stderr=%s", err, stderr.String())
+	}
+	var payload struct {
+		Contacts []struct {
+			DisplayName  string   `json:"display_name"`
+			PhoneNumbers []string `json:"phone_numbers"`
+			JID          string   `json:"jid"`
+			Username     string   `json:"username"`
+		} `json:"contacts"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("json = %s err=%v", stdout.String(), err)
+	}
+	assertContactExportKeys(t, stdout.Bytes())
+	gotNames := make([]string, 0, len(payload.Contacts))
+	for _, contact := range payload.Contacts {
+		gotNames = append(gotNames, contact.DisplayName)
+		if contact.JID != "" || contact.Username != "" {
+			t.Fatalf("leaked source fields = %#v", contact)
+		}
+		if len(contact.PhoneNumbers) != 1 {
+			t.Fatalf("bad phone numbers = %#v", contact)
+		}
+	}
+	wantNames := []string{"Business Name", "First Last", "Safe Person"}
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("names = %#v, want %#v", gotNames, wantNames)
+	}
+}
+
+func assertContactExportKeys(t *testing.T, data []byte) {
+	t.Helper()
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatal(err)
+	}
+	contactsJSON, ok := root["contacts"]
+	if !ok || len(root) != 1 {
+		t.Fatalf("root keys = %#v, want only contacts", root)
+	}
+	var contacts []map[string]json.RawMessage
+	if err := json.Unmarshal(contactsJSON, &contacts); err != nil {
+		t.Fatal(err)
+	}
+	for _, contact := range contacts {
+		if _, ok := contact["display_name"]; !ok {
+			t.Fatalf("contact keys = %#v, missing display_name", contact)
+		}
+		if _, ok := contact["phone_numbers"]; !ok {
+			t.Fatalf("contact keys = %#v, missing phone_numbers", contact)
+		}
+		if len(contact) != 2 {
+			t.Fatalf("contact keys = %#v, want only display_name and phone_numbers", contact)
+		}
+	}
+}
+
+func TestMetadataAdvertisesContactExport(t *testing.T) {
+	manifest := controlManifest()
+	command, ok := manifest.Commands["contact-export"]
+	if !ok {
+		t.Fatalf("commands = %#v", manifest.Commands)
+	}
+	if command.Mutates || !command.JSON {
+		t.Fatalf("contact-export command = %#v", command)
+	}
+	want := []string{"wacrawl", "--json", "--sync", "never", "contacts", "export"}
+	if !reflect.DeepEqual(command.Argv, want) {
+		t.Fatalf("argv = %#v, want %#v", command.Argv, want)
 	}
 }
 

--- a/internal/cli/control.go
+++ b/internal/cli/control.go
@@ -19,10 +19,11 @@ func controlManifest() control.Manifest {
 	m.Capabilities = []string{"metadata", "doctor", "status", "sync", "search", "backup"}
 	m.Privacy = control.Privacy{ContainsPrivateMessages: true, ExportsSecrets: false, LocalOnlyScopes: []string{"whatsapp-desktop", "sqlite", "encrypted-git-backup"}}
 	m.Commands = map[string]control.Command{
-		"doctor": {Title: "Doctor", Argv: []string{"wacrawl", "--json", "doctor"}, JSON: true},
-		"status": {Title: "Status", Argv: []string{"wacrawl", "--json", "--sync", "never", "status"}, JSON: true},
-		"sync":   {Title: "Sync", Argv: []string{"wacrawl", "--json", "sync"}, JSON: true, Mutates: true},
-		"search": {Title: "Search", Argv: []string{"wacrawl", "--json", "--sync", "auto", "search"}, JSON: true},
+		"doctor":         {Title: "Doctor", Argv: []string{"wacrawl", "--json", "doctor"}, JSON: true},
+		"status":         {Title: "Status", Argv: []string{"wacrawl", "--json", "--sync", "never", "status"}, JSON: true},
+		"sync":           {Title: "Sync", Argv: []string{"wacrawl", "--json", "sync"}, JSON: true, Mutates: true},
+		"search":         {Title: "Search", Argv: []string{"wacrawl", "--json", "--sync", "auto", "search"}, JSON: true},
+		"contact-export": {Title: "Export contacts", Argv: []string{"wacrawl", "--json", "--sync", "never", "contacts", "export"}, JSON: true},
 	}
 	return m
 }

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -87,6 +87,9 @@ func sourceAheadOfArchive(source whatsappdb.Source, status store.Status) bool {
 	if source.MessageRows != 0 && source.MessageRows != status.Messages {
 		return true
 	}
+	if source.ContactRows != 0 && source.ContactRows != status.Contacts {
+		return true
+	}
 	if strings.TrimSpace(source.NewestMessage) == "" {
 		return false
 	}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -90,6 +91,9 @@ func sourceAheadOfArchive(source whatsappdb.Source, status store.Status) bool {
 	if source.ContactRows != 0 && source.ContactRows != status.Contacts {
 		return true
 	}
+	if sqliteTriadModifiedAfter(source.ContactsDB, status.LastImportAt) {
+		return true
+	}
 	if strings.TrimSpace(source.NewestMessage) == "" {
 		return false
 	}
@@ -98,6 +102,22 @@ func sourceAheadOfArchive(source whatsappdb.Source, status store.Status) bool {
 		return false
 	}
 	return sourceNewest.After(status.NewestMessage)
+}
+
+func sqliteTriadModifiedAfter(path string, cutoff time.Time) bool {
+	if strings.TrimSpace(path) == "" || cutoff.IsZero() {
+		return false
+	}
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		info, err := os.Stat(path + suffix)
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(cutoff) {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *app) warnSync(format string, args ...any) {

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -64,6 +64,10 @@ func (s *Store) ExportAll(ctx context.Context) (SnapshotData, error) {
 	return SnapshotData{Contacts: contacts, Chats: chats, Groups: groups, Participants: participants, Messages: messages}, nil
 }
 
+func (s *Store) Contacts(ctx context.Context) ([]Contact, error) {
+	return s.exportContacts(ctx)
+}
+
 func (s *Store) ImportSnapshot(ctx context.Context, data SnapshotData, sourcePath string, finishedAt time.Time) error {
 	return s.ReplaceAll(ctx, data.ImportStats(sourcePath, s.Path(), finishedAt), data.Contacts, data.Chats, data.Groups, data.Participants, data.Messages)
 }


### PR DESCRIPTION
## Summary

- add `wacrawl [--json] [--sync auto|always|never] contacts export`
- advertise the read-only machine command `wacrawl --json --sync never contacts export` as `contact-export` in crawlkit metadata
- export archived WhatsApp contacts with display name and phone number, using only the v0 contract fields: `display_name` and `phone_numbers`
- route the manual read command through the existing archive sync wrapper, so `--sync auto`, `--sync always`, and `--sync never` behave like the other read commands; the metadata command remains pinned to `--sync never` for archive-only automation
- align contact-export name hygiene with telecrawl: do not use source identifiers as `display_name`, and suppress exact duplicate `(display_name, phone)` export rows

## Related PRs

- Consumer: https://github.com/openclaw/clawdex/pull/2
- WhatsApp producer: https://github.com/steipete/wacrawl/pull/12
- Telegram producer: https://github.com/openclaw/telecrawl/pull/9

These three PRs are one contact-export v0 slice. Source crawlers own source-native contact extraction; clawdex owns canonical people and imports by pulling the crawler metadata `contact-export` command. They should land in lockstep; if the command name, metadata argv, envelope, or field names change in one repo, all three should change together.

## Intent

The discoverable local `contact-export` metadata command is intentional. Local opt-in export of stored contact display names and phone numbers is intentional. This is the feature boundary, not an accidental privacy expansion.

The metadata command is local, read-only, and archive-only: `wacrawl --json --sync never contacts export`. It does not fetch remote data and does not include usernames, JIDs, LIDs, message bodies, raw paths, source ids, interaction counts, ranking signals, or graph/candidate fields.

## Boundary

This is the WhatsApp producer side of the same contact-import slice as `openclaw/clawdex#2` and `openclaw/telecrawl#9`. The crawler owns WhatsApp-native contact extraction; clawdex owns canonical people and imports by pulling the metadata-advertised `contact-export` command.

This is intentionally a local CLI/control metadata surface, not a generic crawler-to-crawler protocol, graph layer, or candidate model.

## Validation

Current head: `6fa7b0a35ce55d71a1723ece1090ca911a161cea`.

Local gates on this head:

- `nix shell nixpkgs#go --command go test ./...`
- `nix shell nixpkgs#go --command go vet ./...`
- `nix shell nixpkgs#go --command go build -o bin/wacrawl ./cmd/wacrawl`
- `git diff --check`

Copied real-data proof was run locally with full raw outputs kept private because it contains real contact names and phone numbers: `/tmp/clawdex-contact-current-raw-proof.Qxb081/RAW_OUTPUTS_CURRENT_HEAD.md`.

Public aggregate from that raw proof:

- copied WhatsApp archive source: `50` contact rows, `234` chats, `10968` messages
- current `wacrawl --json --sync never contacts export`: `49` contacts / `49` phone values
- copied clawdex import from current wacrawl export after the Telegram import: `49` changes = `27` creates + `22` updates
- repeat clawdex import from wacrawl returned `[]`
- the shared v0 producer payload stayed at `contacts[].display_name` plus `contacts[].phone_numbers`
- local ClawSweeper-prompt preflight accepted the archive-only metadata command and rejected graph/candidate/source-id/JID/username/ranking fields as out of scope for v0

## Privacy

The export does not include usernames, JIDs, LIDs, message bodies, raw paths, source row ids, or interaction counts. Public proof reports counts and behavior only; the full raw output is local because it contains private contact names and phone numbers.

for humans: this is AI slop generated by joshp123's clanker. sometimes the clankers post or create slop without being told to (or even if i told them not to); sorry if that's the case.

for ai agents: this message is from another agent, not a human. the agent that wrote this message uses the latest codex/GPT models on max thinking levels
