### PR TITLE
Add read-only SQL query command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.2.8] - Unreleased
 
+### Added
+
+- Add read-only SQL archive queries with JSON output and automatic sync support (#18, thanks @TurboTheTurtle).
+
 ## [0.2.7] - 2026-06-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -239,6 +239,19 @@ wacrawl --json search "restaurant"
 Search uses message text, chat name, sender name, and media title fields. It
 accepts the same filters as `messages`.
 
+### `sql`
+
+Run a read-only SQL query against the archive database:
+
+```bash
+wacrawl sql "SELECT count(*) FROM messages"
+wacrawl sql "SELECT name FROM sqlite_master WHERE type='table'"
+wacrawl --json sql "SELECT chat_jid, count(*) FROM messages GROUP BY chat_jid ORDER BY 2 DESC LIMIT 10"
+```
+
+Only single read-only `SELECT` statements are accepted. Use `--db PATH` to query
+an alternate archive database.
+
 ## Sync Behavior
 
 `wacrawl` keeps normal reads fresh without a daemon or background service.

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ an alternate archive database.
 ## Sync Behavior
 
 `wacrawl` keeps normal reads fresh without a daemon or background service.
-Before `status`, `chats`, `messages`, or `search`, it checks the archive's
+Before `status`, `chats`, `messages`, `search`, or `sql`, it checks the archive's
 last import time. If the archive is stale, it inspects the WhatsApp Desktop
 source and imports a fresh snapshot only when the source is ahead.
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -106,6 +106,8 @@ func Run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		return a.runMessages(ctx, rest[1:])
 	case "search":
 		return a.runSearch(ctx, rest[1:])
+	case "sql":
+		return a.runSQL(ctx, rest[1:])
 	case "backup":
 		return a.runBackup(ctx, rest[1:])
 	default:
@@ -566,6 +568,17 @@ func (a *app) print(value any) error {
 			}
 		}
 		return nil
+	case sqlQueryResult:
+		tw := tabwriter.NewWriter(a.stdout, 2, 4, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, strings.Join(v.columns, "\t"))
+		for _, row := range v.rows {
+			values := make([]string, 0, len(v.columns))
+			for _, col := range v.columns {
+				values = append(values, formatSQLValue(row[col]))
+			}
+			_, _ = fmt.Fprintln(tw, strings.Join(values, "\t"))
+		}
+		return tw.Flush()
 	case backup.Result:
 		_, err := fmt.Fprintf(a.stdout, "repo=%s\nchanged=%t\nencrypted=%t\nshards=%d\nmessages=%d\n", v.Repo, v.Changed, v.Encrypted, v.Shards, v.Messages)
 		return err
@@ -597,6 +610,7 @@ Commands:
   unread      List chats with unread messages.
   messages    List archived messages.
   search      Search archived messages.
+  sql         Run a read-only SQL query.
   backup      Init, push, pull, or inspect encrypted Git backups.
 
 Options:
@@ -616,6 +630,7 @@ Examples:
   wacrawl unread --limit 20
   wacrawl --json --sync never contacts export
   wacrawl --json search "invoice" --from-them --after 2026-01-01
+  wacrawl sql "SELECT count(*) FROM messages"
   wacrawl help messages
 `)
 }
@@ -753,6 +768,16 @@ Examples:
   wacrawl search "invoice"
   wacrawl search "flight" --after 2026-01-01 --from-them
   wacrawl --json search --chat 1234567890@s.whatsapp.net "release notes"
+`)
+	case "sql":
+		_, _ = fmt.Fprint(w, `Run a read-only SQL query against the archive database.
+
+Usage:
+  wacrawl sql <select query>
+
+Examples:
+  wacrawl sql "SELECT count(*) FROM messages"
+  wacrawl --json sql "SELECT chat_jid, count(*) FROM messages GROUP BY chat_jid"
 `)
 	case "backup":
 		_, _ = fmt.Fprint(w, `Manage encrypted Git backups of the wacrawl archive.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -104,6 +104,17 @@ func TestRunSQLJSONAndReadOnlyValidation(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "only a single read-only select statement is allowed") {
 		t.Fatalf("expected single statement error, got %v", err)
 	}
+
+	invalidDBPath := filepath.Join(t.TempDir(), "archive.db")
+	source := t.TempDir()
+	createDesktopFixture(t, source)
+	err = Run(ctx, []string{"--db", invalidDBPath, "--source", source, "--sync", "always", "sql", "DELETE FROM messages"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), readOnlySelectError) {
+		t.Fatalf("expected read-only select error, got %v", err)
+	}
+	if _, statErr := os.Stat(invalidDBPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("invalid SQL created archive: %v", statErr)
+	}
 }
 
 func TestContactsExportUsesContractShapeAndSkipsUnsafeNames(t *testing.T) {
@@ -381,6 +392,18 @@ func TestReadCommandsSyncArchive(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "[launch] now") {
 		t.Fatalf("search should sync before reading:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"--db", filepath.Join(t.TempDir(), "archive.db"), "--source", source, "--sync", "always", "sql", "SELECT count(*) AS messages FROM messages"}, &stdout, &stderr); err != nil {
+		t.Fatalf("sql --sync always error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "messages") || !strings.Contains(stdout.String(), "3") {
+		t.Fatalf("sql should sync before reading:\n%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "sync: syncing WhatsApp Desktop snapshot") {
+		t.Fatalf("sql should report sync before reading, got %q", stderr.String())
 	}
 
 	stdout.Reset()

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -45,6 +45,7 @@ func TestRunEndToEnd(t *testing.T) {
 		{"messages", []string{"--db", dbPath, "messages", "--chat", "123@g.us", "--asc"}, "launch now"},
 		{"search", []string{"--db", dbPath, "search", "--limit", "5", "launch"}, "[launch] now"},
 		{"search flags after query", []string{"--db", dbPath, "search", "launch", "--limit", "5"}, "[launch] now"},
+		{"sql", []string{"--db", dbPath, "sql", "SELECT count(*) AS messages FROM messages"}, "messages"},
 		{"json", []string{"--db", dbPath, "--json", "search", "launch"}, `"message_id"`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -56,6 +57,52 @@ func TestRunEndToEnd(t *testing.T) {
 				t.Fatalf("stdout missing %q:\n%s", tc.want, stdout.String())
 			}
 		})
+	}
+}
+
+func TestRunSQLJSONAndReadOnlyValidation(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "archive.db")
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ReplaceAll(ctx, store.ImportStats{}, nil, []store.Chat{
+		{JID: "123@g.us", Kind: "group", Name: "Launch Group", MessageCount: 2},
+	}, nil, nil, []store.Message{
+		{SourcePK: 1, ChatJID: "123@g.us", ChatName: "Launch Group", MessageID: "m1", Text: "launch now"},
+		{SourcePK: 2, ChatJID: "123@g.us", ChatName: "Launch Group", MessageID: "m2", Text: "ship later"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Run(ctx, []string{"--db", dbPath, "--json", "sql", "SELECT chat_jid, count(*) AS messages FROM messages GROUP BY chat_jid"}, &stdout, &stderr); err != nil {
+		t.Fatalf("sql json: %v stderr=%s", err, stderr.String())
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("json = %s err=%v", stdout.String(), err)
+	}
+	if len(rows) != 1 || rows[0]["chat_jid"] != "123@g.us" || rows[0]["messages"] != float64(2) {
+		t.Fatalf("rows = %#v", rows)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	err = Run(ctx, []string{"--db", dbPath, "sql", "DELETE FROM messages"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), readOnlySelectError) {
+		t.Fatalf("expected read-only select error, got %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	err = Run(ctx, []string{"--db", dbPath, "sql", "SELECT count(*) FROM messages; SELECT count(*) FROM chats"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "only a single read-only select statement is allowed") {
+		t.Fatalf("expected single statement error, got %v", err)
 	}
 }
 
@@ -150,6 +197,18 @@ func assertContactExportKeys(t *testing.T, data []byte) {
 
 func TestMetadataAdvertisesContactExport(t *testing.T) {
 	manifest := controlManifest()
+	sqlCommand, ok := manifest.Commands["sql"]
+	if !ok {
+		t.Fatalf("commands = %#v", manifest.Commands)
+	}
+	if sqlCommand.Mutates || !sqlCommand.JSON {
+		t.Fatalf("sql command = %#v", sqlCommand)
+	}
+	sqlWant := []string{"wacrawl", "--json", "sql"}
+	if !reflect.DeepEqual(sqlCommand.Argv, sqlWant) {
+		t.Fatalf("sql argv = %#v, want %#v", sqlCommand.Argv, sqlWant)
+	}
+
 	command, ok := manifest.Commands["contact-export"]
 	if !ok {
 		t.Fatalf("commands = %#v", manifest.Commands)
@@ -252,6 +311,8 @@ func TestRunHelpMenus(t *testing.T) {
 		{"unread flag", []string{"unread", "--help"}, "wacrawl unread [--limit N]"},
 		{"command flag", []string{"messages", "--help"}, "--has-media"},
 		{"search flag", []string{"search", "--help"}, "wacrawl search [flags] <query>"},
+		{"sql topic", []string{"help", "sql"}, "wacrawl sql <select query>"},
+		{"sql flag", []string{"sql", "--help"}, "read-only SQL query"},
 		{"import flag", []string{"import", "--help"}, "--copy-media"},
 		{"sync topic", []string{"help", "sync"}, "wacrawl sync [--source PATH]"},
 		{"backup flag", []string{"backup", "--help"}, "wacrawl backup <init|push|pull|status>"},

--- a/internal/cli/control.go
+++ b/internal/cli/control.go
@@ -16,13 +16,14 @@ func controlManifest() control.Manifest {
 		DefaultCache:    filepath.Join(filepath.Dir(defaultDBPath()), "cache"),
 		DefaultLogs:     filepath.Join(filepath.Dir(defaultDBPath()), "logs"),
 	}
-	m.Capabilities = []string{"metadata", "doctor", "status", "sync", "search", "backup"}
+	m.Capabilities = []string{"metadata", "doctor", "status", "sync", "search", "sql", "backup"}
 	m.Privacy = control.Privacy{ContainsPrivateMessages: true, ExportsSecrets: false, LocalOnlyScopes: []string{"whatsapp-desktop", "sqlite", "encrypted-git-backup"}}
 	m.Commands = map[string]control.Command{
 		"doctor":         {Title: "Doctor", Argv: []string{"wacrawl", "--json", "doctor"}, JSON: true},
 		"status":         {Title: "Status", Argv: []string{"wacrawl", "--json", "--sync", "never", "status"}, JSON: true},
 		"sync":           {Title: "Sync", Argv: []string{"wacrawl", "--json", "sync"}, JSON: true, Mutates: true},
 		"search":         {Title: "Search", Argv: []string{"wacrawl", "--json", "--sync", "auto", "search"}, JSON: true},
+		"sql":            {Title: "SQL", Argv: []string{"wacrawl", "--json", "sql"}, JSON: true},
 		"contact-export": {Title: "Export contacts", Argv: []string{"wacrawl", "--json", "--sync", "never", "contacts", "export"}, JSON: true},
 	}
 	return m

--- a/internal/cli/sql.go
+++ b/internal/cli/sql.go
@@ -1,0 +1,270 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	_ "modernc.org/sqlite"
+)
+
+const readOnlySelectError = "only read-only select statements are allowed"
+
+type sqlQueryResult struct {
+	columns []string
+	rows    []map[string]any
+}
+
+func (r sqlQueryResult) MarshalJSON() ([]byte, error) {
+	if r.rows == nil {
+		return json.Marshal([]map[string]any{})
+	}
+	return json.Marshal(r.rows)
+}
+
+func (a *app) runSQL(ctx context.Context, args []string) error {
+	if commandWantsHelp(args) {
+		printCommandUsage(a.stdout, "sql")
+		return nil
+	}
+	query := strings.TrimSpace(strings.Join(args, " "))
+	if query == "" {
+		return usageErr(errors.New("sql query required"))
+	}
+	result, err := queryReadOnlySQL(ctx, a.dbPath, query)
+	if err != nil {
+		return err
+	}
+	return a.print(result)
+}
+
+func queryReadOnlySQL(ctx context.Context, dbPath string, query string) (sqlQueryResult, error) {
+	if strings.TrimSpace(dbPath) == "" {
+		return sqlQueryResult{}, errors.New("db path is required")
+	}
+	if err := validateReadOnlySQL(query); err != nil {
+		return sqlQueryResult{}, err
+	}
+	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=query_only(1)&_pragma=busy_timeout(5000)&_pragma=temp_store(MEMORY)", dbPath)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return sqlQueryResult{}, fmt.Errorf("open sqlite: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	if err := db.PingContext(ctx); err != nil {
+		return sqlQueryResult{}, fmt.Errorf("ping sqlite: %w", err)
+	}
+	rows, err := db.QueryContext(ctx, query) // #nosec G201 -- sql executes user-provided SELECT text against a local read-only archive DB.
+	if err != nil {
+		return sqlQueryResult{}, err
+	}
+	defer func() { _ = rows.Close() }()
+	columns, err := rows.Columns()
+	if err != nil {
+		return sqlQueryResult{}, err
+	}
+	result := sqlQueryResult{
+		columns: columns,
+		rows:    make([]map[string]any, 0),
+	}
+	for rows.Next() {
+		values := make([]any, len(columns))
+		ptrs := make([]any, len(columns))
+		for i := range values {
+			ptrs[i] = &values[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return sqlQueryResult{}, err
+		}
+		row := make(map[string]any, len(columns))
+		for i, col := range columns {
+			row[col] = normalizeSQLValue(values[i])
+		}
+		result.rows = append(result.rows, row)
+	}
+	if err := rows.Err(); err != nil {
+		return sqlQueryResult{}, err
+	}
+	return result, nil
+}
+
+func validateReadOnlySQL(query string) error {
+	trimmed := stripSQLLeadingComments(strings.TrimSpace(query))
+	if !readOnlySQLStartsWithSelect(trimmed) {
+		return errors.New(readOnlySelectError)
+	}
+	if hasAdditionalSQLStatement(trimmed) {
+		return errors.New("only a single read-only select statement is allowed")
+	}
+	return nil
+}
+
+func readOnlySQLStartsWithSelect(query string) bool {
+	switch {
+	case startsWithSQLKeyword(query, "select"):
+		return true
+	case startsWithSQLKeyword(query, "with"):
+		return withClauseEndsInSelect(query)
+	default:
+		return false
+	}
+}
+
+func withClauseEndsInSelect(query string) bool {
+	for i, depth := len("with"), 0; i < len(query); i++ {
+		switch query[i] {
+		case '\'':
+			i = scanSQLQuoted(query, i, '\'')
+		case '"':
+			i = scanSQLQuoted(query, i, '"')
+		case '-':
+			if i+1 < len(query) && query[i+1] == '-' {
+				i = scanSQLLineComment(query, i+2)
+			}
+		case '/':
+			if i+1 < len(query) && query[i+1] == '*' {
+				i = scanSQLBlockComment(query, i+2)
+			}
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth != 0 || !isSQLIdentStart(query[i]) {
+				continue
+			}
+			start := i
+			for i+1 < len(query) && isSQLIdentChar(query[i+1]) {
+				i++
+			}
+			switch strings.ToLower(query[start : i+1]) {
+			case "select":
+				return true
+			case "insert", "update", "delete", "replace", "create", "drop", "alter", "pragma", "vacuum", "attach", "detach", "reindex", "analyze", "explain":
+				return false
+			}
+		}
+	}
+	return false
+}
+
+func startsWithSQLKeyword(query, keyword string) bool {
+	if len(query) < len(keyword) {
+		return false
+	}
+	if !strings.EqualFold(query[:len(keyword)], keyword) {
+		return false
+	}
+	return len(query) == len(keyword) || !isSQLIdentChar(query[len(keyword)])
+}
+
+func hasAdditionalSQLStatement(query string) bool {
+	for i := 0; i < len(query); i++ {
+		switch query[i] {
+		case '\'':
+			i = scanSQLQuoted(query, i, '\'')
+		case '"':
+			i = scanSQLQuoted(query, i, '"')
+		case '-':
+			if i+1 < len(query) && query[i+1] == '-' {
+				i = scanSQLLineComment(query, i+2)
+			}
+		case '/':
+			if i+1 < len(query) && query[i+1] == '*' {
+				i = scanSQLBlockComment(query, i+2)
+			}
+		case ';':
+			return strings.TrimSpace(stripSQLLeadingComments(query[i+1:])) != ""
+		}
+	}
+	return false
+}
+
+func scanSQLQuoted(query string, start int, quote byte) int {
+	for i := start + 1; i < len(query); i++ {
+		if query[i] != quote {
+			continue
+		}
+		if i+1 < len(query) && query[i+1] == quote {
+			i++
+			continue
+		}
+		return i
+	}
+	return len(query) - 1
+}
+
+func scanSQLLineComment(query string, start int) int {
+	for i := start; i < len(query); i++ {
+		if query[i] == '\n' || query[i] == '\r' {
+			return i
+		}
+	}
+	return len(query) - 1
+}
+
+func scanSQLBlockComment(query string, start int) int {
+	for i := start; i+1 < len(query); i++ {
+		if query[i] == '*' && query[i+1] == '/' {
+			return i + 1
+		}
+	}
+	return len(query) - 1
+}
+
+func stripSQLLeadingComments(query string) string {
+	for {
+		query = strings.TrimSpace(query)
+		switch {
+		case strings.HasPrefix(query, "--"):
+			end := strings.IndexAny(query, "\r\n")
+			if end < 0 {
+				return ""
+			}
+			query = query[end+1:]
+		case strings.HasPrefix(query, "/*"):
+			end := strings.Index(query[2:], "*/")
+			if end < 0 {
+				return ""
+			}
+			query = query[end+4:]
+		default:
+			return query
+		}
+	}
+}
+
+func isSQLIdentChar(c byte) bool {
+	return c == '_' || c >= '0' && c <= '9' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z'
+}
+
+func isSQLIdentStart(c byte) bool {
+	return c == '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z'
+}
+
+func normalizeSQLValue(value any) any {
+	switch typed := value.(type) {
+	case []byte:
+		return string(typed)
+	default:
+		return typed
+	}
+}
+
+func formatSQLValue(value any) string {
+	if value == nil {
+		return "NULL"
+	}
+	text := fmt.Sprint(value)
+	text = strings.ReplaceAll(text, "\t", " ")
+	text = strings.ReplaceAll(text, "\r", " ")
+	text = strings.ReplaceAll(text, "\n", " ")
+	return text
+}

--- a/internal/cli/sql.go
+++ b/internal/cli/sql.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openclaw/wacrawl/internal/store"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -33,6 +35,16 @@ func (a *app) runSQL(ctx context.Context, args []string) error {
 	query := strings.TrimSpace(strings.Join(args, " "))
 	if query == "" {
 		return usageErr(errors.New("sql query required"))
+	}
+	if err := validateReadOnlySQL(query); err != nil {
+		return err
+	}
+	if a.syncMode != archiveSyncNever {
+		if err := a.withStore(ctx, func(st *store.Store) error {
+			return a.syncArchive(ctx, st)
+		}); err != nil {
+			return err
+		}
 	}
 	result, err := queryReadOnlySQL(ctx, a.dbPath, query)
 	if err != nil {

--- a/internal/cli/sql_test.go
+++ b/internal/cli/sql_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/wacrawl/internal/store"
+)
+
+func TestValidateReadOnlySQLAllowsCommentsQuotesAndCTEs(t *testing.T) {
+	for _, query := range []string{
+		"-- leading comment\nSELECT 1",
+		"/* leading comment */ SELECT ';' AS literal",
+		"SELECT 'it''s;fine' AS quoted; -- trailing comment",
+		`SELECT "semi;colon" AS quoted; /* trailing block */`,
+		"WITH rows AS (SELECT 1 AS n) SELECT n FROM rows",
+	} {
+		t.Run(query, func(t *testing.T) {
+			if err := validateReadOnlySQL(query); err != nil {
+				t.Fatalf("validateReadOnlySQL() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateReadOnlySQLRejectsWritesAndAdditionalStatements(t *testing.T) {
+	for _, query := range []string{
+		"",
+		"DELETE FROM messages",
+		"SELECTED 1",
+		"INSERT INTO messages(text) VALUES ('nope')",
+		"WITH rows AS (SELECT 1) DELETE FROM messages RETURNING 1",
+	} {
+		t.Run(query, func(t *testing.T) {
+			if err := validateReadOnlySQL(query); err == nil || !strings.Contains(err.Error(), readOnlySelectError) {
+				t.Fatalf("validateReadOnlySQL() error = %v, want read-only select error", err)
+			}
+		})
+	}
+	for _, query := range []string{
+		"SELECT 1; SELECT 2",
+		"SELECT 1; /* comment */ SELECT 2",
+	} {
+		t.Run(query, func(t *testing.T) {
+			if err := validateReadOnlySQL(query); err == nil || !strings.Contains(err.Error(), "single read-only select") {
+				t.Fatalf("validateReadOnlySQL() error = %v, want single statement error", err)
+			}
+		})
+	}
+}
+
+func TestQueryReadOnlySQLNormalizesValuesAndEmptyResults(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "archive.db")
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := queryReadOnlySQL(ctx, dbPath, "SELECT x'6869' AS blob_value, NULL AS missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.rows) != 1 || result.rows[0]["blob_value"] != "hi" || result.rows[0]["missing"] != nil {
+		t.Fatalf("rows = %#v", result.rows)
+	}
+
+	empty, err := queryReadOnlySQL(ctx, dbPath, "SELECT source_pk FROM messages WHERE 0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(empty.rows) != 0 || len(empty.columns) != 1 || empty.columns[0] != "source_pk" {
+		t.Fatalf("empty result = %#v", empty)
+	}
+}
+
+func TestSQLResultJSONAndFormatting(t *testing.T) {
+	data, err := json.Marshal(sqlQueryResult{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "[]" {
+		t.Fatalf("json = %s, want []", data)
+	}
+	if got := formatSQLValue(nil); got != "NULL" {
+		t.Fatalf("nil format = %q", got)
+	}
+	if got := formatSQLValue("a\tb\rc\nd"); got != "a b c d" {
+		t.Fatalf("escaped format = %q", got)
+	}
+}


### PR DESCRIPTION
Closes #17.

Adds `wacrawl sql` for read-only archive queries, including JSON output, control metadata, help, docs, and tests. The command opens the selected archive DB read-only and rejects writable or multi-statement SQL.

## Maintainer verification

- Fixed automatic sync handling while preserving `--sync never` as a strictly read-only path.
- Validates SQL before any sync side effect; regression coverage verifies rejected writes do not create an archive.
- `go test ./...`
- `make test`
- `go test -race ./...`
- `golangci-lint v2.12.2 run ./...`
- `make coverage` — 85.1%, above the 85.0% floor.
- `make build`
- Redacted local smoke: doctor, status, and a read-only aggregate SQL query against the real archive; JSON shape validated with output suppressed.
- Codex autoreview of the complete branch against `origin/main`: clean, no accepted/actionable findings.
