### PR TITLE
Save backup config atomically

### DIFF
--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -557,6 +557,13 @@ func TestConfigRoundTrip(t *testing.T) {
 	if loaded.Repo != cfg.Repo || loaded.Recipients[0] != "age1example" {
 		t.Fatalf("config mismatch: %+v", loaded)
 	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("config mode = %#o, want 0600", got)
+	}
 	if DefaultConfigPath() == "" {
 		t.Fatal("default config path should not be empty")
 	}
@@ -600,6 +607,60 @@ func TestConfigRoundTrip(t *testing.T) {
 	}
 	if strings.Join(resolved.Recipients, ",") != " age1two ,age1one" {
 		t.Fatalf("recipient overrides changed: %#v", resolved.Recipients)
+	}
+}
+
+func TestSaveConfigPreservesExistingConfigOnRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "backup.json")
+	original := DefaultConfig()
+	original.Repo = "~/Projects/original"
+	original.Recipients = []string{"age1original"}
+	if err := SaveConfig(path, original); err != nil {
+		t.Fatal(err)
+	}
+
+	renameErr := errors.New("rename stopped")
+	previousRename := renameConfigFile
+	renameConfigFile = func(_, _ string) error {
+		return renameErr
+	}
+	defer func() {
+		renameConfigFile = previousRename
+	}()
+
+	updated := original
+	updated.Repo = "~/Projects/updated"
+	updated.Recipients = []string{"age1updated"}
+	if err := SaveConfig(path, updated); !errors.Is(err, renameErr) {
+		t.Fatalf("SaveConfig error = %v, want %v", err, renameErr)
+	}
+
+	loaded, err := LoadConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Repo != original.Repo || strings.Join(loaded.Recipients, ",") != "age1original" {
+		t.Fatalf("config was replaced after failed rename: %+v", loaded)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".backup.json.") && strings.HasSuffix(entry.Name(), ".tmp") {
+			t.Fatalf("temporary config file was not cleaned up: %s", entry.Name())
+		}
+	}
+}
+
+func TestAtomicConfigWriteReportsFilesystemErrors(t *testing.T) {
+	missingParent := filepath.Join(t.TempDir(), "missing", "backup.json")
+	if err := writeFileAtomic(missingParent, []byte("{}\n"), 0o600); err == nil {
+		t.Fatal("expected missing parent error")
+	}
+	if err := syncConfigDir(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("expected missing directory sync error")
 	}
 }
 

--- a/internal/backup/config.go
+++ b/internal/backup/config.go
@@ -13,6 +13,8 @@ const (
 	defaultRemote = "https://github.com/steipete/backup-wacrawl.git"
 )
 
+var renameConfigFile = os.Rename
+
 type Config struct {
 	Repo       string   `json:"repo"`
 	Remote     string   `json:"remote"`
@@ -80,7 +82,67 @@ func SaveConfig(path string, cfg Config) error {
 		return err
 	}
 	data = append(data, '\n')
-	return os.WriteFile(path, data, 0o600)
+	return writeFileAtomic(path, data, 0o600)
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	closed := false
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	closeTmp := func() error {
+		if closed {
+			return nil
+		}
+		closed = true
+		return tmp.Close()
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = closeTmp()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = closeTmp()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = closeTmp()
+		return err
+	}
+	if err := closeTmp(); err != nil {
+		return err
+	}
+	if err := renameConfigFile(tmpName, path); err != nil {
+		return err
+	}
+	if err := syncConfigDir(dir); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func syncConfigDir(dir string) error {
+	f, err := os.Open(dir) // #nosec G304 -- dir is the validated parent of the config path being atomically replaced.
+	if err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 func ResolveOptions(opts Options) (Config, error) {


### PR DESCRIPTION
Closes #24.

Summary:
- Writes backup.json through a same-directory temporary file, syncs it, renames it into place, then syncs the parent directory.
- Preserves 0600 permissions and cleans up temporary files on failure.

Behavior proof:

```text
backup init output:
repo=/tmp/.../repo
remote=https://github.com/steipete/backup-wacrawl.git
identity=/tmp/.../age.key
recipient=age1...
config readable: repo=/tmp/.../repo
config readable: recipients=1
config mode: 600
temporary files left: none
```

A focused rename-failure test also forces the final rename to fail after staging the new config; LoadConfig still reads the original repo and age recipient.