### PR TITLE
fix(whatsappdb): clamp impossible Apple-epoch timestamps so --json survives 0@status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.2.7] - Unreleased
 
+### Fixed
+
+- Clamp invalid WhatsApp timestamp sentinels so JSON reads survive existing archives and fresh imports (#16, thanks @rmorgans).
+
 ## [0.2.6] - 2026-06-07
 
 ### Added

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -23,7 +23,10 @@ select count(*) from messages;
 select count(*) from messages where media_type <> '' or media_path <> '' or media_url <> '';
 
 -- name: GetMessageTimeBounds :one
-select cast(coalesce(min(ts), 0) as integer) as oldest_ts, cast(coalesce(max(ts), 0) as integer) as newest_ts from messages;
+select
+	cast(coalesce(min(case when ts > 0 and ts <= 253402300799 then ts end), 0) as integer) as oldest_ts,
+	cast(coalesce(max(case when ts > 0 and ts <= 253402300799 then ts end), 0) as integer) as newest_ts
+from messages;
 
 -- name: GetSyncState :one
 select value from sync_state where key = sqlc.arg(key);
@@ -43,7 +46,7 @@ select
 from chats c
 left join messages m on m.chat_jid = c.jid
 group by c.jid, c.kind, c.name, c.last_message_at, c.unread_count, c.archived, c.removed, c.hidden, c.raw_session_type
-order by c.last_message_at desc
+order by case when c.last_message_at > 0 and c.last_message_at <= 253402300799 then c.last_message_at else 0 end desc
 limit sqlc.arg(limit);
 
 -- name: ListUnreadChats :many
@@ -62,7 +65,7 @@ from chats c
 left join messages m on m.chat_jid = c.jid
 where c.unread_count > 0
 group by c.jid, c.kind, c.name, c.last_message_at, c.unread_count, c.archived, c.removed, c.hidden, c.raw_session_type
-order by c.last_message_at desc
+order by case when c.last_message_at > 0 and c.last_message_at <= 253402300799 then c.last_message_at else 0 end desc
 limit sqlc.arg(limit);
 
 -- name: ExportContacts :many

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -498,7 +498,15 @@ func fromUnix(v int64) time.Time {
 	if v <= 0 {
 		return time.Time{}
 	}
-	return time.Unix(v, 0).UTC()
+	t := time.Unix(v, 0).UTC()
+	// A persisted timestamp can fall outside JSON's marshalable year range if it
+	// was imported before appleNullTime clamped impossible Apple-epoch sentinels
+	// (e.g. the 0@status pseudo-chat, stored as ~year 11001). Treat such values as
+	// unknown so reads of an already-populated archive don't break --json output.
+	if y := t.Year(); y < 1 || y > 9999 {
+		return time.Time{}
+	}
+	return t
 }
 
 func nullString(v string) sql.NullString {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,7 +14,13 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const schemaVersion = 1
+const (
+	schemaVersion     = 1
+	maxJSONUnixSecond = 253402300799 // 9999-12-31T23:59:59Z, the largest time.Time JSON can marshal.
+
+	messageSelectColumns = `source_pk, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred, '' as snippet`
+	messageScanColumns   = `source_pk, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred, snippet`
+)
 
 type Store struct {
 	db   *sql.DB
@@ -348,10 +354,6 @@ func (s *Store) Status(ctx context.Context) (Status, error) {
 	if err != nil {
 		return out, err
 	}
-	// Route message-time bounds through the same JSON-safe conversion as every
-	// other persisted timestamp so a pre-fix out-of-range messages.ts can't break
-	// `--json status`. fromUnix clamps both <= 0 and out-of-range years to zero,
-	// which the omitzero JSON tags then drop.
 	out.OldestMessage = fromUnix(bounds.OldestTs)
 	out.NewestMessage = fromUnix(bounds.NewestTs)
 	lastImport, _ := s.q.GetSyncState(ctx, "last_import_at")
@@ -400,16 +402,50 @@ func (s *Store) Messages(ctx context.Context, filter MessageFilter) ([]Message, 
 	if filter.Limit <= 0 {
 		filter.Limit = 50
 	}
-	query := `select source_pk, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred, '' from messages where 1=1`
-	var args []any
-	query, args = applyMessageFilters(query, args, filter, false)
-	if filter.Asc {
-		query += " order by ts asc, source_pk asc limit ?"
-	} else {
-		query += " order by ts desc, source_pk desc limit ?"
-	}
-	args = append(args, filter.Limit)
+	query, args := messageListQuery(filter)
 	return scanMessages(ctx, s.db, query, args...)
+}
+
+func messageListQuery(filter MessageFilter) (string, []any) {
+	validQuery, validArgs := filteredMessagesQuery(filter, "")
+	validQuery += " and " + validUnixPredicate("ts")
+	if filter.After != nil || filter.Before != nil {
+		if filter.Asc {
+			validQuery += " order by ts asc, source_pk asc limit ?"
+		} else {
+			validQuery += " order by ts desc, source_pk desc limit ?"
+		}
+		return validQuery, append(validArgs, filter.Limit)
+	}
+
+	if filter.Asc {
+		validQuery, validArgs = filteredMessagesQuery(filter, ", 1 as sort_bucket, ts as sort_ts")
+		validQuery += " and " + validUnixPredicate("ts")
+		invalidQuery, invalidArgs := filteredMessagesQuery(filter, ", 0 as sort_bucket, 0 as sort_ts")
+		invalidQuery += " and " + invalidUnixPredicate("ts")
+		query := "select " + messageScanColumns + " from (select * from (" + invalidQuery + " order by source_pk asc limit ?) union all select * from (" + validQuery + " order by ts asc, source_pk asc limit ?)) order by sort_bucket asc, sort_ts asc, source_pk asc limit ?"
+		args := append([]any{}, invalidArgs...)
+		args = append(args, filter.Limit)
+		args = append(args, validArgs...)
+		args = append(args, filter.Limit, filter.Limit)
+		return query, args
+	}
+
+	validQuery, validArgs = filteredMessagesQuery(filter, ", 0 as sort_bucket, ts as sort_ts")
+	validQuery += " and " + validUnixPredicate("ts")
+	invalidQuery, invalidArgs := filteredMessagesQuery(filter, ", 1 as sort_bucket, 0 as sort_ts")
+	invalidQuery += " and " + invalidUnixPredicate("ts")
+	query := "select " + messageScanColumns + " from (select * from (" + validQuery + " order by ts desc, source_pk desc limit ?) union all select * from (" + invalidQuery + " order by source_pk desc limit ?)) order by sort_bucket asc, sort_ts desc, source_pk desc limit ?"
+	args := append([]any{}, validArgs...)
+	args = append(args, filter.Limit)
+	args = append(args, invalidArgs...)
+	args = append(args, filter.Limit, filter.Limit)
+	return query, args
+}
+
+func filteredMessagesQuery(filter MessageFilter, extraColumns string) (string, []any) {
+	query := "select " + messageSelectColumns + extraColumns + " from messages where 1=1"
+	return applyMessageFilters(query, nil, filter, false)
 }
 
 func (s *Store) Search(ctx context.Context, filter MessageFilter) ([]Message, error) {
@@ -495,18 +531,22 @@ func unix(t time.Time) int64 {
 }
 
 func fromUnix(v int64) time.Time {
-	if v <= 0 {
+	if !validUnixTimestamp(v) {
 		return time.Time{}
 	}
-	t := time.Unix(v, 0).UTC()
-	// A persisted timestamp can fall outside JSON's marshalable year range if it
-	// was imported before appleNullTime clamped impossible Apple-epoch sentinels
-	// (e.g. the 0@status pseudo-chat, stored as ~year 11001). Treat such values as
-	// unknown so reads of an already-populated archive don't break --json output.
-	if y := t.Year(); y < 1 || y > 9999 {
-		return time.Time{}
-	}
-	return t
+	return time.Unix(v, 0).UTC()
+}
+
+func validUnixTimestamp(v int64) bool {
+	return v > 0 && v <= maxJSONUnixSecond
+}
+
+func validUnixPredicate(column string) string {
+	return fmt.Sprintf("%s > 0 and %s <= %d", column, column, maxJSONUnixSecond)
+}
+
+func invalidUnixPredicate(column string) string {
+	return fmt.Sprintf("(%s <= 0 or %s > %d)", column, column, maxJSONUnixSecond)
 }
 
 func nullString(v string) sql.NullString {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -348,12 +348,12 @@ func (s *Store) Status(ctx context.Context) (Status, error) {
 	if err != nil {
 		return out, err
 	}
-	if bounds.OldestTs > 0 {
-		out.OldestMessage = time.Unix(bounds.OldestTs, 0).UTC()
-	}
-	if bounds.NewestTs > 0 {
-		out.NewestMessage = time.Unix(bounds.NewestTs, 0).UTC()
-	}
+	// Route message-time bounds through the same JSON-safe conversion as every
+	// other persisted timestamp so a pre-fix out-of-range messages.ts can't break
+	// `--json status`. fromUnix clamps both <= 0 and out-of-range years to zero,
+	// which the omitzero JSON tags then drop.
+	out.OldestMessage = fromUnix(bounds.OldestTs)
+	out.NewestMessage = fromUnix(bounds.NewestTs)
 	lastImport, _ := s.q.GetSyncState(ctx, "last_import_at")
 	if t, err := time.Parse(time.RFC3339Nano, lastImport); err == nil {
 		out.LastImportAt = t

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -158,6 +158,23 @@ func TestOpenRequiresPath(t *testing.T) {
 	}
 }
 
+func TestFromUnixJSONBounds(t *testing.T) {
+	got := fromUnix(maxJSONUnixSecond)
+	want := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+	if !got.Equal(want) || got.Location().String() != "UTC" {
+		t.Fatalf("fromUnix(max) = %s (%s), want %s UTC", got, got.Location(), want)
+	}
+	if _, err := json.Marshal(got); err != nil {
+		t.Fatalf("max JSON-safe timestamp should marshal: %v", err)
+	}
+	if got := fromUnix(maxJSONUnixSecond + 1); !got.IsZero() {
+		t.Fatalf("out-of-range unix should clamp to zero, got %v", got)
+	}
+	if got := fromUnix(-1); !got.IsZero() {
+		t.Fatalf("negative unix should clamp to zero, got %v", got)
+	}
+}
+
 func TestReplaceAllDuplicateSourcePKFails(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(ctx, filepath.Join(t.TempDir(), "store.db"))
@@ -242,12 +259,6 @@ func TestImportSnapshotRefreshesFTS(t *testing.T) {
 	}
 }
 
-// TestListChatsClampsOutOfRangePersistedTimestamp covers an archive populated by
-// a pre-fix build, whose chats.last_message_at holds an impossible Apple-epoch
-// sentinel (the 0@status pseudo-chat) stored as out-of-range Unix seconds. The
-// read path must clamp it so --json chats/unread no longer fail with
-// "Time.MarshalJSON: year outside of range [0,9999]" — without requiring a
-// forced re-import.
 func TestListChatsClampsOutOfRangePersistedTimestamp(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(ctx, filepath.Join(t.TempDir(), "store.db"))
@@ -256,11 +267,13 @@ func TestListChatsClampsOutOfRangePersistedTimestamp(t *testing.T) {
 	}
 	defer func() { _ = st.Close() }()
 
-	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	poison := time.Unix(284990875200, 0).UTC() // year ~11001, as stored before the import-time clamp existed
-	stats := ImportStats{DBPath: st.Path(), StartedAt: now, FinishedAt: now}
-	chats := []Chat{{JID: "0@status", Kind: "status", Name: "status", LastMessageAt: poison, UnreadCount: 1}}
-	if err := st.ReplaceAll(ctx, stats, nil, chats, nil, nil, nil); err != nil {
+	valid := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	if _, err := st.DB().ExecContext(ctx, `
+insert into chats(jid, kind, name, last_message_at, unread_count, archived, removed, hidden, raw_session_type)
+values
+	('0@status', 'status', 'Status', ?, 1, 0, 0, 0, 0),
+	('valid@s.whatsapp.net', 'dm', 'Valid', ?, 1, 0, 0, 0, 0)
+`, maxJSONUnixSecond+1, valid.Unix()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -275,22 +288,74 @@ func TestListChatsClampsOutOfRangePersistedTimestamp(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", tc.name, err)
 		}
-		if len(got) != 1 {
-			t.Fatalf("%s: want 1 chat, got %d", tc.name, len(got))
+		if len(got) != 2 {
+			t.Fatalf("%s: want 2 chats, got %d", tc.name, len(got))
 		}
-		if y := got[0].LastMessageAt.Year(); y < 0 || y > 9999 {
-			t.Fatalf("%s: LastMessageAt year %d is not JSON-marshalable; want clamped to zero", tc.name, y)
+		if got[0].JID != "valid@s.whatsapp.net" || !got[0].LastMessageAt.Equal(valid) {
+			t.Fatalf("%s: valid chat should sort before clamped poison, got %+v", tc.name, got)
 		}
-		if _, err := json.Marshal(got[0]); err != nil {
+		if got[1].JID != "0@status" || !got[1].LastMessageAt.IsZero() {
+			t.Fatalf("%s: poisoned chat should clamp to zero and sort oldest, got %+v", tc.name, got)
+		}
+		if _, err := json.Marshal(got); err != nil {
 			t.Fatalf("%s: JSON marshal of already-populated archive failed: %v", tc.name, err)
 		}
 	}
 }
 
-// TestStatusClampsOutOfRangeMessageTimestamp covers the status path specifically:
-// OldestMessage/NewestMessage come from GetMessageTimeBounds, a separate path from
-// fromUnix. A pre-fix archive with an out-of-range messages.ts must not break
-// `--json status` with "Time.MarshalJSON: year outside of range [0,9999]".
+func TestMessagesClampsOutOfRangePersistedTimestamp(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "store.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	valid := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	if _, err := st.DB().ExecContext(ctx, `
+insert into chats(jid, kind, name, last_message_at, unread_count, archived, removed, hidden, raw_session_type)
+values('c@s.whatsapp.net', 'dm', 'C', ?, 0, 0, 0, 0, 0)
+`, valid.Unix()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+insert into messages(source_pk, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
+values
+	(1, 'c@s.whatsapp.net', 'C', 'poison', '', '', ?, 0, 'poison', 0, 'text', '', '', '', '', 0, 0),
+	(2, 'c@s.whatsapp.net', 'C', 'valid', '', '', ?, 0, 'valid', 0, 'text', '', '', '', '', 0, 0)
+`, maxJSONUnixSecond+1, valid.Unix()); err != nil {
+		t.Fatal(err)
+	}
+
+	desc, err := st.Messages(ctx, MessageFilter{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(desc) != 2 || desc[0].MessageID != "valid" || desc[1].MessageID != "poison" || !desc[1].Timestamp.IsZero() {
+		t.Fatalf("poisoned message should clamp to zero and sort oldest in desc order: %+v", desc)
+	}
+	if _, err := json.Marshal(desc); err != nil {
+		t.Fatalf("messages JSON marshal failed on poisoned messages.ts: %v", err)
+	}
+
+	asc, err := st.Messages(ctx, MessageFilter{Limit: 10, Asc: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(asc) != 2 || asc[0].MessageID != "poison" || asc[1].MessageID != "valid" {
+		t.Fatalf("poisoned message should sort as oldest in asc order: %+v", asc)
+	}
+
+	after := valid.Add(-time.Hour)
+	filtered, err := st.Messages(ctx, MessageFilter{After: &after, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 1 || filtered[0].MessageID != "valid" {
+		t.Fatalf("date filters should exclude unknown poisoned timestamps, got %+v", filtered)
+	}
+}
+
 func TestStatusClampsOutOfRangeMessageTimestamp(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(ctx, filepath.Join(t.TempDir(), "store.db"))
@@ -299,12 +364,19 @@ func TestStatusClampsOutOfRangeMessageTimestamp(t *testing.T) {
 	}
 	defer func() { _ = st.Close() }()
 
-	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
-	poison := time.Unix(284990875200, 0).UTC() // year ~11001 stored as messages.ts
-	chats := []Chat{{JID: "c@s.whatsapp.net", Kind: "dm", Name: "C", LastMessageAt: now}}
-	messages := []Message{{SourcePK: 1, ChatJID: "c@s.whatsapp.net", MessageID: "a", Timestamp: poison, RawType: 0, MessageType: "text"}}
-	stats := ImportStats{DBPath: st.Path(), StartedAt: now, FinishedAt: now}
-	if err := st.ReplaceAll(ctx, stats, nil, chats, nil, nil, messages); err != nil {
+	valid := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	if _, err := st.DB().ExecContext(ctx, `
+insert into chats(jid, kind, name, last_message_at, unread_count, archived, removed, hidden, raw_session_type)
+values('c@s.whatsapp.net', 'dm', 'C', ?, 0, 0, 0, 0, 0)
+`, valid.Unix()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `
+insert into messages(source_pk, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
+values
+	(1, 'c@s.whatsapp.net', 'C', 'poison', '', '', ?, 0, 'poison', 0, 'text', '', '', '', '', 0, 0),
+	(2, 'c@s.whatsapp.net', 'C', 'valid', '', '', ?, 0, 'valid', 0, 'text', '', '', '', '', 0, 0)
+`, maxJSONUnixSecond+1, valid.Unix()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -312,15 +384,21 @@ func TestStatusClampsOutOfRangeMessageTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, ts := range []struct {
-		name string
-		v    time.Time
-	}{{"OldestMessage", status.OldestMessage}, {"NewestMessage", status.NewestMessage}} {
-		if y := ts.v.Year(); y < 0 || y > 9999 {
-			t.Fatalf("%s year %d is not JSON-marshalable; want clamped to zero", ts.name, y)
-		}
+	if !status.OldestMessage.Equal(valid) || !status.NewestMessage.Equal(valid) {
+		t.Fatalf("status bounds should ignore poisoned messages.ts and keep valid bounds: %+v", status)
 	}
 	if _, err := json.Marshal(status); err != nil {
 		t.Fatalf("status JSON marshal failed on poisoned messages.ts: %v", err)
+	}
+
+	if _, err := st.DB().ExecContext(ctx, `delete from messages where source_pk = 2`); err != nil {
+		t.Fatal(err)
+	}
+	status, err = st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.OldestMessage.IsZero() || !status.NewestMessage.IsZero() {
+		t.Fatalf("all-invalid status bounds should clamp to zero: %+v", status)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -286,3 +286,41 @@ func TestListChatsClampsOutOfRangePersistedTimestamp(t *testing.T) {
 		}
 	}
 }
+
+// TestStatusClampsOutOfRangeMessageTimestamp covers the status path specifically:
+// OldestMessage/NewestMessage come from GetMessageTimeBounds, a separate path from
+// fromUnix. A pre-fix archive with an out-of-range messages.ts must not break
+// `--json status` with "Time.MarshalJSON: year outside of range [0,9999]".
+func TestStatusClampsOutOfRangeMessageTimestamp(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "store.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	poison := time.Unix(284990875200, 0).UTC() // year ~11001 stored as messages.ts
+	chats := []Chat{{JID: "c@s.whatsapp.net", Kind: "dm", Name: "C", LastMessageAt: now}}
+	messages := []Message{{SourcePK: 1, ChatJID: "c@s.whatsapp.net", MessageID: "a", Timestamp: poison, RawType: 0, MessageType: "text"}}
+	stats := ImportStats{DBPath: st.Path(), StartedAt: now, FinishedAt: now}
+	if err := st.ReplaceAll(ctx, stats, nil, chats, nil, nil, messages); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ts := range []struct {
+		name string
+		v    time.Time
+	}{{"OldestMessage", status.OldestMessage}, {"NewestMessage", status.NewestMessage}} {
+		if y := ts.v.Year(); y < 0 || y > 9999 {
+			t.Fatalf("%s year %d is not JSON-marshalable; want clamped to zero", ts.name, y)
+		}
+	}
+	if _, err := json.Marshal(status); err != nil {
+		t.Fatalf("status JSON marshal failed on poisoned messages.ts: %v", err)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
@@ -238,5 +239,50 @@ func TestImportSnapshotRefreshesFTS(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].MessageID != "a" {
 		t.Fatalf("expected updated media title FTS result, got %+v", results)
+	}
+}
+
+// TestListChatsClampsOutOfRangePersistedTimestamp covers an archive populated by
+// a pre-fix build, whose chats.last_message_at holds an impossible Apple-epoch
+// sentinel (the 0@status pseudo-chat) stored as out-of-range Unix seconds. The
+// read path must clamp it so --json chats/unread no longer fail with
+// "Time.MarshalJSON: year outside of range [0,9999]" — without requiring a
+// forced re-import.
+func TestListChatsClampsOutOfRangePersistedTimestamp(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "store.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	poison := time.Unix(284990875200, 0).UTC() // year ~11001, as stored before the import-time clamp existed
+	stats := ImportStats{DBPath: st.Path(), StartedAt: now, FinishedAt: now}
+	chats := []Chat{{JID: "0@status", Kind: "status", Name: "status", LastMessageAt: poison, UnreadCount: 1}}
+	if err := st.ReplaceAll(ctx, stats, nil, chats, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		list func() ([]Chat, error)
+	}{
+		{"ListChats", func() ([]Chat, error) { return st.ListChats(ctx, 10) }},
+		{"ListUnreadChats", func() ([]Chat, error) { return st.ListUnreadChats(ctx, 10) }},
+	} {
+		got, err := tc.list()
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if len(got) != 1 {
+			t.Fatalf("%s: want 1 chat, got %d", tc.name, len(got))
+		}
+		if y := got[0].LastMessageAt.Year(); y < 0 || y > 9999 {
+			t.Fatalf("%s: LastMessageAt year %d is not JSON-marshalable; want clamped to zero", tc.name, y)
+		}
+		if _, err := json.Marshal(got[0]); err != nil {
+			t.Fatalf("%s: JSON marshal of already-populated archive failed: %v", tc.name, err)
+		}
 	}
 }

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -381,7 +381,10 @@ func (q *Queries) ExportParticipants(ctx context.Context) ([]ExportParticipantsR
 }
 
 const getMessageTimeBounds = `-- name: GetMessageTimeBounds :one
-select cast(coalesce(min(ts), 0) as integer) as oldest_ts, cast(coalesce(max(ts), 0) as integer) as newest_ts from messages
+select
+	cast(coalesce(min(case when ts > 0 and ts <= 253402300799 then ts end), 0) as integer) as oldest_ts,
+	cast(coalesce(max(case when ts > 0 and ts <= 253402300799 then ts end), 0) as integer) as newest_ts
+from messages
 `
 
 type GetMessageTimeBoundsRow struct {
@@ -624,7 +627,7 @@ select
 from chats c
 left join messages m on m.chat_jid = c.jid
 group by c.jid, c.kind, c.name, c.last_message_at, c.unread_count, c.archived, c.removed, c.hidden, c.raw_session_type
-order by c.last_message_at desc
+order by case when c.last_message_at > 0 and c.last_message_at <= 253402300799 then c.last_message_at else 0 end desc
 limit ?1
 `
 
@@ -691,7 +694,7 @@ from chats c
 left join messages m on m.chat_jid = c.jid
 where c.unread_count > 0
 group by c.jid, c.kind, c.name, c.last_message_at, c.unread_count, c.archived, c.removed, c.hidden, c.raw_session_type
-order by c.last_message_at desc
+order by case when c.last_message_at > 0 and c.last_message_at <= 253402300799 then c.last_message_at else 0 end desc
 limit ?1
 `
 

--- a/internal/whatsappdb/appletime_test.go
+++ b/internal/whatsappdb/appletime_test.go
@@ -1,0 +1,23 @@
+package whatsappdb
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestAppleNullTimeNormalizesSentinel(t *testing.T) {
+	// A 0@status-style sentinel ZLASTMESSAGEDATE converts to an impossible year
+	// (>9999); it must normalize to zero (unknown) so it never reaches JSON.
+	if got := appleNullTime(sql.NullFloat64{Float64: 300000000000, Valid: true}); !got.IsZero() {
+		t.Fatalf("sentinel should normalize to zero, got %v (year %d)", got, got.Year())
+	}
+	// A real timestamp (2026-06-06T00:00:00Z) still converts correctly.
+	got := appleNullTime(sql.NullFloat64{Float64: 802396800, Valid: true})
+	if got.IsZero() || got.Year() != 2026 {
+		t.Fatalf("valid timestamp should convert to 2026, got %v", got)
+	}
+	// Invalid / non-positive stays zero (unchanged behaviour).
+	if got := appleNullTime(sql.NullFloat64{Valid: false}); !got.IsZero() {
+		t.Fatalf("invalid should be zero, got %v", got)
+	}
+}

--- a/internal/whatsappdb/appletime_test.go
+++ b/internal/whatsappdb/appletime_test.go
@@ -2,21 +2,39 @@ package whatsappdb
 
 import (
 	"database/sql"
+	"math"
 	"testing"
+	"time"
 )
 
 func TestAppleNullTimeNormalizesSentinel(t *testing.T) {
-	// A 0@status-style sentinel ZLASTMESSAGEDATE converts to an impossible year
-	// (>9999); it must normalize to zero (unknown) so it never reaches JSON.
 	if got := appleNullTime(sql.NullFloat64{Float64: 300000000000, Valid: true}); !got.IsZero() {
 		t.Fatalf("sentinel should normalize to zero, got %v (year %d)", got, got.Year())
 	}
-	// A real timestamp (2026-06-06T00:00:00Z) still converts correctly.
 	got := appleNullTime(sql.NullFloat64{Float64: 802396800, Valid: true})
-	if got.IsZero() || got.Year() != 2026 {
-		t.Fatalf("valid timestamp should convert to 2026, got %v", got)
+	want := time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) || got.Location().String() != "UTC" {
+		t.Fatalf("valid timestamp = %s (%s), want %s UTC", got, got.Location(), want)
 	}
-	// Invalid / non-positive stays zero (unchanged behaviour).
+}
+
+func TestAppleNullTimeJSONBounds(t *testing.T) {
+	got := appleNullTime(sql.NullFloat64{Float64: maxJSONAppleSecondExclusive - 1, Valid: true})
+	want := time.Unix(maxJSONUnixSecond, 0).UTC()
+	if !got.Equal(want) {
+		t.Fatalf("max JSON-safe Apple timestamp = %s, want %s", got, want)
+	}
+	for _, value := range []float64{
+		maxJSONAppleSecondExclusive,
+		math.Inf(1),
+		math.NaN(),
+		0,
+		-1,
+	} {
+		if got := appleNullTime(sql.NullFloat64{Float64: value, Valid: true}); !got.IsZero() {
+			t.Fatalf("invalid Apple timestamp %v should normalize to zero, got %v", value, got)
+		}
+	}
 	if got := appleNullTime(sql.NullFloat64{Valid: false}); !got.IsZero() {
 		t.Fatalf("invalid should be zero, got %v", got)
 	}

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -794,7 +794,14 @@ func appleNullTime(v sql.NullFloat64) time.Time {
 	if !v.Valid || v.Float64 <= 0 {
 		return time.Time{}
 	}
-	return appleTime(v.Float64)
+	t := appleTime(v.Float64)
+	// WhatsApp stores sentinel dates for pseudo-chats like 0@status that convert
+	// to impossible years (e.g. 11001) and break JSON encoding downstream. Treat
+	// anything outside JSON's marshalable year range as unknown.
+	if y := t.Year(); y < 1 || y > 9999 {
+		return time.Time{}
+	}
+	return t
 }
 
 func appleTime(seconds float64) time.Time {

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,9 +19,11 @@ import (
 )
 
 const (
-	chatDBName     = "ChatStorage.sqlite"
-	contactsDBName = "ContactsV2.sqlite"
-	appleEpoch     = 978307200
+	chatDBName                  = "ChatStorage.sqlite"
+	contactsDBName              = "ContactsV2.sqlite"
+	appleEpoch                  = 978307200
+	maxJSONUnixSecond           = 253402300799
+	maxJSONAppleSecondExclusive = maxJSONUnixSecond - appleEpoch + 1
 )
 
 type Source struct {
@@ -791,17 +794,11 @@ func copyFileIfExists(src, dst string) error {
 }
 
 func appleNullTime(v sql.NullFloat64) time.Time {
-	if !v.Valid || v.Float64 <= 0 {
+	seconds := v.Float64
+	if !v.Valid || seconds <= 0 || math.IsNaN(seconds) || math.IsInf(seconds, 0) || seconds >= maxJSONAppleSecondExclusive {
 		return time.Time{}
 	}
-	t := appleTime(v.Float64)
-	// WhatsApp stores sentinel dates for pseudo-chats like 0@status that convert
-	// to impossible years (e.g. 11001) and break JSON encoding downstream. Treat
-	// anything outside JSON's marshalable year range as unknown.
-	if y := t.Year(); y < 1 || y > 9999 {
-		return time.Time{}
-	}
-	return t
+	return appleTime(seconds)
 }
 
 func appleTime(seconds float64) time.Time {


### PR DESCRIPTION
## Problem

`wacrawl --json chats` / `unread` / `status` can fail with:

```
json: error calling MarshalJSON for type time.Time: Time.MarshalJSON: year outside of range [0,9999]
```

and emit empty stdout + exit 1. The human (table) output is unaffected, so it only surfaces under `--json`.

## Cause

WhatsApp Desktop stores a sentinel timestamp for pseudo-chats such as the `0@status` broadcast chat. `appleTime()` interprets it as a literal Apple-epoch value, which converts to an impossible year (~11001). That value lands in the archive, and `encoding/json` then can't marshal it (`time.Time.MarshalJSON` rejects years outside `[0,9999]`) for any command whose JSON output includes the row:

- **`chats` / `unread`** — directly, via the sentinel `ZLASTMESSAGEDATE` on the pseudo-chat (also sorts it to the top of listings).
- **`status`** — only if the out-of-range value lands in `messages.ts`, which `status` surfaces as `newest_message`/`oldest_message`. In a real archive the sentinel observed was in `chats`, which is why `status` tolerated it while `chats`/`unread` failed — but the message-bounds path is the same class of bug and is fixed defensively.

## Fix

One JSON-safe conversion at every boundary a persisted timestamp crosses:

1. **Import** (`appleNullTime`, `internal/whatsappdb/desktop.go`) — the single function every imported timestamp flows through. Impossible Apple-epoch conversions normalize to zero, so the sentinel never enters the archive (and sorts as oldest, not newest). Root fix for fresh imports.
2. **Read** (`fromUnix`, `internal/store/store.go`) — the single function every stored timestamp flows through on read (chats/unread list + messages). An out-of-range persisted value (from a pre-fix archive) clamps to zero, so an **already-populated archive self-heals without a forced re-import** — `--sync never` reads stop failing immediately.
3. **Status bounds** (`Store.Status`) — `OldestMessage`/`NewestMessage` previously used bare `time.Unix`, bypassing the clamp; now routed through `fromUnix` too, so `--json status` is covered for a poisoned `messages.ts`.

No public JSON model types change.

## Test

- `TestAppleNullTimeNormalizesSentinel` — sentinel → zero; valid timestamp unchanged; invalid/non-positive stays zero.
- `TestListChatsClampsOutOfRangePersistedTimestamp` — a poisoned `chats.last_message_at` survives `ListChats`/`ListUnreadChats` + `json.Marshal`.
- `TestStatusClampsOutOfRangeMessageTimestamp` — a poisoned `messages.ts` survives `Status()` + `json.Marshal` (the separate message-bounds path).

`go test ./...` passes; `go vet ./...` clean.

---

## Real-behavior proof (redacted)

macOS, real WhatsApp Desktop archive. Both sides built from source. `--sync never` reads the stored snapshot deterministically (no re-import); `--sync always` forces a fresh import. Private paths/content redacted. (The live sentinel was in `chats`, so this exercises the `chats`/`unread` failure + the read-side self-heal; the `status`/`messages.ts` path is covered by `TestStatusClampsOutOfRangeMessageTimestamp`.)

```console
# 1) Reproduce on origin/main @ 7c4f382 (import re-stores the 0@status sentinel):
$ wacrawl --sync never --json chats ; echo "exit=$?"
json: error calling MarshalJSON for type time.Time: Time.MarshalJSON: year outside of range [0,9999]
exit=1
$ wacrawl --sync never --json unread ; echo "exit=$?"
json: error calling MarshalJSON for type time.Time: Time.MarshalJSON: year outside of range [0,9999]
exit=1

#    stored sentinel row (year ~11001):
$ sqlite3 ~/.wacrawl/wacrawl.db 'select count(*),sum(last_message_at>253402300799),max(last_message_at) from chats'
176 chats | 1 out-of-range | max=284990875200

# 2) Fix branch — read-side clamp: already-populated archive succeeds WITHOUT re-import (--sync never):
$ wacrawl --sync never --json status ; echo "exit=$?"   # valid JSON
exit=0
$ wacrawl --sync never --json chats | jq 'length'   # valid JSON, 50 records
exit=0
$ wacrawl --sync never --json unread | jq 'length'  # valid JSON, 26 records
exit=0

#    the out-of-range row is STILL in the store — reads are clamped, no re-import needed:
$ sqlite3 ~/.wacrawl/wacrawl.db 'select count(*),sum(last_message_at>253402300799) from chats'
176 chats | 1 out-of-range
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
