### PR TITLE
feat: back up copied WhatsApp media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Added
 
+- Back up copied WhatsApp media as content-deduplicated encrypted Git blobs and restore current or historical media with portable paths and integrity checks.
 - Add read-only SQL archive queries with JSON output, automatic sync support, and lossless duplicate-column handling (#18, thanks @TurboTheTurtle).
 - Add named Git backup snapshots, snapshot history listing, and non-mutating historical restores through `backup pull --ref`.
 
 ### Changed
 
+- Keep media filenames and archive paths inside an encrypted backup index; cleartext manifests expose only counts, encrypted blob paths, sizes, and hashes.
 - Retry concurrent encrypted backup branch-and-tag pushes after rebasing and retargeting the unpublished tag.
 - Move encrypted snapshot, Git history/tag/ref, SQLite bundle, contact export, and safe FTS query mechanics to CrawlKit while preserving the archive schema, backup manifest format, and CLI JSON contracts.
 

--- a/README.md
+++ b/README.md
@@ -304,13 +304,19 @@ data/contacts.jsonl.gz.age
 data/groups.jsonl.gz.age
 data/group_participants.jsonl.gz.age
 data/messages/YYYY/MM.jsonl.gz.age
+data/files/index*.jsonl.gz.age
+data/files/HH/SHA256.gz.age
 ```
 
 `manifest.json` is intentionally cleartext so a machine can inspect backup
 freshness, public age recipients, counts, shard paths, encrypted byte sizes, and
-plaintext hashes without decrypting message contents. It does not contain
-message text, chat names, contacts, participant IDs, or media metadata. Those
-fields live inside the `*.jsonl.gz.age` shards.
+plaintext hashes without decrypting backup contents. It does not contain
+message text, chat names, contacts, participant IDs, media metadata, filenames,
+or archive paths. Those fields live inside the `*.jsonl.gz.age` shards.
+
+Media previously copied with `wacrawl sync --copy-media` is included by default.
+Identical files share one encrypted content-addressed blob. Use `backup push
+--no-media` or `backup pull --no-media` when only archive rows are wanted.
 
 ### Command Cheat Sheet
 
@@ -339,7 +345,8 @@ Useful safety variants:
 
 ```bash
 # Force a fresh WhatsApp import before writing the backup.
-wacrawl --sync always backup push
+wacrawl sync --copy-media
+wacrawl --sync never backup push
 
 # Write and commit locally, but do not push to GitHub.
 wacrawl backup push --no-push
@@ -382,20 +389,22 @@ safe to place in `~/.wacrawl/backup.json`, `manifest.json`, or docs.
 For each shard, `wacrawl backup push`:
 
 1. Exports rows from the local archive as deterministic JSONL.
-2. Gzip-compresses the JSONL with a fixed gzip timestamp.
-3. Encrypts the compressed bytes with age for every configured recipient.
-4. Writes only the encrypted `*.jsonl.gz.age` shard to Git.
-5. Writes `manifest.json` with cleartext metadata used for status, diffing, and restore verification.
+2. Streams copied media through hashing, gzip, and age encryption in one pass.
+3. Content-deduplicates identical media and encrypts the private path index.
+4. Encrypts every compressed payload for each configured recipient.
+5. Writes only encrypted `*.jsonl.gz.age` payloads to Git.
+6. Writes `manifest.json` with cleartext metadata used for status, diffing, and restore verification.
 
 `wacrawl backup pull` does the reverse: it pulls/rebases the backup repo,
 checks manifest shard paths, decrypts each shard with the local age identity,
-verifies the shard hash, validates cross-table references, and imports the
-snapshot into the configured archive database in one transaction.
+verifies row and media hashes, restores copied media under `media/` next to the
+configured database, localizes portable media paths, validates cross-table
+references, and imports the snapshot in one transaction.
 
 What the backup protects:
 
 - A GitHub read-only compromise or accidental clone does not reveal message text,
-  contacts, chat names, participant IDs, or media metadata.
+  contacts, chat names, participant IDs, media metadata, filenames, or archive paths.
 - Each encrypted shard can be decrypted by any listed age recipient, so multiple
   machines can share one backup without sharing one private key.
 - Age provides encrypted-file integrity; corrupted or wrong-key shards fail to
@@ -405,7 +414,7 @@ What remains visible in Git:
 
 - `manifest.json` is cleartext.
 - The manifest reveals export time, public recipients, table names, row counts,
-  shard paths, encrypted byte sizes, and plaintext shard hashes.
+  opaque shard paths, encrypted byte sizes, plaintext content hashes, and media counts.
 - Message shard paths reveal activity by year and month, for example
   `data/messages/2026/04.jsonl.gz.age`.
 - Git history reveals backup cadence and which encrypted shards changed.
@@ -470,7 +479,10 @@ it refreshes the local archive only when the WhatsApp Desktop source is stale
 and newer than the archive. Then it exports stable JSONL, gzip-compresses each
 shard, encrypts each shard for every configured recipient, updates
 `manifest.json`, removes stale encrypted shards, commits, and pushes the backup
-repo.
+repo. Copied files already under the archive `media/` directory are included by
+default; run `wacrawl sync --copy-media` first to capture media bytes still
+available from WhatsApp Desktop. `backup push` never reads media directly from
+the WhatsApp container.
 
 Pass `--tag NAME` to tag the resulting snapshot commit. If the archive is
 unchanged, the tag points at the existing current snapshot. Existing tags are
@@ -478,7 +490,7 @@ never moved to a different commit.
 
 Re-running `backup push` without archive changes leaves Git clean. The command
 prints the repo path, whether anything changed, whether the backup is encrypted,
-the shard count, and the message count.
+the shard count, message count, and copied-media count.
 
 Use `--no-push` for local dry runs that commit into the backup checkout but do
 not push to the remote:
@@ -486,6 +498,9 @@ not push to the remote:
 ```bash
 wacrawl backup push --no-push
 ```
+
+Use `--no-media` to omit copied media from a snapshot. The current backup then
+contains archive rows only; earlier Git commits still retain their media blobs.
 
 ### Restore
 
@@ -498,7 +513,8 @@ wacrawl backup pull
 `backup pull` pulls/rebases the configured backup repo, decrypts every shard with
 the local age identity, verifies each plaintext shard hash from the manifest,
 validates cross-table references, and replaces the configured `wacrawl` archive
-database in one import transaction.
+database in one import transaction. Copied media is restored alongside the
+database unless `--no-media` is set.
 
 Restore a historical tag, commit, or branch with `--ref`:
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ data/groups.jsonl.gz.age
 data/group_participants.jsonl.gz.age
 data/messages/YYYY/MM.jsonl.gz.age
 data/files/index*.jsonl.gz.age
-data/files/HH/SHA256.gz.age
+data/files/objects/OPAQUE_ID.gz.age
 ```
 
 `manifest.json` is intentionally cleartext so a machine can inspect backup
@@ -315,8 +315,9 @@ message text, chat names, contacts, participant IDs, media metadata, filenames,
 or archive paths. Those fields live inside the `*.jsonl.gz.age` shards.
 
 Media previously copied with `wacrawl sync --copy-media` is included by default.
-Identical files share one encrypted content-addressed blob. Use `backup push
---no-media` or `backup pull --no-media` when only archive rows are wanted.
+Identical files share one encrypted blob with a random opaque object ID. Their
+content hashes remain inside the encrypted index. Use `backup push --no-media`
+or `backup pull --no-media` when only archive rows are wanted.
 
 ### Command Cheat Sheet
 
@@ -414,7 +415,8 @@ What remains visible in Git:
 
 - `manifest.json` is cleartext.
 - The manifest reveals export time, public recipients, table names, row counts,
-  opaque shard paths, encrypted byte sizes, plaintext content hashes, and media counts.
+  opaque shard paths, encrypted byte sizes, row/index hashes, and media counts.
+  Individual media paths, filenames, plaintext sizes, and content hashes remain encrypted.
 - Message shard paths reveal activity by year and month, for example
   `data/messages/2026/04.jsonl.gz.age`.
 - Git history reveals backup cadence and which encrypted shards changed.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.12.3-0.20260619175603-441777525b33
+	github.com/openclaw/crawlkit v0.12.3-0.20260619180003-d9c6440db799
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.12.3-0.20260619180003-d9c6440db799
+	github.com/openclaw/crawlkit v0.12.3-0.20260619181405-28d58de9e09a
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.12.3-0.20260619175259-adafd8d3f56d
+	github.com/openclaw/crawlkit v0.12.3-0.20260619175603-441777525b33
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78
+	github.com/openclaw/crawlkit v0.12.3-0.20260619174909-f9c1c822ef65
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.12.3-0.20260619174909-f9c1c822ef65
+	github.com/openclaw/crawlkit v0.12.3-0.20260619175259-adafd8d3f56d
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.12.3-0.20260619180003-d9c6440db799 h1:zdIHMmLNUJiG4ZvQN6jqiMTs/65CVFOoMVzodh05HUA=
-github.com/openclaw/crawlkit v0.12.3-0.20260619180003-d9c6440db799/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
+github.com/openclaw/crawlkit v0.12.3-0.20260619181405-28d58de9e09a h1:fynmCNvXO9KHaSzo8rKtpsA0zOFW2hGim4KvDtmY9bQ=
+github.com/openclaw/crawlkit v0.12.3-0.20260619181405-28d58de9e09a/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.12.3-0.20260619175259-adafd8d3f56d h1:ePyWiD9Sxl9091/zje0a346zdRIceP+4HWG7NlNFyOw=
-github.com/openclaw/crawlkit v0.12.3-0.20260619175259-adafd8d3f56d/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
+github.com/openclaw/crawlkit v0.12.3-0.20260619175603-441777525b33 h1:us4LFnTI8kQT/xsCI7weVKfxwN/x130EaZsiAA4mUPY=
+github.com/openclaw/crawlkit v0.12.3-0.20260619175603-441777525b33/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78 h1:7ebiHhILVHAJT+b4h2CVu/xeUKsLN3nNSfq994uo/3I=
-github.com/openclaw/crawlkit v0.12.3-0.20260619115105-eb1aa35e0e78/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
+github.com/openclaw/crawlkit v0.12.3-0.20260619174909-f9c1c822ef65 h1:vZyRst33xsz85D535mLC6jwcd1OZFGACbYFfrmyc0IU=
+github.com/openclaw/crawlkit v0.12.3-0.20260619174909-f9c1c822ef65/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.12.3-0.20260619174909-f9c1c822ef65 h1:vZyRst33xsz85D535mLC6jwcd1OZFGACbYFfrmyc0IU=
-github.com/openclaw/crawlkit v0.12.3-0.20260619174909-f9c1c822ef65/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
+github.com/openclaw/crawlkit v0.12.3-0.20260619175259-adafd8d3f56d h1:ePyWiD9Sxl9091/zje0a346zdRIceP+4HWG7NlNFyOw=
+github.com/openclaw/crawlkit v0.12.3-0.20260619175259-adafd8d3f56d/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/mattn/go-isatty v0.0.22 h1:j8l17JJ9i6VGPUFUYoTUKPSgKe/83EYU2zBC7YNKMw
 github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.12.3-0.20260619175603-441777525b33 h1:us4LFnTI8kQT/xsCI7weVKfxwN/x130EaZsiAA4mUPY=
-github.com/openclaw/crawlkit v0.12.3-0.20260619175603-441777525b33/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
+github.com/openclaw/crawlkit v0.12.3-0.20260619180003-d9c6440db799 h1:zdIHMmLNUJiG4ZvQN6jqiMTs/65CVFOoMVzodh05HUA=
+github.com/openclaw/crawlkit v0.12.3-0.20260619180003-d9c6440db799/go.mod h1:zOJv5WPWO1AuuXO7zW8NRTxb/ZTkIQXYPrx3StmnMUI=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -37,8 +37,10 @@ type Counts struct {
 	MediaFiles   int `json:"media_files,omitempty"`
 }
 
-type ShardEntry = ckbackup.ShardEntry
-type FileEntry = ckbackup.FileEntry
+type (
+	ShardEntry = ckbackup.ShardEntry
+	FileEntry  = ckbackup.FileEntry
+)
 
 type Result struct {
 	Repo       string `json:"repo"`

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -170,7 +170,7 @@ func Pull(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 		if err != nil {
 			return Result{}, err
 		}
-		defer os.RemoveAll(stageRoot)
+		defer func() { _ = os.RemoveAll(stageRoot) }()
 		if ref == "" {
 			_, err = ckbackup.RestoreFilesUnder(ctx, crawlkitConfig(cfg), toCrawlkitManifest(manifest), stageRoot, "media")
 		} else {

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -450,7 +450,7 @@ data/groups.jsonl.gz.age
 data/group_participants.jsonl.gz.age
 data/messages/YYYY/MM.jsonl.gz.age
 data/files/index*.jsonl.gz.age
-data/files/HH/SHA256.gz.age
+data/files/objects/OPAQUE_ID.gz.age
 ` + "```" + `
 
 ` + "`manifest.json`" + ` is cleartext and contains format version, export time,

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -23,6 +24,7 @@ type Manifest struct {
 	Recipients []string     `json:"recipients,omitempty"`
 	Counts     Counts       `json:"counts"`
 	Shards     []ShardEntry `json:"shards"`
+	Files      []FileEntry  `json:"files,omitempty"`
 }
 
 type Counts struct {
@@ -31,18 +33,21 @@ type Counts struct {
 	Groups       int `json:"groups"`
 	Participants int `json:"participants"`
 	Messages     int `json:"messages"`
+	MediaFiles   int `json:"media_files,omitempty"`
 }
 
 type ShardEntry = ckbackup.ShardEntry
+type FileEntry = ckbackup.FileEntry
 
 type Result struct {
-	Repo      string `json:"repo"`
-	Changed   bool   `json:"changed"`
-	Encrypted bool   `json:"encrypted"`
-	Shards    int    `json:"shards"`
-	Messages  int    `json:"messages"`
-	Ref       string `json:"ref,omitempty"`
-	Tag       string `json:"tag,omitempty"`
+	Repo       string `json:"repo"`
+	Changed    bool   `json:"changed"`
+	Encrypted  bool   `json:"encrypted"`
+	Shards     int    `json:"shards"`
+	Messages   int    `json:"messages"`
+	MediaFiles int    `json:"media_files"`
+	Ref        string `json:"ref,omitempty"`
+	Tag        string `json:"tag,omitempty"`
 }
 
 func Init(ctx context.Context, opts Options) (Config, string, error) {
@@ -96,7 +101,14 @@ func Push(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	manifest, err := writeSnapshot(ctx, cfg, data, oldManifest)
+	var files []ckbackup.File
+	if !opts.NoMedia {
+		files, err = collectBackupMedia(ctx, st.Path(), data.Messages)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	manifest, err := writeSnapshot(ctx, cfg, data, files, oldManifest)
 	if err != nil {
 		return Result{}, err
 	}
@@ -114,7 +126,7 @@ func Push(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 			return Result{}, err
 		}
 	}
-	return Result{Repo: cfg.Repo, Changed: changed, Encrypted: true, Shards: len(manifest.Shards), Messages: manifest.Counts.Messages, Tag: tag}, nil
+	return Result{Repo: cfg.Repo, Changed: changed, Encrypted: true, Shards: len(manifest.Shards), Messages: manifest.Counts.Messages, MediaFiles: len(manifest.Files), Tag: tag}, nil
 }
 
 func Pull(ctx context.Context, st *store.Store, opts Options) (Result, error) {
@@ -142,6 +154,23 @@ func Pull(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
+	root, err := archiveRoot(st.Path())
+	if err != nil {
+		return Result{}, err
+	}
+	if !opts.NoMedia {
+		if ref == "" {
+			_, err = ckbackup.RestoreFilesUnder(ctx, crawlkitConfig(cfg), toCrawlkitManifest(manifest), root, "media")
+		} else {
+			_, _, err = ckbackup.RestoreFilesAtUnder(ctx, crawlkitConfig(cfg), mirrorOptions(cfg), toCrawlkitManifest(manifest), ref, root, "media")
+		}
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	if err := localizeMediaPaths(data.Messages, root); err != nil {
+		return Result{}, err
+	}
 	if err := data.Validate(); err != nil {
 		return Result{}, err
 	}
@@ -152,7 +181,7 @@ func Pull(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 	if err := st.ImportSnapshot(ctx, data, sourcePath, manifest.Exported); err != nil {
 		return Result{}, err
 	}
-	return Result{Repo: cfg.Repo, Changed: true, Encrypted: manifest.Encrypted, Shards: len(manifest.Shards), Messages: len(data.Messages), Ref: ref}, nil
+	return Result{Repo: cfg.Repo, Changed: true, Encrypted: manifest.Encrypted, Shards: len(manifest.Shards), Messages: len(data.Messages), MediaFiles: len(manifest.Files), Ref: ref}, nil
 }
 
 func Status(ctx context.Context, opts Options) (Manifest, string, error) {
@@ -170,7 +199,7 @@ func Status(ctx context.Context, opts Options) (Manifest, string, error) {
 	return manifest, cfg.Repo, nil
 }
 
-func writeSnapshot(ctx context.Context, cfg Config, data store.SnapshotData, old Manifest) (Manifest, error) {
+func writeSnapshot(ctx context.Context, cfg Config, data store.SnapshotData, files []ckbackup.File, old Manifest) (Manifest, error) {
 	shards := []ckbackup.Shard{
 		{Table: "contacts", Path: "data/contacts.jsonl.gz.age", Rows: data.Contacts},
 		{Table: "chats", Path: "data/chats.jsonl.gz.age", Rows: data.Chats},
@@ -184,7 +213,7 @@ func writeSnapshot(ctx context.Context, cfg Config, data store.SnapshotData, old
 	if len(data.Messages) == 0 {
 		delete(sharedOld.Counts, "messages")
 	}
-	manifest, err := ckbackup.WriteSnapshot(ctx, crawlkitConfig(cfg), shards, sharedOld)
+	manifest, err := ckbackup.WriteSnapshotWithFiles(ctx, crawlkitConfig(cfg), shards, files, sharedOld)
 	if err != nil {
 		return Manifest{}, err
 	}
@@ -311,6 +340,7 @@ func toCrawlkitManifest(manifest Manifest) ckbackup.Manifest {
 			"messages":     manifest.Counts.Messages,
 		},
 		Shards: manifest.Shards,
+		Files:  manifest.Files,
 	}
 }
 
@@ -330,9 +360,71 @@ func fromCrawlkitManifest(manifest ckbackup.Manifest) Manifest {
 			Groups:       manifest.Counts["groups"],
 			Participants: participants,
 			Messages:     manifest.Counts["messages"],
+			MediaFiles:   len(manifest.Files),
 		},
 		Shards: manifest.Shards,
+		Files:  manifest.Files,
 	}
+}
+
+func collectBackupMedia(ctx context.Context, dbPath string, messages []store.Message) ([]ckbackup.File, error) {
+	root, err := archiveRoot(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	files, err := ckbackup.CollectFiles(ctx, filepath.Join(root, "media"), "media")
+	if err != nil {
+		return nil, err
+	}
+	logicalBySource := make(map[string]string, len(files))
+	for _, file := range files {
+		absolute, err := filepath.Abs(file.Source)
+		if err != nil {
+			return nil, err
+		}
+		logicalBySource[filepath.Clean(absolute)] = file.Path
+	}
+	for index := range messages {
+		mediaPath := messages[index].MediaPath
+		if mediaPath == "" {
+			continue
+		}
+		absolute, err := filepath.Abs(mediaPath)
+		if err != nil {
+			return nil, err
+		}
+		if logical, ok := logicalBySource[filepath.Clean(absolute)]; ok {
+			messages[index].MediaPath = logical
+		}
+	}
+	return files, nil
+}
+
+func localizeMediaPaths(messages []store.Message, root string) error {
+	for index := range messages {
+		value := filepath.ToSlash(messages[index].MediaPath)
+		if value == "media" || !strings.HasPrefix(value, "media/") {
+			continue
+		}
+		clean := path.Clean(value)
+		if clean == "media" || !strings.HasPrefix(clean, "media/") {
+			return fmt.Errorf("backup media path escapes archive root: %s", value)
+		}
+		target := filepath.Clean(filepath.Join(root, filepath.FromSlash(clean)))
+		if target != root && !strings.HasPrefix(target, root+string(filepath.Separator)) {
+			return fmt.Errorf("backup media path escapes archive root: %s", value)
+		}
+		messages[index].MediaPath = target
+	}
+	return nil
+}
+
+func archiveRoot(dbPath string) (string, error) {
+	absolute, err := filepath.Abs(filepath.Dir(dbPath))
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(absolute), nil
 }
 
 func writeBackupReadme(repo string) error {
@@ -357,12 +449,15 @@ data/contacts.jsonl.gz.age
 data/groups.jsonl.gz.age
 data/group_participants.jsonl.gz.age
 data/messages/YYYY/MM.jsonl.gz.age
+data/files/index*.jsonl.gz.age
+data/files/HH/SHA256.gz.age
 ` + "```" + `
 
 ` + "`manifest.json`" + ` is cleartext and contains format version, export time,
 public age recipients, table counts, shard paths, encrypted byte sizes, and
 plaintext hashes used for restore verification. Message text, contacts, chat
-names, participant IDs, and media metadata stay inside encrypted ` + "`*.jsonl.gz.age`" + ` shards.
+names, participant IDs, media metadata, filenames, and archive paths stay inside
+encrypted ` + "`*.jsonl.gz.age`" + ` shards.
 
 ## Security Model
 
@@ -373,8 +468,8 @@ encrypted with age for every configured public recipient. The local
 Git can still see manifest metadata: export time, public recipients, table
 names, row counts, shard paths, encrypted byte sizes, plaintext shard hashes,
 backup cadence, and which encrypted shards changed. Git cannot read message
-text, contacts, chat names, participant IDs, or media metadata without an age
-identity.
+text, contacts, chat names, participant IDs, media metadata, filenames, or
+archive paths without an age identity.
 
 Anyone who can push to this repository can replace encrypted backup data with
 different data encrypted to your public recipient. Keep repository write access
@@ -390,8 +485,8 @@ wacrawl backup push --tag snapshot/before-phone-migration
 ` + "```" + `
 
 The command pulls/rebases this checkout, refreshes the local wacrawl archive
-according to the normal sync policy, writes encrypted shards, updates the
-manifest, commits, and pushes this repository.
+according to the normal sync policy, writes encrypted row shards and copied
+media blobs, updates the manifest, commits, and pushes this repository.
 
 Every changed backup is a Git commit. Optional tags name important checkpoints;
 tag names are visible Git metadata and should not contain sensitive text.
@@ -404,10 +499,10 @@ wacrawl backup snapshots
 wacrawl --db /tmp/wacrawl-history.db backup pull --ref snapshot/before-phone-migration
 ` + "```" + `
 
-` + "`backup pull`" + ` decrypts every shard with the local age identity, verifies the
-manifest hashes, validates the snapshot, and imports it into the configured
-wacrawl archive database. Historical refs are read directly from Git objects
-without changing this checkout's current branch.
+` + "`backup pull`" + ` decrypts every payload with the local age identity, verifies
+the manifest hashes, restores copied media, validates the snapshot, and imports
+it into the configured wacrawl archive database. Historical refs are read
+directly from Git objects without changing this checkout's current branch.
 
 ## Recovery
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -154,15 +155,24 @@ func Pull(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
+	if err := data.Validate(); err != nil {
+		return Result{}, err
+	}
 	root, err := archiveRoot(st.Path())
 	if err != nil {
 		return Result{}, err
 	}
-	if !opts.NoMedia {
+	stageRoot := ""
+	if !opts.NoMedia && len(manifest.Files) > 0 {
+		stageRoot, err = os.MkdirTemp(root, ".wacrawl-media-restore-")
+		if err != nil {
+			return Result{}, err
+		}
+		defer os.RemoveAll(stageRoot)
 		if ref == "" {
-			_, err = ckbackup.RestoreFilesUnder(ctx, crawlkitConfig(cfg), toCrawlkitManifest(manifest), root, "media")
+			_, err = ckbackup.RestoreFilesUnder(ctx, crawlkitConfig(cfg), toCrawlkitManifest(manifest), stageRoot, "media")
 		} else {
-			_, _, err = ckbackup.RestoreFilesAtUnder(ctx, crawlkitConfig(cfg), mirrorOptions(cfg), toCrawlkitManifest(manifest), ref, root, "media")
+			_, _, err = ckbackup.RestoreFilesAtUnder(ctx, crawlkitConfig(cfg), mirrorOptions(cfg), toCrawlkitManifest(manifest), ref, stageRoot, "media")
 		}
 		if err != nil {
 			return Result{}, err
@@ -171,14 +181,17 @@ func Pull(ctx context.Context, st *store.Store, opts Options) (Result, error) {
 	if err := localizeMediaPaths(data.Messages, root); err != nil {
 		return Result{}, err
 	}
-	if err := data.Validate(); err != nil {
-		return Result{}, err
-	}
 	sourcePath := "backup:" + cfg.Repo
 	if ref != "" {
 		sourcePath += "@" + ref
 	}
-	if err := st.ImportSnapshot(ctx, data, sourcePath, manifest.Exported); err != nil {
+	importSnapshot := func() error { return st.ImportSnapshot(ctx, data, sourcePath, manifest.Exported) }
+	if stageRoot != "" {
+		err = replaceMediaDuring(filepath.Join(stageRoot, "media"), filepath.Join(root, "media"), importSnapshot)
+	} else {
+		err = importSnapshot()
+	}
+	if err != nil {
 		return Result{}, err
 	}
 	return Result{Repo: cfg.Repo, Changed: true, Encrypted: manifest.Encrypted, Shards: len(manifest.Shards), Messages: len(data.Messages), MediaFiles: len(manifest.Files), Ref: ref}, nil
@@ -425,6 +438,55 @@ func archiveRoot(dbPath string) (string, error) {
 		return "", err
 	}
 	return filepath.Clean(absolute), nil
+}
+
+func replaceMediaDuring(staged, target string, commit func() error) error {
+	stagedInfo, err := os.Lstat(staged)
+	if err != nil {
+		return err
+	}
+	if stagedInfo.Mode()&os.ModeSymlink != 0 || !stagedInfo.IsDir() {
+		return fmt.Errorf("staged media is not a directory: %s", staged)
+	}
+	parent := filepath.Dir(target)
+	previous, err := os.MkdirTemp(parent, ".wacrawl-media-previous-")
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(previous); err != nil {
+		return err
+	}
+	hadPrevious := false
+	if targetInfo, statErr := os.Lstat(target); statErr == nil {
+		if targetInfo.Mode()&os.ModeSymlink != 0 || !targetInfo.IsDir() {
+			return fmt.Errorf("archive media is not a directory: %s", target)
+		}
+		if err := os.Rename(target, previous); err != nil {
+			return err
+		}
+		hadPrevious = true
+	} else if !os.IsNotExist(statErr) {
+		return statErr
+	}
+	if err := os.Rename(staged, target); err != nil {
+		var restoreErr error
+		if hadPrevious {
+			restoreErr = os.Rename(previous, target)
+		}
+		return errors.Join(err, restoreErr)
+	}
+	if err := commit(); err != nil {
+		removeErr := os.RemoveAll(target)
+		var restoreErr error
+		if hadPrevious {
+			restoreErr = os.Rename(previous, target)
+		}
+		return errors.Join(err, removeErr, restoreErr)
+	}
+	if hadPrevious {
+		_ = os.RemoveAll(previous)
+	}
+	return nil
 }
 
 func writeBackupReadme(repo string) error {

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -188,6 +189,34 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	}
 	if !pushed.Changed || pushed.Messages != 2 {
 		t.Fatalf("unexpected pushed backup: %+v", pushed)
+	}
+}
+
+func TestReplaceMediaDuringRollsBackFailedImport(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "media")
+	staged := filepath.Join(dir, "staged")
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(staged, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(target, "old"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staged, "new"), []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("import failed")
+	if err := replaceMediaDuring(staged, target, func() error { return wantErr }); !errors.Is(err, wantErr) {
+		t.Fatalf("replace error = %v", err)
+	}
+	if body, err := os.ReadFile(filepath.Join(target, "old")); err != nil || string(body) != "old" {
+		t.Fatalf("previous media was not restored: %q err=%v", body, err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "new")); !os.IsNotExist(err) {
+		t.Fatalf("failed media remained after rollback: %v", err)
 	}
 }
 

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -278,6 +278,20 @@ func TestLocalizeMediaPathsRejectsEscape(t *testing.T) {
 	}
 }
 
+func TestDecodeSnapshotRejectsInvalidShards(t *testing.T) {
+	for _, table := range []string{"contacts", "chats", "groups", "group_participants", "messages", "unknown"} {
+		t.Run(table, func(t *testing.T) {
+			shard := ckbackup.DecodedShard{
+				Entry:     ckbackup.ShardEntry{Table: table},
+				Plaintext: []byte("{"),
+			}
+			if _, err := decodeSnapshot([]ckbackup.DecodedShard{shard}); err == nil {
+				t.Fatal("invalid shard should fail")
+			}
+		})
+	}
+}
+
 func TestHistoricalSnapshotRestore(t *testing.T) {
 	ctx := context.Background()
 	source := openFixtureStore(t, "history-source.db")

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -29,6 +29,15 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 			{SourcePK: 1, ChatJID: "chat@g.us", ChatName: "Launch Group", MessageID: "a", SenderJID: "alice@s.whatsapp.net", SenderName: "Alice", Timestamp: now, Text: "secret launch text", RawType: 0, MessageType: "text"},
 		},
 	}
+	mediaPath := filepath.Join(filepath.Dir(source.Path()), "media", "photo.jpg ")
+	if err := os.MkdirAll(filepath.Dir(mediaPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mediaPath, []byte("private media bytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	data.Messages[0].MediaType = "image"
+	data.Messages[0].MediaPath = mediaPath
 	if err := source.ImportSnapshot(ctx, data, "/fixture", now); err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +59,7 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !result.Changed || result.Messages != 1 || result.Shards == 0 {
+	if !result.Changed || result.Messages != 1 || result.MediaFiles != 1 || result.Shards == 0 {
 		t.Fatalf("unexpected push result: %+v", result)
 	}
 	second, err := Push(ctx, source, opts)
@@ -64,14 +73,14 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if statusRepo != repo || status.Counts.Messages != 1 {
+	if statusRepo != repo || status.Counts.Messages != 1 || status.Counts.MediaFiles != 1 {
 		t.Fatalf("unexpected backup status repo=%s status=%+v", statusRepo, status)
 	}
 	manifest, err := readManifest(repo)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !manifest.Encrypted || manifest.Counts.Messages != 1 {
+	if !manifest.Encrypted || manifest.Counts.Messages != 1 || len(manifest.Files) != 1 {
 		t.Fatalf("unexpected manifest: %+v", manifest)
 	}
 	ciphertext, err := os.ReadFile(filepath.Join(repo, filepath.FromSlash(manifest.Shards[len(manifest.Shards)-1].Path))) // #nosec G304 -- test reads a generated shard path from its temp repo manifest.
@@ -81,13 +90,20 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	if strings.Contains(string(ciphertext), "secret launch text") {
 		t.Fatal("encrypted shard contains plaintext")
 	}
+	manifestBody, err := os.ReadFile(filepath.Join(repo, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(manifestBody), "photo.jpg ") || strings.Contains(string(manifestBody), "private media bytes") {
+		t.Fatalf("backup manifest exposes media details: %s", manifestBody)
+	}
 
 	restored := openFixtureStore(t, "restored.db")
 	pulled, err := Pull(ctx, restored, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pulled.Messages != 1 {
+	if pulled.Messages != 1 || pulled.MediaFiles != 1 {
 		t.Fatalf("unexpected pull result: %+v", pulled)
 	}
 	results, err := restored.Search(ctx, store.MessageFilter{Query: "secret", Limit: 10})
@@ -96,6 +112,14 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].Text != "secret launch text" {
 		t.Fatalf("restore search mismatch: %+v", results)
+	}
+	wantRestoredMedia := filepath.Join(filepath.Dir(restored.Path()), "media", "photo.jpg ")
+	if results[0].MediaPath != wantRestoredMedia {
+		t.Fatalf("restored media path = %q, want %q", results[0].MediaPath, wantRestoredMedia)
+	}
+	mediaBody, err := os.ReadFile(wantRestoredMedia)
+	if err != nil || string(mediaBody) != "private media bytes" {
+		t.Fatalf("restored media = %q err=%v", mediaBody, err)
 	}
 
 	secondIdentity := filepath.Join(t.TempDir(), "second-age.key")
@@ -146,11 +170,11 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 		t.Fatal(err)
 	}
 	runGit(t, derivedRepo, "init")
-	derived, err := Push(ctx, source, Options{Repo: derivedRepo, Identity: identity, Push: false})
+	derived, err := Push(ctx, source, Options{Repo: derivedRepo, Identity: identity, Push: false, NoMedia: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !derived.Changed || derived.Messages != 1 {
+	if !derived.Changed || derived.Messages != 1 || derived.MediaFiles != 0 {
 		t.Fatalf("unexpected derived-recipient push: %+v", derived)
 	}
 
@@ -178,6 +202,15 @@ func TestHistoricalSnapshotRestore(t *testing.T) {
 			SenderJID: "alice@s.whatsapp.net", Timestamp: now, Text: "first snapshot", MessageType: "text",
 		}},
 	}
+	mediaPath := filepath.Join(filepath.Dir(source.Path()), "media", "history.jpg")
+	if err := os.MkdirAll(filepath.Dir(mediaPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mediaPath, []byte("first historical media"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	data.Messages[0].MediaType = "image"
+	data.Messages[0].MediaPath = mediaPath
 	if err := source.ImportSnapshot(ctx, data, "/fixture", now); err != nil {
 		t.Fatal(err)
 	}
@@ -209,6 +242,9 @@ func TestHistoricalSnapshotRestore(t *testing.T) {
 		SourcePK: 2, ChatJID: "chat@g.us", ChatName: "History", MessageID: "second",
 		SenderJID: "alice@s.whatsapp.net", Timestamp: now.Add(time.Minute), Text: "second snapshot", MessageType: "text",
 	})
+	if err := os.WriteFile(mediaPath, []byte("second historical media"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	if err := source.ImportSnapshot(ctx, data, "/fixture", now.Add(time.Minute)); err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +307,7 @@ func TestHistoricalSnapshotRestore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pulled.Messages != 1 || pulled.Ref != initial {
+	if pulled.Messages != 1 || pulled.MediaFiles != 1 || pulled.Ref != initial {
 		t.Fatalf("unexpected historical pull: %+v", pulled)
 	}
 	after, err := resolveCommit(ctx, repo, "HEAD")
@@ -287,6 +323,10 @@ func TestHistoricalSnapshotRestore(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].MessageID != "first" {
 		t.Fatalf("historical restore mismatch: %+v", results)
+	}
+	historicalMedia, err := os.ReadFile(filepath.Join(filepath.Dir(restored.Path()), "media", "history.jpg"))
+	if err != nil || string(historicalMedia) != "first historical media" {
+		t.Fatalf("historical media = %q err=%v", historicalMedia, err)
 	}
 	if _, err := Pull(ctx, restored, Options{ConfigPath: configPath, Ref: "missing-ref"}); err == nil {
 		t.Fatal("missing historical ref should fail")

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -91,7 +91,7 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	if strings.Contains(string(ciphertext), "secret launch text") {
 		t.Fatal("encrypted shard contains plaintext")
 	}
-	manifestBody, err := os.ReadFile(filepath.Join(repo, "manifest.json"))
+	manifestBody, err := os.ReadFile(filepath.Join(repo, "manifest.json")) // #nosec G304 -- test reads the manifest from its temp backup repo.
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	if results[0].MediaPath != wantRestoredMedia {
 		t.Fatalf("restored media path = %q, want %q", results[0].MediaPath, wantRestoredMedia)
 	}
-	mediaBody, err := os.ReadFile(wantRestoredMedia)
+	mediaBody, err := os.ReadFile(wantRestoredMedia) // #nosec G304 -- test reads its expected temp restore path.
 	if err != nil || string(mediaBody) != "private media bytes" {
 		t.Fatalf("restored media = %q err=%v", mediaBody, err)
 	}
@@ -212,7 +212,7 @@ func TestReplaceMediaDuringRollsBackFailedImport(t *testing.T) {
 	if err := replaceMediaDuring(staged, target, func() error { return wantErr }); !errors.Is(err, wantErr) {
 		t.Fatalf("replace error = %v", err)
 	}
-	if body, err := os.ReadFile(filepath.Join(target, "old")); err != nil || string(body) != "old" {
+	if body, err := os.ReadFile(filepath.Join(target, "old")); err != nil || string(body) != "old" { // #nosec G304 -- test reads its temp media target.
 		t.Fatalf("previous media was not restored: %q err=%v", body, err)
 	}
 	if _, err := os.Stat(filepath.Join(target, "new")); !os.IsNotExist(err) {
@@ -228,7 +228,7 @@ func TestReplaceMediaDuringRollsBackFailedImport(t *testing.T) {
 	if err := replaceMediaDuring(staged, target, func() error { return nil }); err != nil {
 		t.Fatal(err)
 	}
-	if body, err := os.ReadFile(filepath.Join(target, "new")); err != nil || string(body) != "new" {
+	if body, err := os.ReadFile(filepath.Join(target, "new")); err != nil || string(body) != "new" { // #nosec G304 -- test reads its temp media target.
 		t.Fatalf("promoted media = %q err=%v", body, err)
 	}
 	if _, err := os.Stat(filepath.Join(target, "old")); !os.IsNotExist(err) {
@@ -266,7 +266,7 @@ func TestReplaceMediaDuringValidatesAndHandlesNoPreviousMedia(t *testing.T) {
 	if err := replaceMediaDuring(staged, target, func() error { return nil }); err != nil {
 		t.Fatal(err)
 	}
-	if body, err := os.ReadFile(filepath.Join(target, "new")); err != nil || string(body) != "new" {
+	if body, err := os.ReadFile(filepath.Join(target, "new")); err != nil || string(body) != "new" { // #nosec G304 -- test reads its temp media target.
 		t.Fatalf("new media without previous directory = %q err=%v", body, err)
 	}
 }

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -218,6 +218,64 @@ func TestReplaceMediaDuringRollsBackFailedImport(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(target, "new")); !os.IsNotExist(err) {
 		t.Fatalf("failed media remained after rollback: %v", err)
 	}
+	staged = filepath.Join(dir, "staged-success")
+	if err := os.MkdirAll(staged, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staged, "new"), []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := replaceMediaDuring(staged, target, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if body, err := os.ReadFile(filepath.Join(target, "new")); err != nil || string(body) != "new" {
+		t.Fatalf("promoted media = %q err=%v", body, err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "old")); !os.IsNotExist(err) {
+		t.Fatalf("previous media remained after success: %v", err)
+	}
+}
+
+func TestReplaceMediaDuringValidatesAndHandlesNoPreviousMedia(t *testing.T) {
+	dir := t.TempDir()
+	stagedFile := filepath.Join(dir, "staged-file")
+	if err := os.WriteFile(stagedFile, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := replaceMediaDuring(stagedFile, filepath.Join(dir, "media"), func() error { return nil }); err == nil {
+		t.Fatal("regular staged file should fail")
+	}
+
+	staged := filepath.Join(dir, "staged")
+	if err := os.MkdirAll(staged, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staged, "new"), []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(dir, "media")
+	if err := os.WriteFile(target, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := replaceMediaDuring(staged, target, func() error { return nil }); err == nil {
+		t.Fatal("regular target file should fail")
+	}
+	if err := os.Remove(target); err != nil {
+		t.Fatal(err)
+	}
+	if err := replaceMediaDuring(staged, target, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if body, err := os.ReadFile(filepath.Join(target, "new")); err != nil || string(body) != "new" {
+		t.Fatalf("new media without previous directory = %q err=%v", body, err)
+	}
+}
+
+func TestLocalizeMediaPathsRejectsEscape(t *testing.T) {
+	messages := []store.Message{{MediaPath: "media/../outside"}}
+	if err := localizeMediaPaths(messages, t.TempDir()); err == nil {
+		t.Fatal("escaping portable media path should fail")
+	}
 }
 
 func TestHistoricalSnapshotRestore(t *testing.T) {

--- a/internal/backup/config.go
+++ b/internal/backup/config.go
@@ -30,6 +30,7 @@ type Options struct {
 	Ref        string
 	Tag        string
 	Limit      int
+	NoMedia    bool
 }
 
 func DefaultConfig() Config {

--- a/internal/cli/backup.go
+++ b/internal/cli/backup.go
@@ -70,6 +70,7 @@ func (a *app) runBackupInit(ctx context.Context, args []string) error {
 func (a *app) runBackupPush(ctx context.Context, args []string) error {
 	fs, opts, noPush := backupFlagSet("backup push")
 	fs.StringVar(&opts.Tag, "tag", "", "")
+	fs.BoolVar(&opts.NoMedia, "no-media", false, "")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printCommandUsage(a.stdout, "backup", "push")
@@ -93,6 +94,7 @@ func (a *app) runBackupPush(ctx context.Context, args []string) error {
 func (a *app) runBackupPull(ctx context.Context, args []string) error {
 	fs, opts, _ := backupFlagSet("backup pull")
 	fs.StringVar(&opts.Ref, "ref", "", "")
+	fs.BoolVar(&opts.NoMedia, "no-media", false, "")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printCommandUsage(a.stdout, "backup", "pull")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -576,7 +576,7 @@ func (a *app) print(value any) error {
 		}
 		return tw.Flush()
 	case backup.Result:
-		_, err := fmt.Fprintf(a.stdout, "repo=%s\nchanged=%t\nencrypted=%t\nshards=%d\nmessages=%d\n", v.Repo, v.Changed, v.Encrypted, v.Shards, v.Messages)
+		_, err := fmt.Fprintf(a.stdout, "repo=%s\nchanged=%t\nencrypted=%t\nshards=%d\nmessages=%d\nmedia_files=%d\n", v.Repo, v.Changed, v.Encrypted, v.Shards, v.Messages, v.MediaFiles)
 		if err == nil && v.Ref != "" {
 			_, err = fmt.Fprintf(a.stdout, "ref=%s\n", v.Ref)
 		}
@@ -590,17 +590,17 @@ func (a *app) print(value any) error {
 			return err
 		}
 		tw := tabwriter.NewWriter(a.stdout, 2, 4, 2, ' ', 0)
-		_, _ = fmt.Fprintln(tw, "REF\tEXPORTED\tMESSAGES\tSHARDS\tTAGS")
+		_, _ = fmt.Fprintln(tw, "REF\tEXPORTED\tMESSAGES\tMEDIA\tSHARDS\tTAGS")
 		for _, snapshot := range v {
 			ref := snapshot.Ref
 			if len(ref) > 12 {
 				ref = ref[:12]
 			}
-			_, _ = fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%s\n", ref, formatTime(snapshot.Exported), snapshot.Counts.Messages, snapshot.Shards, strings.Join(snapshot.Tags, ","))
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%d\t%s\n", ref, formatTime(snapshot.Exported), snapshot.Counts.Messages, snapshot.Counts.MediaFiles, snapshot.Shards, strings.Join(snapshot.Tags, ","))
 		}
 		return tw.Flush()
 	case backup.Manifest:
-		_, err := fmt.Fprintf(a.stdout, "encrypted=%t\nshards=%d\nmessages=%d\nexported=%s\n", v.Encrypted, len(v.Shards), v.Counts.Messages, formatTime(v.Exported))
+		_, err := fmt.Fprintf(a.stdout, "encrypted=%t\nshards=%d\nmessages=%d\nmedia_files=%d\nexported=%s\n", v.Encrypted, len(v.Shards), v.Counts.Messages, len(v.Files), formatTime(v.Exported))
 		return err
 	default:
 		enc := json.NewEncoder(a.stdout)
@@ -839,7 +839,7 @@ Flags:
   --no-push          Commit locally without pushing.
 `)
 	case "backup push":
-		_, _ = fmt.Fprint(w, `Export and push encrypted archive shards.
+		_, _ = fmt.Fprint(w, `Export and push encrypted archive shards and copied media.
 
 Usage:
   wacrawl backup push [flags]
@@ -851,10 +851,11 @@ Flags:
   --identity PATH    Age identity path.
   --recipient AGE    Age recipient. Repeatable.
   --no-push          Commit locally without pushing.
+  --no-media         Omit copied media files from this backup.
   --tag NAME         Tag the resulting backup commit.
 `)
 	case "backup pull":
-		_, _ = fmt.Fprint(w, `Restore encrypted archive shards into the archive database.
+		_, _ = fmt.Fprint(w, `Restore encrypted archive shards and copied media.
 
 Usage:
   wacrawl backup pull [flags]
@@ -864,6 +865,7 @@ Flags:
   --repo PATH        Backup Git repository path.
   --remote URL       Backup Git remote.
   --identity PATH    Age identity path.
+  --no-media         Restore archive rows without copied media files.
   --ref REF          Restore a tag, commit, or branch without changing checkout.
 `)
 	case "backup status":

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -589,7 +589,7 @@ func TestBackupCommands(t *testing.T) {
 		t.Fatalf("restored search mismatch:\n%s", stdout.String())
 	}
 	restoredMedia := filepath.Join(filepath.Dir(restoredDB), "media", "Media", "123@g.us", "a", "test.jpg")
-	if body, err := os.ReadFile(restoredMedia); err != nil || string(body) != "image" {
+	if body, err := os.ReadFile(restoredMedia); err != nil || string(body) != "image" { // #nosec G304 -- test reads its expected temp restore path.
 		t.Fatalf("restored media = %q err=%v", body, err)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -518,7 +518,7 @@ func TestBackupCommands(t *testing.T) {
 	identity := filepath.Join(t.TempDir(), "age.key")
 
 	var stdout, stderr bytes.Buffer
-	if err := Run(ctx, []string{"--db", dbPath, "--source", source, "sync"}, &stdout, &stderr); err != nil {
+	if err := Run(ctx, []string{"--db", dbPath, "--source", source, "sync", "--copy-media"}, &stdout, &stderr); err != nil {
 		t.Fatalf("sync error = %v stderr=%s", err, stderr.String())
 	}
 	stdout.Reset()
@@ -534,7 +534,7 @@ func TestBackupCommands(t *testing.T) {
 	if err := Run(ctx, []string{"--db", dbPath, "--sync", "never", "backup", "push", "--config", config, "--no-push", "--tag", "snapshot/initial"}, &stdout, &stderr); err != nil {
 		t.Fatalf("backup push error = %v stderr=%s", err, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "encrypted=true") || !strings.Contains(stdout.String(), "messages=3") || !strings.Contains(stdout.String(), "tag=snapshot/initial") {
+	if !strings.Contains(stdout.String(), "encrypted=true") || !strings.Contains(stdout.String(), "messages=3") || !strings.Contains(stdout.String(), "media_files=1") || !strings.Contains(stdout.String(), "tag=snapshot/initial") {
 		t.Fatalf("backup push output mismatch:\n%s", stdout.String())
 	}
 	stdout.Reset()
@@ -587,6 +587,10 @@ func TestBackupCommands(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "[launch] now") {
 		t.Fatalf("restored search mismatch:\n%s", stdout.String())
+	}
+	restoredMedia := filepath.Join(filepath.Dir(restoredDB), "media", "Media", "123@g.us", "a", "test.jpg")
+	if body, err := os.ReadFile(restoredMedia); err != nil || string(body) != "image" {
+		t.Fatalf("restored media = %q err=%v", body, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- back up copied WhatsApp media alongside encrypted database shards by default
- restore media for current and historical snapshots, with `--no-media` opt-out
- store portable `media/...` references in encrypted message rows
- use CrawlKit's encrypted file index, content deduplication, opaque object names, and confined restore APIs
- stage media replacement and roll it back when database import fails
- report `media_files` in backup push/pull/status output

Existing database schema and existing snapshots remain compatible. Backup push uses media already copied into the Wacrawl archive; run `wacrawl sync --copy-media` before pushing when new payloads are needed.

## Validation

- `go test -count=1 ./...`
- `go test -count=1 -race ./...`
- `go vet ./...`
- `golangci-lint v2.12.2 run` (zero issues)
- `go run golang.org/x/tools/cmd/deadcode@v0.46.0 -test ./...`
- `./scripts/coverage.sh 85.0` (85.3% locally; Linux CI green)
- structured whole-branch autoreview: no accepted/actionable findings
