### PR TITLE
fix: retry atomic snapshot pushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 
+- Retry concurrent encrypted backup branch-and-tag pushes after rebasing and retargeting the unpublished tag.
 - Move encrypted snapshot, Git history/tag/ref, SQLite bundle, contact export, and safe FTS query mechanics to CrawlKit while preserving the archive schema, backup manifest format, and CLI JSON contracts.
 
 ## [0.2.7] - 2026-06-10

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.12.3-0.20260619102715-6e14735bb248
+	github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.12.3-0.20260619102715-6e14735bb248 h1:EpOaEZl2IDx4Ck1UoULzMyENijI80Qn98WvsHztARPo=
-github.com/openclaw/crawlkit v0.12.3-0.20260619102715-6e14735bb248/go.mod h1:GwfF/ZPPIaAy1lKcWIhA/YgcOXPHA+8rJm5Ned+AuIc=
+github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78 h1:7ebiHhILVHAJT+b4h2CVu/xeUKsLN3nNSfq994uo/3I=
+github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -110,7 +110,7 @@ func Push(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 		return Result{}, err
 	}
 	if pushWithTag {
-		if err := mirror.PushAtomic(ctx, mirrorOptions(cfg), "HEAD", "refs/tags/"+tag); err != nil {
+		if err := mirror.PushCurrentSnapshot(ctx, mirrorOptions(cfg), tag); err != nil {
 			return Result{}, err
 		}
 	}


### PR DESCRIPTION
## Summary

- retry concurrent encrypted backup branch-and-tag pushes through CrawlKit
- preserve the current/legacy backup branch and retarget unpublished tags after rebase
- preserve unrelated backup-repository edits during retry rebases

## Proof

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- autoreview clean
