### PR TITLE
feat(backup): add Git snapshot restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add read-only SQL archive queries with JSON output, automatic sync support, and lossless duplicate-column handling (#18, thanks @TurboTheTurtle).
+- Add named Git backup snapshots, snapshot history listing, and non-mutating historical restores through `backup pull --ref`.
 
 ## [0.2.7] - 2026-06-10
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,9 @@ wacrawl backup push
 # Pull the Git backup, decrypt, verify, and import into the local archive.
 wacrawl backup pull
 
+# List restorable commits and any snapshot tags.
+wacrawl backup snapshots
+
 # Inspect the backup manifest without decrypting message data.
 wacrawl backup status
 ```
@@ -341,14 +344,26 @@ wacrawl --sync always backup push
 # Write and commit locally, but do not push to GitHub.
 wacrawl backup push --no-push
 
+# Create a named checkpoint while pushing a backup.
+wacrawl backup push --tag snapshot/before-phone-migration
+
 # Restore into a throwaway database for testing.
 wacrawl --db /tmp/wacrawl-restore-test.db backup pull
 wacrawl --db /tmp/wacrawl-restore-test.db --sync never status
+
+# Restore a historical tag, commit, or branch without changing the backup checkout.
+wacrawl --db /tmp/wacrawl-history.db backup pull --ref snapshot/before-phone-migration
 ```
 
 You should not need to run `git` manually for normal use. `backup push` handles
 the backup repo pull/rebase, commit, and push. `backup pull` handles the backup
 repo pull/rebase before decrypting.
+
+Every changed backup is already a Git commit. Use `--tag NAME` to add an
+optional named checkpoint without moving an existing tag. Tag names and commit
+metadata are visible to anyone who can inspect the Git repository, so keep tag
+names non-sensitive. `backup snapshots` lists the newest manifest-changing
+commits and their tags; use `--limit N` to control the history depth.
 
 ### Encryption and Security Model
 
@@ -456,6 +471,10 @@ shard, encrypts each shard for every configured recipient, updates
 `manifest.json`, removes stale encrypted shards, commits, and pushes the backup
 repo.
 
+Pass `--tag NAME` to tag the resulting snapshot commit. If the archive is
+unchanged, the tag points at the existing current snapshot. Existing tags are
+never moved to a different commit.
+
 Re-running `backup push` without archive changes leaves Git clean. The command
 prints the repo path, whether anything changed, whether the backup is encrypted,
 the shard count, and the message count.
@@ -479,6 +498,16 @@ wacrawl backup pull
 the local age identity, verifies each plaintext shard hash from the manifest,
 validates cross-table references, and replaces the configured `wacrawl` archive
 database in one import transaction.
+
+Restore a historical tag, commit, or branch with `--ref`:
+
+```bash
+wacrawl --db /tmp/wacrawl-history.db backup pull --ref snapshot/before-phone-migration
+```
+
+Historical restore resolves the ref to a commit and reads its manifest and
+encrypted shards directly from Git objects. It does not checkout that commit or
+change the backup repository's current branch.
 
 To test a restore without touching your real archive:
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -50,6 +50,8 @@ type Result struct {
 	Encrypted bool   `json:"encrypted"`
 	Shards    int    `json:"shards"`
 	Messages  int    `json:"messages"`
+	Ref       string `json:"ref,omitempty"`
+	Tag       string `json:"tag,omitempty"`
 }
 
 func Init(ctx context.Context, opts Options) (Config, string, error) {
@@ -92,6 +94,9 @@ func Push(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 	if err := ensureRepo(ctx, cfg); err != nil {
 		return Result{}, err
 	}
+	if err := validateSnapshotTag(ctx, cfg.Repo, opts.Tag); err != nil {
+		return Result{}, err
+	}
 	if err := writeBackupReadme(cfg.Repo); err != nil {
 		return Result{}, err
 	}
@@ -104,11 +109,21 @@ func Push(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	changed, err := commitAndPush(ctx, cfg, "sync: update encrypted wacrawl backup", opts.Push)
+	pushWithTag := opts.Push && strings.TrimSpace(opts.Tag) != ""
+	changed, err := commitAndPush(ctx, cfg, "sync: update encrypted wacrawl backup", opts.Push && !pushWithTag)
 	if err != nil {
 		return Result{}, err
 	}
-	return Result{Repo: cfg.Repo, Changed: changed, Encrypted: true, Shards: len(manifest.Shards), Messages: manifest.Counts.Messages}, nil
+	tag, err := tagSnapshot(ctx, cfg, opts.Tag)
+	if err != nil {
+		return Result{}, err
+	}
+	if pushWithTag {
+		if err := git(ctx, cfg.Repo, "push", "--atomic", "-u", "origin", "HEAD", "refs/tags/"+tag); err != nil {
+			return Result{}, err
+		}
+	}
+	return Result{Repo: cfg.Repo, Changed: changed, Encrypted: true, Shards: len(manifest.Shards), Messages: manifest.Counts.Messages, Tag: tag}, nil
 }
 
 func Pull(ctx context.Context, st *store.Store, opts Options) (Result, error) {
@@ -116,24 +131,37 @@ func Pull(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	if err := ensureRepo(ctx, cfg); err != nil {
+	ensure := ensureRepo
+	if strings.TrimSpace(opts.Ref) != "" {
+		ensure = ensureRepoForRead
+	}
+	if err := ensure(ctx, cfg); err != nil {
 		return Result{}, err
 	}
-	manifest, err := readManifest(cfg.Repo)
+	manifest, ref, err := readManifestAtRef(ctx, cfg.Repo, opts.Ref)
 	if err != nil {
 		return Result{}, err
 	}
-	data, err := readSnapshot(cfg, manifest)
+	var data store.SnapshotData
+	if ref == "" {
+		data, err = readSnapshot(cfg, manifest)
+	} else {
+		data, err = readSnapshotAtRef(ctx, cfg, manifest, ref)
+	}
 	if err != nil {
 		return Result{}, err
 	}
 	if err := data.Validate(); err != nil {
 		return Result{}, err
 	}
-	if err := st.ImportSnapshot(ctx, data, "backup:"+cfg.Repo, manifest.Exported); err != nil {
+	sourcePath := "backup:" + cfg.Repo
+	if ref != "" {
+		sourcePath += "@" + ref
+	}
+	if err := st.ImportSnapshot(ctx, data, sourcePath, manifest.Exported); err != nil {
 		return Result{}, err
 	}
-	return Result{Repo: cfg.Repo, Changed: true, Encrypted: manifest.Encrypted, Shards: len(manifest.Shards), Messages: len(data.Messages)}, nil
+	return Result{Repo: cfg.Repo, Changed: true, Encrypted: manifest.Encrypted, Shards: len(manifest.Shards), Messages: len(data.Messages), Ref: ref}, nil
 }
 
 func Status(ctx context.Context, opts Options) (Manifest, string, error) {
@@ -216,12 +244,18 @@ func writeSnapshot(ctx context.Context, cfg Config, data store.SnapshotData, old
 }
 
 func readSnapshot(cfg Config, manifest Manifest) (store.SnapshotData, error) {
+	return readSnapshotWith(manifest, func(shard ShardEntry) ([]byte, error) {
+		return decryptShardFile(cfg, shard)
+	})
+}
+
+func readSnapshotWith(manifest Manifest, load func(ShardEntry) ([]byte, error)) (store.SnapshotData, error) {
 	if manifest.Format != formatVersion {
 		return store.SnapshotData{}, fmt.Errorf("unsupported backup format %d", manifest.Format)
 	}
 	var data store.SnapshotData
 	for _, shard := range manifest.Shards {
-		plaintext, err := decryptShardFile(cfg, shard)
+		plaintext, err := load(shard)
 		if err != nil {
 			return store.SnapshotData{}, err
 		}
@@ -387,11 +421,7 @@ func readManifest(repo string) (Manifest, error) {
 	if err != nil {
 		return Manifest{}, err
 	}
-	var manifest Manifest
-	if err := json.Unmarshal(data, &manifest); err != nil {
-		return Manifest{}, err
-	}
-	return manifest, nil
+	return decodeManifest(data)
 }
 
 func writeManifest(repo string, manifest Manifest) error {
@@ -546,21 +576,28 @@ may still contain shards decryptable by the compromised key.
 
 ` + "```bash" + `
 wacrawl backup push
+wacrawl backup push --tag snapshot/before-phone-migration
 ` + "```" + `
 
 The command pulls/rebases this checkout, refreshes the local wacrawl archive
 according to the normal sync policy, writes encrypted shards, updates the
 manifest, commits, and pushes this repository.
 
+Every changed backup is a Git commit. Optional tags name important checkpoints;
+tag names are visible Git metadata and should not contain sensitive text.
+
 ## Restore
 
 ` + "```bash" + `
 wacrawl backup pull
+wacrawl backup snapshots
+wacrawl --db /tmp/wacrawl-history.db backup pull --ref snapshot/before-phone-migration
 ` + "```" + `
 
 ` + "`backup pull`" + ` decrypts every shard with the local age identity, verifies the
 manifest hashes, validates the snapshot, and imports it into the configured
-wacrawl archive database.
+wacrawl archive database. Historical refs are read directly from Git objects
+without changing this checkout's current branch.
 
 ## Recovery
 

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -295,6 +295,19 @@ func TestHistoricalSnapshotRestore(t *testing.T) {
 
 func TestSnapshotHistoryValidation(t *testing.T) {
 	ctx := context.Background()
+	if err := ensureRepoForRead(ctx, Config{}); err == nil {
+		t.Fatal("empty backup repo path should fail")
+	}
+	createdRepo := filepath.Join(t.TempDir(), "created-backup")
+	if err := ensureRepoForRead(ctx, Config{Repo: createdRepo}); err != nil {
+		t.Fatalf("read-only setup should initialize a missing repository: %v", err)
+	}
+	localRepo := filepath.Join(t.TempDir(), "local-backup")
+	runGit(t, "", "init", localRepo)
+	if err := ensureRepoForRead(ctx, Config{Repo: localRepo}); err != nil {
+		t.Fatalf("read-only setup without origin: %v", err)
+	}
+
 	repo := filepath.Join(t.TempDir(), "backup")
 	remote := filepath.Join(t.TempDir(), "remote.git")
 	runGit(t, "", "init", "--bare", remote)

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -164,6 +164,171 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	}
 }
 
+func TestHistoricalSnapshotRestore(t *testing.T) {
+	ctx := context.Background()
+	source := openFixtureStore(t, "history-source.db")
+	now := time.Date(2026, 6, 19, 9, 0, 0, 0, time.UTC)
+	data := store.SnapshotData{
+		Chats: []store.Chat{{JID: "chat@g.us", Kind: "group", Name: "History", LastMessageAt: now}},
+		Messages: []store.Message{{
+			SourcePK: 1, ChatJID: "chat@g.us", ChatName: "History", MessageID: "first",
+			SenderJID: "alice@s.whatsapp.net", Timestamp: now, Text: "first snapshot", MessageType: "text",
+		}},
+	}
+	if err := source.ImportSnapshot(ctx, data, "/fixture", now); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := filepath.Join(t.TempDir(), "backup")
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, "", "init", "--bare", remote)
+	identity := filepath.Join(t.TempDir(), "age.key")
+	configPath := filepath.Join(t.TempDir(), "backup.json")
+	if _, _, err := Init(ctx, Options{ConfigPath: configPath, Repo: repo, Remote: remote, Identity: identity, Push: false}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Push(ctx, source, Options{ConfigPath: configPath, Push: false, Tag: "snapshot/initial"}); err != nil {
+		t.Fatal(err)
+	}
+	idempotent, err := Push(ctx, source, Options{ConfigPath: configPath, Push: false, Tag: "snapshot/initial"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idempotent.Changed || idempotent.Tag != "snapshot/initial" {
+		t.Fatalf("unexpected idempotent tagged push: %+v", idempotent)
+	}
+	initial, err := resolveCommit(ctx, repo, "snapshot/initial")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data.Messages = append(data.Messages, store.Message{
+		SourcePK: 2, ChatJID: "chat@g.us", ChatName: "History", MessageID: "second",
+		SenderJID: "alice@s.whatsapp.net", Timestamp: now.Add(time.Minute), Text: "second snapshot", MessageType: "text",
+	})
+	if err := source.ImportSnapshot(ctx, data, "/fixture", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Push(ctx, source, Options{ConfigPath: configPath, Push: false}); err != nil {
+		t.Fatal(err)
+	}
+	current, err := resolveCommit(ctx, repo, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current == initial {
+		t.Fatal("updated backup did not create a new snapshot commit")
+	}
+	tagged, err := Push(ctx, source, Options{ConfigPath: configPath, Push: true, Tag: "snapshot/current"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tagged.Changed || tagged.Tag != "snapshot/current" {
+		t.Fatalf("unexpected unchanged tagged push: %+v", tagged)
+	}
+	remoteTags, err := gitOutput(ctx, repo, "ls-remote", "--tags", "origin", "refs/tags/snapshot/current")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(remoteTags), "refs/tags/snapshot/current") {
+		t.Fatalf("snapshot tag was not pushed: %s", remoteTags)
+	}
+
+	snapshots, snapshotsRepo, err := Snapshots(ctx, Options{ConfigPath: configPath, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshotsRepo != repo || len(snapshots) != 2 {
+		t.Fatalf("unexpected snapshots repo=%s snapshots=%+v", snapshotsRepo, snapshots)
+	}
+	if snapshots[0].Ref != current || snapshots[0].Counts.Messages != 2 || len(snapshots[0].Tags) != 1 || snapshots[0].Tags[0] != "snapshot/current" {
+		t.Fatalf("unexpected current snapshot: %+v", snapshots[0])
+	}
+	if snapshots[1].Ref != initial || len(snapshots[1].Tags) != 1 || snapshots[1].Tags[0] != "snapshot/initial" {
+		t.Fatalf("unexpected tagged snapshot: %+v", snapshots[1])
+	}
+	peer := filepath.Join(t.TempDir(), "peer")
+	runGit(t, "", "clone", remote, peer)
+	if err := os.WriteFile(filepath.Join(peer, "remote-note.txt"), []byte("remote advanced\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, peer, "add", "remote-note.txt")
+	runGit(t, peer, "commit", "-m", "test: advance remote")
+	runGit(t, peer, "push", "origin", "HEAD")
+	remoteHead, err := resolveCommit(ctx, peer, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remoteHead == current {
+		t.Fatal("remote test commit did not advance")
+	}
+
+	restored := openFixtureStore(t, "history-restored.db")
+	pulled, err := Pull(ctx, restored, Options{ConfigPath: configPath, Ref: "snapshot/initial"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pulled.Messages != 1 || pulled.Ref != initial {
+		t.Fatalf("unexpected historical pull: %+v", pulled)
+	}
+	after, err := resolveCommit(ctx, repo, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != current {
+		t.Fatalf("historical pull changed checkout: before=%s after=%s", current, after)
+	}
+	results, err := restored.Search(ctx, store.MessageFilter{Query: "snapshot", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].MessageID != "first" {
+		t.Fatalf("historical restore mismatch: %+v", results)
+	}
+	if _, err := Pull(ctx, restored, Options{ConfigPath: configPath, Ref: "missing-ref"}); err == nil {
+		t.Fatal("missing historical ref should fail")
+	}
+	if _, err := Push(ctx, source, Options{ConfigPath: configPath, Push: false, Tag: "snapshot/initial"}); err == nil {
+		t.Fatal("moving an existing snapshot tag should fail")
+	}
+}
+
+func TestSnapshotHistoryValidation(t *testing.T) {
+	ctx := context.Background()
+	repo := filepath.Join(t.TempDir(), "backup")
+	remote := filepath.Join(t.TempDir(), "remote.git")
+	runGit(t, "", "init", "--bare", remote)
+	configPath := filepath.Join(t.TempDir(), "backup.json")
+	if _, _, err := Init(ctx, Options{ConfigPath: configPath, Repo: repo, Remote: remote, Identity: filepath.Join(t.TempDir(), "age.key"), Push: false}); err != nil {
+		t.Fatal(err)
+	}
+	snapshots, _, err := Snapshots(ctx, Options{ConfigPath: configPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshots) != 0 {
+		t.Fatalf("new backup repo should have no data snapshots: %+v", snapshots)
+	}
+	if _, _, err := Snapshots(ctx, Options{ConfigPath: configPath, Limit: -1}); err == nil {
+		t.Fatal("negative snapshot limit should fail")
+	}
+	if err := validateSnapshotTag(ctx, repo, "not a tag"); err == nil {
+		t.Fatal("invalid snapshot tag should fail")
+	}
+	if tag, err := tagSnapshot(ctx, Config{Repo: repo}, ""); err != nil || tag != "" {
+		t.Fatalf("empty snapshot tag = %q, %v", tag, err)
+	}
+	if _, err := resolveCommit(ctx, repo, ""); err == nil {
+		t.Fatal("empty backup ref should fail")
+	}
+	if _, err := decodeManifest([]byte("{")); err == nil {
+		t.Fatal("invalid manifest JSON should fail")
+	}
+	if got := shortRef("short"); got != "short" {
+		t.Fatalf("short ref = %q", got)
+	}
+}
+
 func TestConfigRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "backup.json")
 	cfg := DefaultConfig()

--- a/internal/backup/config.go
+++ b/internal/backup/config.go
@@ -27,6 +27,9 @@ type Options struct {
 	Identity   string
 	Recipients []string
 	Push       bool
+	Ref        string
+	Tag        string
+	Limit      int
 }
 
 func DefaultConfig() Config {

--- a/internal/backup/git.go
+++ b/internal/backup/git.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -59,7 +60,11 @@ func ensureRepoForRead(ctx context.Context, cfg Config) error {
 	if _, err := os.Stat(filepath.Join(cfg.Repo, ".git")); err != nil {
 		return ensureRepo(ctx, cfg)
 	}
-	if err := git(ctx, cfg.Repo, "remote", "get-url", "origin"); err != nil {
+	remotes, err := gitOutput(ctx, cfg.Repo, "remote")
+	if err != nil {
+		return err
+	}
+	if !slices.Contains(strings.Fields(string(remotes)), "origin") {
 		return nil
 	}
 	return git(ctx, cfg.Repo, "fetch", "--prune", "--tags", "origin")

--- a/internal/backup/git.go
+++ b/internal/backup/git.go
@@ -52,6 +52,19 @@ func ensureRepo(ctx context.Context, cfg Config) error {
 	return nil
 }
 
+func ensureRepoForRead(ctx context.Context, cfg Config) error {
+	if strings.TrimSpace(cfg.Repo) == "" {
+		return fmt.Errorf("backup repo path is required")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.Repo, ".git")); err != nil {
+		return ensureRepo(ctx, cfg)
+	}
+	if err := git(ctx, cfg.Repo, "remote", "get-url", "origin"); err != nil {
+		return nil
+	}
+	return git(ctx, cfg.Repo, "fetch", "--prune", "--tags", "origin")
+}
+
 func commitAndPush(ctx context.Context, cfg Config, message string, push bool) (bool, error) {
 	if err := git(ctx, cfg.Repo, "add", "."); err != nil {
 		return false, err
@@ -71,6 +84,11 @@ func commitAndPush(ctx context.Context, cfg Config, message string, push bool) (
 }
 
 func git(ctx context.Context, dir string, args ...string) error {
+	_, err := gitOutput(ctx, dir, args...)
+	return err
+}
+
+func gitOutput(ctx context.Context, dir string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- wacrawl only passes fixed git subcommands plus configured repo paths.
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(),
@@ -79,13 +97,15 @@ func git(ctx context.Context, dir string, args ...string) error {
 		"GIT_COMMITTER_NAME=wacrawl",
 		"GIT_COMMITTER_EMAIL=wacrawl@example.invalid",
 	)
+	var stdout bytes.Buffer
 	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		if stderr.Len() > 0 {
-			return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+			return nil, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
 		}
-		return fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+		return nil, fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
 	}
-	return nil
+	return stdout.Bytes(), nil
 }

--- a/internal/backup/history.go
+++ b/internal/backup/history.go
@@ -1,0 +1,168 @@
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openclaw/wacrawl/internal/store"
+)
+
+const defaultSnapshotLimit = 20
+
+type Snapshot struct {
+	Ref      string    `json:"ref"`
+	Tags     []string  `json:"tags,omitempty"`
+	Exported time.Time `json:"exported"`
+	Counts   Counts    `json:"counts"`
+	Shards   int       `json:"shards"`
+}
+
+func Snapshots(ctx context.Context, opts Options) ([]Snapshot, string, error) {
+	cfg, err := ResolveOptions(opts)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := ensureRepoForRead(ctx, cfg); err != nil {
+		return nil, "", err
+	}
+	limit := opts.Limit
+	if limit == 0 {
+		limit = defaultSnapshotLimit
+	}
+	if limit < 1 {
+		return nil, "", fmt.Errorf("snapshot limit must be greater than zero")
+	}
+	raw, err := gitOutput(ctx, cfg.Repo, "log", "--all", "--format=%H", "-n", strconv.Itoa(limit), "--", "manifest.json")
+	if err != nil {
+		return nil, "", err
+	}
+	refs := strings.Fields(string(raw))
+	out := make([]Snapshot, 0, len(refs))
+	for _, ref := range refs {
+		manifest, err := manifestAtCommit(ctx, cfg.Repo, ref)
+		if err != nil {
+			return nil, "", err
+		}
+		tagsRaw, err := gitOutput(ctx, cfg.Repo, "tag", "--points-at", ref)
+		if err != nil {
+			return nil, "", err
+		}
+		tags := strings.Fields(string(tagsRaw))
+		sort.Strings(tags)
+		out = append(out, Snapshot{Ref: ref, Tags: tags, Exported: manifest.Exported, Counts: manifest.Counts, Shards: len(manifest.Shards)})
+	}
+	return out, cfg.Repo, nil
+}
+
+func readManifestAtRef(ctx context.Context, repo, requested string) (Manifest, string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		manifest, err := readManifest(repo)
+		return manifest, "", err
+	}
+	commit, err := resolveCommit(ctx, repo, requested)
+	if err != nil {
+		return Manifest{}, "", fmt.Errorf("resolve backup ref %q: %w", requested, err)
+	}
+	manifest, err := manifestAtCommit(ctx, repo, commit)
+	if err != nil {
+		return Manifest{}, "", err
+	}
+	return manifest, commit, nil
+}
+
+func manifestAtCommit(ctx context.Context, repo, commit string) (Manifest, error) {
+	raw, err := gitOutput(ctx, repo, "show", commit+":manifest.json")
+	if err != nil {
+		return Manifest{}, fmt.Errorf("read backup manifest at %s: %w", shortRef(commit), err)
+	}
+	return decodeManifest(raw)
+}
+
+func readSnapshotAtRef(ctx context.Context, cfg Config, manifest Manifest, commit string) (store.SnapshotData, error) {
+	return readSnapshotWith(manifest, func(shard ShardEntry) ([]byte, error) {
+		if _, err := resolveShardPath(cfg.Repo, shard.Path); err != nil {
+			return nil, err
+		}
+		clean := path.Clean(strings.TrimSpace(shard.Path))
+		ciphertext, err := gitOutput(ctx, cfg.Repo, "show", commit+":"+clean)
+		if err != nil {
+			return nil, fmt.Errorf("read backup shard %s at %s: %w", clean, shortRef(commit), err)
+		}
+		return decryptShard(ciphertext, cfg.Identity)
+	})
+}
+
+func validateSnapshotTag(ctx context.Context, repo, requested string) error {
+	tag := strings.TrimSpace(requested)
+	if tag == "" {
+		return nil
+	}
+	ref := "refs/tags/" + tag
+	if err := git(ctx, repo, "check-ref-format", ref); err != nil {
+		return fmt.Errorf("invalid snapshot tag %q: %w", tag, err)
+	}
+	return nil
+}
+
+func tagSnapshot(ctx context.Context, cfg Config, requested string) (string, error) {
+	tag := strings.TrimSpace(requested)
+	if tag == "" {
+		return "", nil
+	}
+	if err := validateSnapshotTag(ctx, cfg.Repo, tag); err != nil {
+		return "", err
+	}
+	ref := "refs/tags/" + tag
+	head, err := resolveCommit(ctx, cfg.Repo, "HEAD")
+	if err != nil {
+		return "", err
+	}
+	existingRaw, existingErr := gitOutput(ctx, cfg.Repo, "rev-parse", "--verify", "--end-of-options", ref+"^{commit}")
+	if existingErr == nil {
+		existing := strings.TrimSpace(string(existingRaw))
+		if existing != head {
+			return "", fmt.Errorf("snapshot tag %q already points to %s", tag, shortRef(existing))
+		}
+	} else if err := git(ctx, cfg.Repo, "update-ref", ref, head); err != nil {
+		return "", err
+	}
+	return tag, nil
+}
+
+func resolveCommit(ctx context.Context, repo, ref string) (string, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return "", fmt.Errorf("backup ref is required")
+	}
+	raw, err := gitOutput(ctx, repo, "rev-parse", "--verify", "--end-of-options", ref+"^{commit}")
+	if err != nil {
+		return "", err
+	}
+	commit := strings.TrimSpace(string(raw))
+	if commit == "" {
+		return "", fmt.Errorf("backup ref %q resolved to an empty commit", ref)
+	}
+	return commit, nil
+}
+
+func decodeManifest(data []byte) (Manifest, error) {
+	var manifest Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return Manifest{}, err
+	}
+	return manifest, nil
+}
+
+func shortRef(ref string) string {
+	if len(ref) > 12 {
+		return ref[:12]
+	}
+	return ref
+}

--- a/internal/cli/backup.go
+++ b/internal/cli/backup.go
@@ -36,6 +36,8 @@ func (a *app) runBackup(ctx context.Context, args []string) error {
 		return a.runBackupPull(ctx, args[1:])
 	case "status":
 		return a.runBackupStatus(ctx, args[1:])
+	case "snapshots":
+		return a.runBackupSnapshots(ctx, args[1:])
 	default:
 		return usageErr(fmt.Errorf("unknown backup command %q", args[0]))
 	}
@@ -67,6 +69,7 @@ func (a *app) runBackupInit(ctx context.Context, args []string) error {
 
 func (a *app) runBackupPush(ctx context.Context, args []string) error {
 	fs, opts, noPush := backupFlagSet("backup push")
+	fs.StringVar(&opts.Tag, "tag", "", "")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printCommandUsage(a.stdout, "backup", "push")
@@ -89,6 +92,7 @@ func (a *app) runBackupPush(ctx context.Context, args []string) error {
 
 func (a *app) runBackupPull(ctx context.Context, args []string) error {
 	fs, opts, _ := backupFlagSet("backup pull")
+	fs.StringVar(&opts.Ref, "ref", "", "")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printCommandUsage(a.stdout, "backup", "pull")
@@ -106,6 +110,32 @@ func (a *app) runBackupPull(ctx context.Context, args []string) error {
 		}
 		return a.print(result)
 	})
+}
+
+func (a *app) runBackupSnapshots(ctx context.Context, args []string) error {
+	fs, opts, _ := backupFlagSet("backup snapshots")
+	fs.IntVar(&opts.Limit, "limit", 20, "")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printCommandUsage(a.stdout, "backup", "snapshots")
+			return nil
+		}
+		return usageErr(err)
+	}
+	if fs.NArg() != 0 {
+		return usageErr(errors.New("backup snapshots takes flags only"))
+	}
+	if opts.Limit < 1 {
+		return usageErr(errors.New("backup snapshots --limit must be greater than zero"))
+	}
+	snapshots, repo, err := backup.Snapshots(ctx, *opts)
+	if err != nil {
+		return err
+	}
+	if a.json {
+		return a.print(map[string]any{"repo": repo, "snapshots": snapshots})
+	}
+	return a.print(snapshots)
 }
 
 func (a *app) runBackupStatus(ctx context.Context, args []string) error {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -581,7 +581,28 @@ func (a *app) print(value any) error {
 		return tw.Flush()
 	case backup.Result:
 		_, err := fmt.Fprintf(a.stdout, "repo=%s\nchanged=%t\nencrypted=%t\nshards=%d\nmessages=%d\n", v.Repo, v.Changed, v.Encrypted, v.Shards, v.Messages)
+		if err == nil && v.Ref != "" {
+			_, err = fmt.Fprintf(a.stdout, "ref=%s\n", v.Ref)
+		}
+		if err == nil && v.Tag != "" {
+			_, err = fmt.Fprintf(a.stdout, "tag=%s\n", v.Tag)
+		}
 		return err
+	case []backup.Snapshot:
+		if len(v) == 0 {
+			_, err := fmt.Fprintln(a.stdout, "No backup snapshots found.")
+			return err
+		}
+		tw := tabwriter.NewWriter(a.stdout, 2, 4, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "REF\tEXPORTED\tMESSAGES\tSHARDS\tTAGS")
+		for _, snapshot := range v {
+			ref := snapshot.Ref
+			if len(ref) > 12 {
+				ref = ref[:12]
+			}
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%s\n", ref, formatTime(snapshot.Exported), snapshot.Counts.Messages, snapshot.Shards, strings.Join(snapshot.Tags, ","))
+		}
+		return tw.Flush()
 	case backup.Manifest:
 		_, err := fmt.Fprintf(a.stdout, "encrypted=%t\nshards=%d\nmessages=%d\nexported=%s\n", v.Encrypted, len(v.Shards), v.Counts.Messages, formatTime(v.Exported))
 		return err
@@ -783,13 +804,14 @@ Examples:
 		_, _ = fmt.Fprint(w, `Manage encrypted Git backups of the wacrawl archive.
 
 Usage:
-  wacrawl backup <init|push|pull|status> [flags]
+  wacrawl backup <init|push|pull|status|snapshots> [flags]
 
 Commands:
   init      Create backup config, age identity, and first encrypted backup.
   push      Export the archive and push encrypted shards.
   pull      Restore encrypted shards into the configured archive DB.
   status    Inspect backup config and manifest.
+  snapshots List restorable Git backup snapshots and tags.
 
 Common flags:
   --config PATH      Backup config path.
@@ -801,6 +823,7 @@ Common flags:
 
 Examples:
   wacrawl backup status
+  wacrawl backup snapshots
   wacrawl backup push
   wacrawl --sync never backup push
   wacrawl backup init --repo ~/Projects/backup-wacrawl --remote https://github.com/steipete/backup-wacrawl.git
@@ -832,6 +855,7 @@ Flags:
   --identity PATH    Age identity path.
   --recipient AGE    Age recipient. Repeatable.
   --no-push          Commit locally without pushing.
+  --tag NAME         Tag the resulting backup commit.
 `)
 	case "backup pull":
 		_, _ = fmt.Fprint(w, `Restore encrypted archive shards into the archive database.
@@ -844,6 +868,7 @@ Flags:
   --repo PATH        Backup Git repository path.
   --remote URL       Backup Git remote.
   --identity PATH    Age identity path.
+  --ref REF          Restore a tag, commit, or branch without changing checkout.
 `)
 	case "backup status":
 		_, _ = fmt.Fprint(w, `Show encrypted backup status and manifest metadata.
@@ -856,6 +881,18 @@ Flags:
   --repo PATH        Backup Git repository path.
   --remote URL       Backup Git remote.
   --identity PATH    Age identity path.
+`)
+	case "backup snapshots":
+		_, _ = fmt.Fprint(w, `List restorable encrypted backup snapshots from Git history.
+
+Usage:
+  wacrawl backup snapshots [flags]
+
+Flags:
+  --config PATH      Backup config path.
+  --repo PATH        Backup Git repository path.
+  --remote URL       Backup Git remote.
+  --limit N          Maximum snapshots to list. Default: 20.
 `)
 	default:
 		return false

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -310,8 +310,8 @@ func TestRunHelpMenus(t *testing.T) {
 		want string
 	}{
 		{"global short", []string{"--help"}, "Examples:"},
-		{"backup help", []string{"backup", "help"}, "wacrawl backup <init|push|pull|status>"},
-		{"backup topic", []string{"help", "backup"}, "wacrawl backup <init|push|pull|status>"},
+		{"backup help", []string{"backup", "help"}, "wacrawl backup <init|push|pull|status|snapshots>"},
+		{"backup topic", []string{"help", "backup"}, "wacrawl backup <init|push|pull|status|snapshots>"},
 		{"doctor topic", []string{"help", "doctor"}, "wacrawl doctor [--source PATH]"},
 		{"command help topic", []string{"help", "messages"}, "wacrawl messages [flags]"},
 		{"doctor flag", []string{"doctor", "--help"}, "wacrawl doctor [--source PATH]"},
@@ -326,11 +326,12 @@ func TestRunHelpMenus(t *testing.T) {
 		{"sql flag", []string{"sql", "--help"}, "read-only SQL query"},
 		{"import flag", []string{"import", "--help"}, "--copy-media"},
 		{"sync topic", []string{"help", "sync"}, "wacrawl sync [--source PATH]"},
-		{"backup flag", []string{"backup", "--help"}, "wacrawl backup <init|push|pull|status>"},
+		{"backup flag", []string{"backup", "--help"}, "wacrawl backup <init|push|pull|status|snapshots>"},
 		{"backup nested flag", []string{"backup", "init", "--help"}, "wacrawl backup init [flags]"},
 		{"backup nested topic", []string{"backup", "help", "push"}, "wacrawl backup push [flags]"},
 		{"backup pull topic", []string{"help", "backup", "pull"}, "wacrawl backup pull [flags]"},
 		{"backup status topic", []string{"help", "backup", "status"}, "wacrawl backup status [flags]"},
+		{"backup snapshots topic", []string{"help", "backup", "snapshots"}, "wacrawl backup snapshots [flags]"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
@@ -530,11 +531,37 @@ func TestBackupCommands(t *testing.T) {
 	}
 	stdout.Reset()
 	stderr.Reset()
-	if err := Run(ctx, []string{"--db", dbPath, "--sync", "never", "backup", "push", "--config", config, "--no-push"}, &stdout, &stderr); err != nil {
+	if err := Run(ctx, []string{"--db", dbPath, "--sync", "never", "backup", "push", "--config", config, "--no-push", "--tag", "snapshot/initial"}, &stdout, &stderr); err != nil {
 		t.Fatalf("backup push error = %v stderr=%s", err, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "encrypted=true") || !strings.Contains(stdout.String(), "messages=3") {
+	if !strings.Contains(stdout.String(), "encrypted=true") || !strings.Contains(stdout.String(), "messages=3") || !strings.Contains(stdout.String(), "tag=snapshot/initial") {
 		t.Fatalf("backup push output mismatch:\n%s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"backup", "snapshots", "--config", config}, &stdout, &stderr); err != nil {
+		t.Fatalf("backup snapshots error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "snapshot/initial") || !strings.Contains(stdout.String(), "MESSAGES") {
+		t.Fatalf("backup snapshots output mismatch:\n%s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"--json", "backup", "snapshots", "--config", config, "--limit", "1"}, &stdout, &stderr); err != nil {
+		t.Fatalf("JSON backup snapshots error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"repo"`) || !strings.Contains(stdout.String(), `"snapshots"`) || !strings.Contains(stdout.String(), `"ref"`) {
+		t.Fatalf("JSON backup snapshots output mismatch:\n%s", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"backup", "snapshots", "--config", config, "--limit", "0"}, &stdout, &stderr); err == nil || ExitCode(err) != 2 {
+		t.Fatalf("invalid backup snapshots limit error = %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"backup", "snapshots", "--config", config, "extra"}, &stdout, &stderr); err == nil || ExitCode(err) != 2 {
+		t.Fatalf("backup snapshots positional argument error = %v", err)
 	}
 	stdout.Reset()
 	stderr.Reset()
@@ -547,8 +574,11 @@ func TestBackupCommands(t *testing.T) {
 	restoredDB := filepath.Join(t.TempDir(), "restored.db")
 	stdout.Reset()
 	stderr.Reset()
-	if err := Run(ctx, []string{"--db", restoredDB, "backup", "pull", "--config", config}, &stdout, &stderr); err != nil {
+	if err := Run(ctx, []string{"--db", restoredDB, "backup", "pull", "--config", config, "--ref", "snapshot/initial"}, &stdout, &stderr); err != nil {
 		t.Fatalf("backup pull error = %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "ref=") {
+		t.Fatalf("backup pull should report resolved ref:\n%s", stdout.String())
 	}
 	stdout.Reset()
 	stderr.Reset()


### PR DESCRIPTION
## Summary

- keep every changed encrypted backup as the durable Git snapshot
- optionally name checkpoints with `backup push --tag NAME`
- list recoverable checkpoints with `backup snapshots --limit N`
- restore a tag, commit, or branch with `backup pull --ref REF` without changing the backup checkout

No archive database format change. Tag names are documented as visible Git metadata.

## Proof

- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `./scripts/coverage.sh 85.0` (85.3%)
- `gofumpt -l .`
- autoreview: clean, no actionable findings

Improves the historical-recovery part of #11; media backup and scheduled automation remain separate work.
