### PR TITLE
ci: refresh workflow tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Go
         uses: actions/setup-go@v6.4.0
@@ -28,16 +28,16 @@ jobs:
           cache: true
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@v9.2.1
         with:
-          version: v2.11.1
+          version: v2.12.2
 
       - name: Install analyzers
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
-          go install mvdan.cc/gofumpt@v0.9.2
-          go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
-          go install golang.org/x/tools/cmd/deadcode@v0.45.0
+          go install mvdan.cc/gofumpt@v0.10.0
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+          go install golang.org/x/tools/cmd/deadcode@v0.46.0
 
       - name: Vet
         run: go vet ./...
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Go
         uses: actions/setup-go@v6.4.0
@@ -96,7 +96,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
 
       - name: Setup Go
         uses: actions/setup-go@v6.4.0
@@ -113,7 +113,7 @@ jobs:
           git diff --exit-code -- go.mod go.sum
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.4.0
 
       - name: Run govulncheck
         run: '"$(go env GOPATH)/bin/govulncheck" ./...'
@@ -123,7 +123,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
@@ -134,7 +134,7 @@ jobs:
           cache: true
 
       - name: Snapshot release build
-        uses: goreleaser/goreleaser-action@v7.1.0
+        uses: goreleaser/goreleaser-action@v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -145,7 +145,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
         run: git checkout ${{ inputs.tag }}
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v7.1.0
+        uses: goreleaser/goreleaser-action@v7.2.2
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -765,7 +765,8 @@ func runGit(t *testing.T, dir string, args ...string) {
 func gitOutput(ctx context.Context, dir string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- tests pass only fixed Git commands and temporary paths.
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(
+		os.Environ(),
 		"GIT_AUTHOR_NAME=wacrawl-test",
 		"GIT_AUTHOR_EMAIL=wacrawl-test@example.invalid",
 		"GIT_COMMITTER_NAME=wacrawl-test",

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -599,7 +599,8 @@ func TestSyncArchiveKeepsExistingArchiveWhenSourceUnavailable(t *testing.T) {
 	defer func() { _ = st.Close() }()
 
 	now := time.Now().UTC().Add(-time.Hour)
-	if err := st.ReplaceAll(ctx,
+	if err := st.ReplaceAll(
+		ctx,
 		store.ImportStats{SourcePath: "/missing", DBPath: st.Path(), FinishedAt: now},
 		nil,
 		[]store.Chat{{JID: "chat", Kind: "dm", Name: "Chat", LastMessageAt: now}},

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -184,7 +184,8 @@ func TestReplaceAllDuplicateSourcePKFails(t *testing.T) {
 	defer func() { _ = st.Close() }()
 
 	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
-	err = st.ReplaceAll(ctx, ImportStats{FinishedAt: now}, nil,
+	err = st.ReplaceAll(
+		ctx, ImportStats{FinishedAt: now}, nil,
 		[]Chat{{JID: "chat", Kind: "dm", Name: "Chat", LastMessageAt: now}},
 		nil,
 		nil,

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -117,7 +117,8 @@ func Discover(ctx context.Context, path string) (Source, error) {
 		if maxDate.Valid {
 			source.NewestMessage = appleTime(maxDate.Float64).Format(time.RFC3339)
 		}
-		source.SchemaNotes = append(source.SchemaNotes,
+		source.SchemaNotes = append(
+			source.SchemaNotes,
 			"CoreData tables: ZWACHATSESSION, ZWAMESSAGE, ZWAMEDIAITEM, ZWAGROUPINFO, ZWAGROUPMEMBER",
 			"timestamps are seconds since 2001-01-01 UTC",
 			"ZWAMESSAGE.ZGROUPMEMBER identifies group senders",


### PR DESCRIPTION
## Summary

- update checkout to v7.0.0 and current stable CI actions
- update golangci-lint, gofumpt, gosec, deadcode, and govulncheck
- apply gofumpt v0.10.0's multiline-call formatting

The checkout major adds the upstream fork-checkout guard for privileged workflow contexts. The remaining changes keep existing checks on current compatible stable releases; runtime dependencies are unchanged.

## Proof

- `GOWORK=off go mod verify`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test -count=1 ./...`
- `GOWORK=off go test -race -count=1 ./...`
- `./scripts/coverage.sh 85.0` (`85.4%`)
- golangci-lint v2.12.2, staticcheck v0.7.0, deadcode v0.46.0, gofumpt v0.10.0, and gosec v2.27.1 clean
- govulncheck v1.4.0: no vulnerabilities
- actionlint and GoReleaser config checks clean
- GoReleaser snapshot completed for every configured target without publishing
- built `doctor` and `status` JSON contracts checked with private values suppressed
- temporary empty archive completed encrypted push, named snapshot listing, and historical restore while preserving backup checkout HEAD
- autoreview: clean, no accepted/actionable findings

No release, version bump, tag, or publish action.
