### PR TITLE
feat: add local web viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.3.1] - Unreleased
 
+### Added
+
+- Add a private loopback-only web viewer for archive status, chats, messages, and search, with per-run access keys and no media/configuration/write surface (#10, thanks @greenido).
+
 ## [0.3.0] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Search message text:
 wacrawl search "release notes"
 ```
 
+Browse the archive locally:
+
+```bash
+wacrawl web
+```
+
 Use JSON for scripts:
 
 ```bash
@@ -115,6 +121,8 @@ wacrawl --db /tmp/wacrawl.db import
 - Replaces only the `wacrawl` archive database.
 - Does not modify WhatsApp databases, settings, contacts, chats, or media.
 - Does not use the WhatsApp network protocol.
+- Serves the optional web viewer only on IPv4 loopback with a random per-run
+  access key; the viewer exposes no archive writes, configuration, or media files.
 - Does not upload data during normal archive/search commands. `backup push`
   uploads only age-encrypted backup shards when you explicitly run it.
 
@@ -251,6 +259,30 @@ wacrawl --json sql "SELECT chat_jid, count(*) FROM messages GROUP BY chat_jid OR
 
 Only single read-only `SELECT` statements are accepted. Use `--db PATH` to query
 an alternate archive database.
+
+### `web`
+
+Browse archive status, recent chats, messages, and full-text search in a local
+web viewer:
+
+```bash
+wacrawl web
+```
+
+The command prints a private URL and keeps running until you press Ctrl-C. It
+binds only to `127.0.0.1`, chooses a free random port by default, and protects
+archive APIs with a random key stored in the URL fragment so browsers do not
+send it in requests or referrers. The page consumes the key into memory and
+removes it from the address bar. Use a fixed loopback port when useful:
+
+```bash
+wacrawl --sync never web --port 8787
+```
+
+The viewer is deliberately read-only. It does not serve media bytes or paths,
+change archive or backup configuration, schedule syncs, or expose a non-local
+listen address. The normal global sync policy runs once before the viewer
+starts; use the CLI to sync again, then select **Refresh view** in the browser.
 
 ## Sync Behavior
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -109,6 +109,8 @@ func Run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		return a.runSearch(ctx, rest[1:])
 	case "sql":
 		return a.runSQL(ctx, rest[1:])
+	case "web":
+		return a.runWeb(ctx, rest[1:])
 	case "backup":
 		return a.runBackup(ctx, rest[1:])
 	default:
@@ -628,6 +630,7 @@ Commands:
   messages    List archived messages.
   search      Search archived messages.
   sql         Run a read-only SQL query.
+  web         Browse the local archive in a private web viewer.
   backup      Init, push, pull, or inspect encrypted Git backups.
 
 Options:
@@ -648,6 +651,7 @@ Examples:
   wacrawl --json --sync never contacts export
   wacrawl --json search "invoice" --from-them --after 2026-01-01
   wacrawl sql "SELECT count(*) FROM messages"
+  wacrawl --sync never web
   wacrawl help messages
 `)
 }
@@ -795,6 +799,23 @@ Usage:
 Examples:
   wacrawl sql "SELECT count(*) FROM messages"
   wacrawl --json sql "SELECT chat_jid, count(*) FROM messages GROUP BY chat_jid"
+`)
+	case "web":
+		_, _ = fmt.Fprint(w, `Browse the local archive in a private web viewer.
+
+The viewer binds only to 127.0.0.1 and requires a random key printed in its URL.
+It reads archive status, chats, messages, and search results without serving media
+files or exposing configuration and write controls.
+
+Usage:
+  wacrawl web [--port N]
+
+Flags:
+  --port N   Loopback port. Default: choose a free random port.
+
+Examples:
+  wacrawl web
+  wacrawl --sync never web --port 8787
 `)
 	case "backup":
 		_, _ = fmt.Fprint(w, `Manage encrypted Git backups of the wacrawl archive.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -208,6 +208,18 @@ func assertContactExportKeys(t *testing.T, data []byte) {
 
 func TestMetadataAdvertisesContactExport(t *testing.T) {
 	manifest := controlManifest()
+	webCommand, ok := manifest.Commands["web"]
+	if !ok {
+		t.Fatalf("commands = %#v", manifest.Commands)
+	}
+	if webCommand.Mutates || webCommand.JSON {
+		t.Fatalf("web command = %#v", webCommand)
+	}
+	webWant := []string{"wacrawl", "--sync", "never", "web"}
+	if !reflect.DeepEqual(webCommand.Argv, webWant) {
+		t.Fatalf("web argv = %#v, want %#v", webCommand.Argv, webWant)
+	}
+
 	sqlCommand, ok := manifest.Commands["sql"]
 	if !ok {
 		t.Fatalf("commands = %#v", manifest.Commands)
@@ -271,6 +283,7 @@ func TestRunUsageErrors(t *testing.T) {
 		{"chats", "extra"},
 		{"messages", "extra"},
 		{"unread", "extra"},
+		{"web", "extra"},
 	} {
 		err = Run(context.Background(), args, &stdout, &stderr)
 		if err == nil || !strings.Contains(err.Error(), "flags only") {
@@ -301,6 +314,14 @@ func TestRunUsageErrors(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "contacts export takes no arguments") {
 		t.Fatalf("expected contacts export args error, got %v", err)
 	}
+	err = Run(context.Background(), []string{"web", "--port", "-1"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "--port must be between") {
+		t.Fatalf("expected web port error, got %v", err)
+	}
+	err = Run(context.Background(), []string{"--json", "web"}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "does not support --json") {
+		t.Fatalf("expected web json error, got %v", err)
+	}
 }
 
 func TestRunHelpMenus(t *testing.T) {
@@ -324,6 +345,8 @@ func TestRunHelpMenus(t *testing.T) {
 		{"search flag", []string{"search", "--help"}, "wacrawl search [flags] <query>"},
 		{"sql topic", []string{"help", "sql"}, "wacrawl sql <select query>"},
 		{"sql flag", []string{"sql", "--help"}, "read-only SQL query"},
+		{"web topic", []string{"help", "web"}, "wacrawl web [--port N]"},
+		{"web flag", []string{"web", "--help"}, "private web viewer"},
 		{"import flag", []string{"import", "--help"}, "--copy-media"},
 		{"sync topic", []string{"help", "sync"}, "wacrawl sync [--source PATH]"},
 		{"backup flag", []string{"backup", "--help"}, "wacrawl backup <init|push|pull|status|snapshots>"},

--- a/internal/cli/control.go
+++ b/internal/cli/control.go
@@ -16,7 +16,7 @@ func controlManifest() control.Manifest {
 		DefaultCache:    filepath.Join(filepath.Dir(defaultDBPath()), "cache"),
 		DefaultLogs:     filepath.Join(filepath.Dir(defaultDBPath()), "logs"),
 	}
-	m.Capabilities = []string{"metadata", "doctor", "status", "sync", "search", "sql", "backup"}
+	m.Capabilities = []string{"metadata", "doctor", "status", "sync", "search", "sql", "web", "backup"}
 	m.Privacy = control.Privacy{ContainsPrivateMessages: true, ExportsSecrets: false, LocalOnlyScopes: []string{"whatsapp-desktop", "sqlite", "encrypted-git-backup"}}
 	m.Commands = map[string]control.Command{
 		"doctor":         {Title: "Doctor", Argv: []string{"wacrawl", "--json", "doctor"}, JSON: true},
@@ -24,6 +24,7 @@ func controlManifest() control.Manifest {
 		"sync":           {Title: "Sync", Argv: []string{"wacrawl", "--json", "sync"}, JSON: true, Mutates: true},
 		"search":         {Title: "Search", Argv: []string{"wacrawl", "--json", "--sync", "auto", "search"}, JSON: true},
 		"sql":            {Title: "SQL", Argv: []string{"wacrawl", "--json", "sql"}, JSON: true},
+		"web":            {Title: "Web viewer", Argv: []string{"wacrawl", "--sync", "never", "web"}},
 		"contact-export": {Title: "Export contacts", Argv: []string{"wacrawl", "--json", "--sync", "never", "contacts", "export"}, JSON: true},
 	}
 	return m

--- a/internal/cli/web.go
+++ b/internal/cli/web.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+
+	"github.com/openclaw/wacrawl/internal/store"
+	"github.com/openclaw/wacrawl/internal/webui"
+)
+
+func (a *app) runWeb(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("web", flag.ContinueOnError)
+	fs.SetOutput(a.stderr)
+	port := fs.Int("port", 0, "")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			printCommandUsage(a.stdout, "web")
+			return nil
+		}
+		return usageErr(err)
+	}
+	if fs.NArg() != 0 {
+		return usageErr(errors.New("web takes flags only"))
+	}
+	if *port < 0 || *port > 65535 {
+		return usageErr(errors.New("--port must be between 0 and 65535"))
+	}
+	if a.json {
+		return usageErr(errors.New("web does not support --json"))
+	}
+	return a.withArchiveStore(ctx, func(st *store.Store) error {
+		return webui.Serve(ctx, st, webui.Config{Port: *port, Output: a.stdout})
+	})
+}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -1,0 +1,345 @@
+package webui
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"embed"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openclaw/wacrawl/internal/store"
+)
+
+//go:embed static/*
+var assets embed.FS
+
+type Config struct {
+	Port   int
+	Output io.Writer
+}
+
+type handler struct {
+	store       *store.Store
+	token       string
+	allowedHost string
+}
+
+type statusResponse struct {
+	Chats          int       `json:"chats"`
+	UnreadChats    int       `json:"unread_chats"`
+	UnreadMessages int       `json:"unread_messages"`
+	Contacts       int       `json:"contacts"`
+	Groups         int       `json:"groups"`
+	Messages       int       `json:"messages"`
+	MediaMessages  int       `json:"media_messages"`
+	OldestMessage  time.Time `json:"oldest_message,omitzero"`
+	NewestMessage  time.Time `json:"newest_message,omitzero"`
+	LastImportAt   time.Time `json:"last_import_at,omitzero"`
+}
+
+type chatResponse struct {
+	JID           string    `json:"jid"`
+	Kind          string    `json:"kind"`
+	Name          string    `json:"name,omitempty"`
+	LastMessageAt time.Time `json:"last_message_at,omitzero"`
+	UnreadCount   int       `json:"unread_count"`
+	Archived      bool      `json:"archived"`
+	MessageCount  int       `json:"message_count"`
+}
+
+type messageResponse struct {
+	ChatJID     string    `json:"chat_jid"`
+	ChatName    string    `json:"chat_name,omitempty"`
+	MessageID   string    `json:"message_id"`
+	SenderJID   string    `json:"sender_jid,omitempty"`
+	SenderName  string    `json:"sender_name,omitempty"`
+	Timestamp   time.Time `json:"timestamp"`
+	FromMe      bool      `json:"from_me"`
+	Text        string    `json:"text,omitempty"`
+	MessageType string    `json:"message_type,omitempty"`
+	MediaType   string    `json:"media_type,omitempty"`
+	MediaTitle  string    `json:"media_title,omitempty"`
+	MediaSize   int64     `json:"media_size,omitempty"`
+	Starred     bool      `json:"starred,omitempty"`
+	Snippet     string    `json:"snippet,omitempty"`
+}
+
+func Serve(ctx context.Context, archive *store.Store, cfg Config) error {
+	if cfg.Port < 0 || cfg.Port > 65535 {
+		return errors.New("web port must be between 0 and 65535")
+	}
+	listener, err := net.Listen("tcp4", fmt.Sprintf("127.0.0.1:%d", cfg.Port))
+	if err != nil {
+		return fmt.Errorf("listen for web viewer: %w", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	token, err := randomToken()
+	if err != nil {
+		return err
+	}
+	host := listener.Addr().String()
+	url := "http://" + host + "/#" + token
+	output := cfg.Output
+	if output == nil {
+		output = io.Discard
+	}
+	_, _ = fmt.Fprintf(output, "wacrawl web viewer\n%s\n\nLocal and read-only. Keep this URL private; Ctrl-C stops the server.\n", url)
+
+	server := &http.Server{
+		Handler:           NewHandler(archive, token, host),
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       time.Minute,
+	}
+	stopWatcher := make(chan struct{})
+	watcherDone := make(chan struct{})
+	go func() {
+		defer close(watcherDone)
+		select {
+		case <-ctx.Done():
+			shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+			defer cancel()
+			_ = server.Shutdown(shutdownCtx)
+		case <-stopWatcher:
+		}
+	}()
+
+	err = server.Serve(listener)
+	close(stopWatcher)
+	<-watcherDone
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return fmt.Errorf("serve web viewer: %w", err)
+	}
+	return nil
+}
+
+func NewHandler(archive *store.Store, token, allowedHost string) http.Handler {
+	return &handler{store: archive, token: token, allowedHost: allowedHost}
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	setSecurityHeaders(w)
+	if r.Host != h.allowedHost {
+		http.Error(w, "unexpected host", http.StatusMisdirectedRequest)
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	switch r.URL.Path {
+	case "/":
+		h.serveAsset(w, "static/index.html", "text/html; charset=utf-8")
+		return
+	case "/app.css":
+		h.serveAsset(w, "static/app.css", "text/css; charset=utf-8")
+		return
+	case "/app.js":
+		h.serveAsset(w, "static/app.js", "text/javascript; charset=utf-8")
+		return
+	}
+
+	if !strings.HasPrefix(r.URL.Path, "/api/") {
+		http.NotFound(w, r)
+		return
+	}
+	if !h.authorized(r) {
+		w.Header().Set("WWW-Authenticate", "Bearer")
+		http.Error(w, "authorization required", http.StatusUnauthorized)
+		return
+	}
+
+	switch r.URL.Path {
+	case "/api/status":
+		h.serveStatus(w, r)
+	case "/api/chats":
+		h.serveChats(w, r)
+	case "/api/messages":
+		h.serveMessages(w, r)
+	case "/api/search":
+		h.serveSearch(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *handler) serveAsset(w http.ResponseWriter, name, contentType string) {
+	body, err := assets.ReadFile(name)
+	if err != nil {
+		http.Error(w, "asset unavailable", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+func (h *handler) authorized(r *http.Request) bool {
+	const prefix = "Bearer "
+	header := r.Header.Get("Authorization")
+	if !strings.HasPrefix(header, prefix) {
+		return false
+	}
+	candidate := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+	if len(candidate) != len(h.token) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(candidate), []byte(h.token)) == 1
+}
+
+func (h *handler) serveStatus(w http.ResponseWriter, r *http.Request) {
+	status, err := h.store.Status(r.Context())
+	if err != nil {
+		writeArchiveError(w)
+		return
+	}
+	writeJSON(w, statusResponse{
+		Chats:          status.Chats,
+		UnreadChats:    status.UnreadChats,
+		UnreadMessages: status.UnreadMessages,
+		Contacts:       status.Contacts,
+		Groups:         status.Groups,
+		Messages:       status.Messages,
+		MediaMessages:  status.MediaMessages,
+		OldestMessage:  status.OldestMessage,
+		NewestMessage:  status.NewestMessage,
+		LastImportAt:   status.LastImportAt,
+	})
+}
+
+func (h *handler) serveChats(w http.ResponseWriter, r *http.Request) {
+	limit, ok := parseLimit(w, r, 100)
+	if !ok {
+		return
+	}
+	chats, err := h.store.ListChats(r.Context(), limit)
+	if err != nil {
+		writeArchiveError(w)
+		return
+	}
+	out := make([]chatResponse, 0, len(chats))
+	for _, chat := range chats {
+		out = append(out, chatResponse{
+			JID:           chat.JID,
+			Kind:          chat.Kind,
+			Name:          chat.Name,
+			LastMessageAt: chat.LastMessageAt,
+			UnreadCount:   chat.UnreadCount,
+			Archived:      chat.Archived,
+			MessageCount:  chat.MessageCount,
+		})
+	}
+	writeJSON(w, out)
+}
+
+func (h *handler) serveMessages(w http.ResponseWriter, r *http.Request) {
+	limit, ok := parseLimit(w, r, 100)
+	if !ok {
+		return
+	}
+	messages, err := h.store.Messages(r.Context(), store.MessageFilter{
+		ChatJID: strings.TrimSpace(r.URL.Query().Get("chat")),
+		Limit:   limit,
+	})
+	if err != nil {
+		writeArchiveError(w)
+		return
+	}
+	for left, right := 0, len(messages)-1; left < right; left, right = left+1, right-1 {
+		messages[left], messages[right] = messages[right], messages[left]
+	}
+	writeJSON(w, messagesForWeb(messages))
+}
+
+func (h *handler) serveSearch(w http.ResponseWriter, r *http.Request) {
+	query := strings.TrimSpace(r.URL.Query().Get("q"))
+	if query == "" {
+		http.Error(w, "search query required", http.StatusBadRequest)
+		return
+	}
+	limit, ok := parseLimit(w, r, 100)
+	if !ok {
+		return
+	}
+	messages, err := h.store.Search(r.Context(), store.MessageFilter{Query: query, Limit: limit})
+	if err != nil {
+		http.Error(w, "invalid search query", http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, messagesForWeb(messages))
+}
+
+func messagesForWeb(messages []store.Message) []messageResponse {
+	out := make([]messageResponse, 0, len(messages))
+	for _, message := range messages {
+		out = append(out, messageResponse{
+			ChatJID:     message.ChatJID,
+			ChatName:    message.ChatName,
+			MessageID:   message.MessageID,
+			SenderJID:   message.SenderJID,
+			SenderName:  message.SenderName,
+			Timestamp:   message.Timestamp,
+			FromMe:      message.FromMe,
+			Text:        message.Text,
+			MessageType: message.MessageType,
+			MediaType:   message.MediaType,
+			MediaTitle:  message.MediaTitle,
+			MediaSize:   message.MediaSize,
+			Starred:     message.Starred,
+			Snippet:     message.Snippet,
+		})
+	}
+	return out
+}
+
+func parseLimit(w http.ResponseWriter, r *http.Request, fallback int) (int, bool) {
+	raw := strings.TrimSpace(r.URL.Query().Get("limit"))
+	if raw == "" {
+		return fallback, true
+	}
+	limit, err := strconv.Atoi(raw)
+	if err != nil || limit < 1 || limit > 500 {
+		http.Error(w, "limit must be between 1 and 500", http.StatusBadRequest)
+		return 0, false
+	}
+	return limit, true
+}
+
+func randomToken() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("generate web viewer token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes), nil
+}
+
+func setSecurityHeaders(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' data:; connect-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'")
+	w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "DENY")
+}
+
+func writeJSON(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		writeArchiveError(w)
+	}
+}
+
+func writeArchiveError(w http.ResponseWriter) {
+	http.Error(w, "archive unavailable", http.StatusInternalServerError)
+}

--- a/internal/webui/server_test.go
+++ b/internal/webui/server_test.go
@@ -1,0 +1,292 @@
+package webui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/wacrawl/internal/store"
+)
+
+const (
+	testHost  = "127.0.0.1:43210"
+	testToken = "test-private-token"
+)
+
+func TestHandlerServesAuthenticatedArchiveViews(t *testing.T) {
+	handler := testHandler(t)
+
+	root := request(t, handler, "/", "")
+	if root.Code != http.StatusOK || !strings.Contains(root.Body.String(), "Your message") {
+		t.Fatalf("root status=%d body=%q", root.Code, root.Body.String())
+	}
+	if got := root.Header().Get("Content-Security-Policy"); !strings.Contains(got, "default-src 'none'") || !strings.Contains(got, "frame-ancestors 'none'") {
+		t.Fatalf("content security policy = %q", got)
+	}
+	if got := root.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("cache control = %q", got)
+	}
+
+	unauthorized := request(t, handler, "/api/status", "")
+	if unauthorized.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthorized status = %d", unauthorized.Code)
+	}
+
+	status := request(t, handler, "/api/status", testToken)
+	if status.Code != http.StatusOK || !strings.Contains(status.Body.String(), `"messages":2`) || strings.Contains(status.Body.String(), "db_path") {
+		t.Fatalf("status code=%d body=%s", status.Code, status.Body.String())
+	}
+
+	chats := request(t, handler, "/api/chats?limit=10", testToken)
+	if chats.Code != http.StatusOK || !strings.Contains(chats.Body.String(), `"name":"Launch Group"`) {
+		t.Fatalf("chats code=%d body=%s", chats.Code, chats.Body.String())
+	}
+
+	messages := request(t, handler, "/api/messages?chat=123%40g.us&limit=10", testToken)
+	if messages.Code != http.StatusOK || !strings.Contains(messages.Body.String(), `"text":"launch now"`) {
+		t.Fatalf("messages code=%d body=%s", messages.Code, messages.Body.String())
+	}
+	if strings.Contains(messages.Body.String(), "media_path") || strings.Contains(messages.Body.String(), "private.jpg") || strings.Contains(messages.Body.String(), "media_url") {
+		t.Fatalf("messages exposed private media location: %s", messages.Body.String())
+	}
+
+	search := request(t, handler, "/api/search?q=launch&limit=10", testToken)
+	if search.Code != http.StatusOK || !strings.Contains(search.Body.String(), `"message_id":"m1"`) {
+		t.Fatalf("search code=%d body=%s", search.Code, search.Body.String())
+	}
+	var results []map[string]any
+	if err := json.Unmarshal(search.Body.Bytes(), &results); err != nil || len(results) == 0 {
+		t.Fatalf("search json results=%#v err=%v", results, err)
+	}
+}
+
+func TestHandlerRejectsHostMethodsAndInvalidQueries(t *testing.T) {
+	handler := testHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "http://malicious.invalid/api/status", nil)
+	req.Host = "malicious.invalid"
+	req.Header.Set("Authorization", "Bearer "+testToken)
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	if response.Code != http.StatusMisdirectedRequest {
+		t.Fatalf("wrong host status = %d", response.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "http://"+testHost+"/api/status", nil)
+	req.Host = testHost
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	if response.Code != http.StatusMethodNotAllowed || response.Header().Get("Allow") != http.MethodGet {
+		t.Fatalf("post status=%d allow=%q", response.Code, response.Header().Get("Allow"))
+	}
+
+	invalidLimit := request(t, handler, "/api/chats?limit=501", testToken)
+	if invalidLimit.Code != http.StatusBadRequest {
+		t.Fatalf("invalid limit status = %d", invalidLimit.Code)
+	}
+
+	emptySearch := request(t, handler, "/api/search?q=", testToken)
+	if emptySearch.Code != http.StatusBadRequest {
+		t.Fatalf("empty search status = %d", emptySearch.Code)
+	}
+
+	notFound := request(t, handler, "/api/missing", testToken)
+	if notFound.Code != http.StatusNotFound {
+		t.Fatalf("api missing status = %d", notFound.Code)
+	}
+	notFound = request(t, handler, "/missing", "")
+	if notFound.Code != http.StatusNotFound {
+		t.Fatalf("static missing status = %d", notFound.Code)
+	}
+
+	wrongToken := request(t, handler, "/api/status", "test-private-tokem")
+	if wrongToken.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong token status = %d", wrongToken.Code)
+	}
+}
+
+func TestServeLifecycleAndPrivateURL(t *testing.T) {
+	archive := testArchive(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	output := &captureWriter{written: make(chan string, 1)}
+	result := make(chan error, 1)
+	go func() {
+		result <- Serve(ctx, archive, Config{Output: output})
+	}()
+
+	var printed string
+	select {
+	case printed = <-output.written:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not print its private URL")
+	}
+	var privateURL string
+	for _, field := range strings.Fields(printed) {
+		if strings.HasPrefix(field, "http://") {
+			privateURL = field
+			break
+		}
+	}
+	parsed, err := url.Parse(privateURL)
+	if err != nil || parsed.Host == "" || parsed.Fragment == "" {
+		t.Fatalf("private URL = %q parsed=%#v err=%v", privateURL, parsed, err)
+	}
+	if parsed.Hostname() != "127.0.0.1" {
+		t.Fatalf("viewer host = %q", parsed.Hostname())
+	}
+
+	rootURL := *parsed
+	rootURL.Fragment = ""
+	response, err := http.Get(rootURL.String()) // #nosec G107 -- test URL is a fresh loopback listener.
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("root status = %d", response.StatusCode)
+	}
+
+	apiURL := rootURL
+	apiURL.Path = "/api/status"
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiURL.String(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+parsed.Fragment)
+	response, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("api status = %d", response.StatusCode)
+	}
+
+	cancel()
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("Serve returned %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not stop after context cancellation")
+	}
+}
+
+func TestServeRejectsInvalidOrOccupiedPorts(t *testing.T) {
+	if err := Serve(context.Background(), nil, Config{Port: -1}); err == nil || !strings.Contains(err.Error(), "between 0 and 65535") {
+		t.Fatalf("invalid port error = %v", err)
+	}
+
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = listener.Close() }()
+	port := listener.Addr().(*net.TCPAddr).Port
+	err = Serve(context.Background(), nil, Config{Port: port})
+	if err == nil || !strings.Contains(err.Error(), "listen for web viewer") {
+		t.Fatalf("occupied port error = %v", err)
+	}
+}
+
+func TestHandlerArchiveAndAssetFailures(t *testing.T) {
+	archive := testArchive(t)
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	h := NewHandler(archive, testToken, testHost)
+	for _, path := range []string{"/api/status", "/api/chats", "/api/messages"} {
+		response := request(t, h, path, testToken)
+		if response.Code != http.StatusInternalServerError || !strings.Contains(response.Body.String(), "archive unavailable") {
+			t.Fatalf("%s status=%d body=%q", path, response.Code, response.Body.String())
+		}
+	}
+
+	response := httptest.NewRecorder()
+	(&handler{allowedHost: testHost}).serveAsset(response, "static/missing", "text/plain")
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("missing asset status = %d", response.Code)
+	}
+
+	failing := &failingResponseWriter{header: make(http.Header)}
+	writeJSON(failing, map[string]string{"ok": "yes"})
+	if failing.writes < 2 {
+		t.Fatalf("writeJSON failure writes = %d", failing.writes)
+	}
+}
+
+func testHandler(t *testing.T) http.Handler {
+	t.Helper()
+	return NewHandler(testArchive(t), testToken, testHost)
+}
+
+func testArchive(t *testing.T) *store.Store {
+	t.Helper()
+	ctx := context.Background()
+	archive, err := store.Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = archive.Close() })
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	err = archive.ReplaceAll(ctx, store.ImportStats{FinishedAt: now}, nil, []store.Chat{
+		{JID: "123@g.us", Kind: "group", Name: "Launch Group", LastMessageAt: now, UnreadCount: 1},
+	}, nil, nil, []store.Message{
+		{SourcePK: 1, ChatJID: "123@g.us", ChatName: "Launch Group", MessageID: "m1", SenderName: "Alice", Timestamp: now.Add(-time.Minute), Text: "launch now", MediaType: "image", MediaPath: "/private/media/private.jpg", MediaURL: "https://example.invalid/private.jpg"},
+		{SourcePK: 2, ChatJID: "123@g.us", ChatName: "Launch Group", MessageID: "m2", Timestamp: now, FromMe: true, Text: "ship later"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return archive
+}
+
+func request(t *testing.T, handler http.Handler, path, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "http://"+testHost+path, nil)
+	req.Host = testHost
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, req)
+	return response
+}
+
+type captureWriter struct {
+	written chan string
+}
+
+func (w *captureWriter) Write(body []byte) (int, error) {
+	select {
+	case w.written <- string(body):
+	default:
+	}
+	return len(body), nil
+}
+
+type failingResponseWriter struct {
+	header http.Header
+	writes int
+}
+
+func (w *failingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingResponseWriter) Write([]byte) (int, error) {
+	w.writes++
+	return 0, errors.New("write failed")
+}
+
+func (w *failingResponseWriter) WriteHeader(int) {}

--- a/internal/webui/static/app.css
+++ b/internal/webui/static/app.css
@@ -1,0 +1,768 @@
+:root {
+  --ink: #151813;
+  --paper: #eee9db;
+  --paper-deep: #ded7c5;
+  --acid: #b7f45a;
+  --forest: #18392f;
+  --forest-soft: #245246;
+  --rust: #b65336;
+  --line: rgba(238, 233, 219, 0.18);
+  --muted: rgba(238, 233, 219, 0.62);
+  --display: "Iowan Old Style", "Baskerville", "Times New Roman", serif;
+  --body: "Avenir Next", "Gill Sans", "Trebuchet MS", sans-serif;
+  --mono: "Berkeley Mono", "SFMono-Regular", Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+html {
+  min-width: 320px;
+  background: var(--ink);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--paper);
+  background:
+    radial-gradient(circle at 84% 8%, rgba(183, 244, 90, 0.12), transparent 27rem),
+    linear-gradient(140deg, #10130f 0%, #18201a 50%, #111a16 100%);
+  font-family: var(--body);
+  font-size: 15px;
+}
+
+body::before {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  pointer-events: none;
+  content: "";
+  opacity: 0.035;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 180 180' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.85'/%3E%3C/svg%3E");
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button,
+a {
+  -webkit-tap-highlight-color: transparent;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible {
+  outline: 2px solid var(--acid);
+  outline-offset: 3px;
+}
+
+.sr-only {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+.atmosphere {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 33vw;
+  height: 100vh;
+  pointer-events: none;
+  border-left: 1px solid rgba(183, 244, 90, 0.08);
+  background: repeating-linear-gradient(90deg, transparent 0 31px, rgba(183, 244, 90, 0.035) 32px);
+  transform: skewX(-9deg) translateX(8vw);
+  transform-origin: top;
+}
+
+.shell {
+  position: relative;
+  width: min(1500px, calc(100% - 48px));
+  margin: 0 auto;
+  padding-bottom: 32px;
+}
+
+.masthead {
+  display: grid;
+  grid-template-columns: minmax(190px, 0.8fr) minmax(300px, 1.5fr) minmax(150px, 0.8fr);
+  align-items: center;
+  gap: 28px;
+  min-height: 86px;
+  border-bottom: 1px solid var(--line);
+}
+
+.wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  color: var(--paper);
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-decoration: none;
+}
+
+.wordmark-mark {
+  display: grid;
+  width: 33px;
+  height: 33px;
+  place-items: center;
+  color: var(--ink);
+  background: var(--acid);
+  border-radius: 50%;
+  letter-spacing: -0.08em;
+}
+
+.search {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  height: 45px;
+  padding: 0 15px;
+  border: 1px solid var(--line);
+  background: rgba(238, 233, 219, 0.045);
+  transition: border-color 160ms ease, background 160ms ease;
+}
+
+.search:focus-within {
+  border-color: rgba(183, 244, 90, 0.72);
+  background: rgba(238, 233, 219, 0.075);
+}
+
+.search-glyph {
+  color: var(--acid);
+  font-size: 24px;
+  line-height: 1;
+  transform: rotate(-12deg);
+}
+
+.search input {
+  width: 100%;
+  color: var(--paper);
+  border: 0;
+  outline: 0;
+  background: transparent;
+}
+
+.search input::placeholder {
+  color: rgba(238, 233, 219, 0.45);
+}
+
+kbd {
+  padding: 3px 7px;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 10px;
+}
+
+.quiet-button,
+.text-button {
+  justify-self: end;
+  color: var(--paper);
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.quiet-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.quiet-button:hover,
+.text-button:hover {
+  color: var(--acid);
+}
+
+.refresh-mark {
+  font-size: 17px;
+  transition: transform 400ms ease;
+}
+
+.quiet-button:hover .refresh-mark {
+  transform: rotate(180deg);
+}
+
+.ledger {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: clamp(40px, 8vw, 130px);
+  align-items: end;
+  padding: clamp(58px, 8vw, 112px) 0 clamp(48px, 7vw, 88px);
+}
+
+.eyebrow {
+  margin: 0 0 15px;
+  color: var(--acid);
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+}
+
+.ledger h1 {
+  max-width: 760px;
+  margin: 0;
+  font-family: var(--display);
+  font-size: clamp(60px, 8.5vw, 128px);
+  font-weight: 400;
+  letter-spacing: -0.065em;
+  line-height: 0.78;
+}
+
+.ledger-range {
+  margin: 30px 0 0;
+  color: var(--muted);
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0;
+  margin: 0;
+  border-top: 1px solid var(--line);
+  border-left: 1px solid var(--line);
+}
+
+.metrics div {
+  min-height: 130px;
+  padding: 22px;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.metrics dt {
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.metrics dd {
+  margin: 28px 0 0;
+  font-family: var(--display);
+  font-size: clamp(34px, 4vw, 58px);
+  line-height: 0.8;
+}
+
+.metrics div:nth-child(1) {
+  color: var(--ink);
+  background: var(--acid);
+}
+
+.metrics div:nth-child(1) dt {
+  color: rgba(21, 24, 19, 0.6);
+}
+
+.workbench {
+  display: grid;
+  grid-template-columns: minmax(290px, 0.7fr) minmax(420px, 1.6fr);
+  min-height: 680px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  background: rgba(8, 12, 9, 0.5);
+  box-shadow: 0 42px 90px rgba(0, 0, 0, 0.28);
+}
+
+.chat-rail {
+  min-width: 0;
+  border-right: 1px solid var(--line);
+  background: rgba(238, 233, 219, 0.035);
+}
+
+.rail-heading,
+.panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  min-height: 118px;
+  padding: 27px 28px;
+  border-bottom: 1px solid var(--line);
+}
+
+.rail-heading h2,
+.panel-heading h2 {
+  margin: 0;
+  font-family: var(--display);
+  font-size: 30px;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+}
+
+.count-badge {
+  display: grid;
+  min-width: 34px;
+  height: 34px;
+  padding: 0 8px;
+  place-items: center;
+  color: var(--ink);
+  background: var(--paper);
+  border-radius: 50%;
+  font-family: var(--mono);
+  font-size: 10px;
+}
+
+.chat-list {
+  max-height: 690px;
+  overflow: auto;
+  scrollbar-color: var(--forest-soft) transparent;
+}
+
+.chat-row {
+  display: grid;
+  width: 100%;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  gap: 13px;
+  align-items: center;
+  padding: 18px 22px;
+  color: inherit;
+  border: 0;
+  border-bottom: 1px solid rgba(238, 233, 219, 0.09);
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition: background 160ms ease, padding-left 160ms ease;
+}
+
+.chat-row:hover {
+  padding-left: 27px;
+  background: rgba(183, 244, 90, 0.065);
+}
+
+.chat-row.active {
+  color: var(--ink);
+  background: var(--paper);
+}
+
+.avatar {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  color: var(--paper);
+  border: 1px solid rgba(238, 233, 219, 0.26);
+  border-radius: 50%;
+  font-family: var(--display);
+  font-size: 16px;
+  text-transform: uppercase;
+}
+
+.active .avatar {
+  color: var(--paper);
+  background: var(--forest);
+  border-color: var(--forest);
+}
+
+.chat-copy {
+  min-width: 0;
+}
+
+.chat-name,
+.chat-meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-name {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.chat-meta {
+  margin-top: 5px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.active .chat-meta {
+  color: rgba(21, 24, 19, 0.54);
+}
+
+.unread-dot {
+  min-width: 22px;
+  padding: 5px 6px;
+  color: var(--ink);
+  background: var(--acid);
+  border-radius: 99px;
+  font-family: var(--mono);
+  font-size: 9px;
+  text-align: center;
+}
+
+.active .unread-dot {
+  color: var(--paper);
+  background: var(--rust);
+}
+
+.message-panel {
+  min-width: 0;
+  background:
+    linear-gradient(rgba(238, 233, 219, 0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(238, 233, 219, 0.025) 1px, transparent 1px);
+  background-size: 32px 32px;
+}
+
+.panel-heading {
+  padding-right: 34px;
+  background: rgba(17, 24, 19, 0.86);
+}
+
+.panel-subtitle {
+  max-width: 620px;
+  margin: 8px 0 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.text-button {
+  padding: 8px 0;
+  border-bottom: 1px solid currentcolor;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.message-list {
+  display: flex;
+  max-height: 690px;
+  flex-direction: column;
+  gap: 13px;
+  overflow: auto;
+  padding: 28px clamp(24px, 4vw, 54px) 50px;
+  scrollbar-color: var(--forest-soft) transparent;
+}
+
+.message-card {
+  position: relative;
+  width: min(79%, 720px);
+  padding: 17px 20px 16px;
+  color: var(--ink);
+  background: var(--paper);
+  animation: note-in 260ms both;
+}
+
+.message-card::before {
+  position: absolute;
+  top: 0;
+  left: -5px;
+  width: 5px;
+  height: 100%;
+  content: "";
+  background: var(--acid);
+}
+
+.message-card.mine {
+  align-self: flex-end;
+  color: var(--paper);
+  background: var(--forest);
+}
+
+.message-card.mine::before {
+  right: -5px;
+  left: auto;
+  background: var(--rust);
+}
+
+.message-card.search-hit {
+  width: min(92%, 840px);
+}
+
+.message-card:nth-child(2n) {
+  animation-delay: 35ms;
+}
+
+.message-card:nth-child(3n) {
+  animation-delay: 70ms;
+}
+
+.message-card:nth-child(5n) {
+  animation-delay: 105ms;
+}
+
+.message-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  color: rgba(21, 24, 19, 0.56);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.mine .message-meta {
+  color: rgba(238, 233, 219, 0.55);
+}
+
+.message-body {
+  margin: 12px 0 0;
+  font-size: 15px;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.message-media {
+  display: inline-flex;
+  margin-top: 13px;
+  padding: 5px 8px;
+  gap: 6px;
+  color: var(--forest);
+  border: 1px solid rgba(24, 57, 47, 0.25);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mine .message-media {
+  color: var(--acid);
+  border-color: rgba(183, 244, 90, 0.3);
+}
+
+.empty-state,
+.loading-state {
+  display: grid;
+  min-height: 360px;
+  place-items: center;
+  align-content: center;
+  gap: 15px;
+  color: var(--muted);
+  font-family: var(--display);
+  font-size: 22px;
+  text-align: center;
+}
+
+.empty-state span,
+.loading-state span {
+  color: var(--acid);
+  font-size: 54px;
+  animation: slow-turn 5s linear infinite;
+}
+
+.empty-state p,
+.loading-state p {
+  margin: 0;
+}
+
+footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px 2px 0;
+  color: rgba(238, 233, 219, 0.38);
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.locked {
+  width: min(650px, calc(100% - 48px));
+  margin: 18vh auto 0;
+  padding: clamp(30px, 6vw, 70px);
+  color: var(--ink);
+  background: var(--paper);
+  box-shadow: 18px 18px 0 var(--acid);
+}
+
+.locked .eyebrow {
+  color: var(--rust);
+}
+
+.locked h1 {
+  margin: 0;
+  font-family: var(--display);
+  font-size: clamp(44px, 7vw, 80px);
+  font-weight: 400;
+  letter-spacing: -0.05em;
+  line-height: 0.92;
+}
+
+.locked p:last-child {
+  max-width: 480px;
+  margin: 30px 0 0;
+  line-height: 1.6;
+}
+
+.locked code {
+  font-family: var(--mono);
+  font-size: 0.9em;
+}
+
+.toast {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 20;
+  max-width: min(430px, calc(100% - 48px));
+  padding: 14px 18px;
+  color: var(--ink);
+  background: var(--acid);
+  box-shadow: 8px 8px 0 rgba(0, 0, 0, 0.25);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+@keyframes note-in {
+  from {
+    opacity: 0;
+    transform: translateY(9px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slow-turn {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 900px) {
+  .shell {
+    width: min(100% - 28px, 760px);
+  }
+
+  .masthead {
+    grid-template-columns: 1fr auto;
+  }
+
+  .search {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    margin-bottom: 18px;
+  }
+
+  .ledger {
+    grid-template-columns: 1fr;
+  }
+
+  .ledger h1 {
+    font-size: clamp(58px, 15vw, 105px);
+  }
+
+  .workbench {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-rail {
+    border-right: 0;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .chat-list {
+    display: flex;
+    max-height: none;
+    overflow-x: auto;
+  }
+
+  .chat-row {
+    min-width: 280px;
+    border-right: 1px solid var(--line);
+  }
+
+  .message-list {
+    min-height: 560px;
+  }
+}
+
+@media (max-width: 560px) {
+  .shell {
+    width: min(100% - 20px, 520px);
+  }
+
+  .masthead {
+    gap: 12px;
+  }
+
+  .quiet-button {
+    font-size: 0;
+  }
+
+  .quiet-button .refresh-mark {
+    font-size: 20px;
+  }
+
+  .ledger {
+    padding-top: 52px;
+  }
+
+  .metrics div {
+    min-height: 105px;
+    padding: 17px;
+  }
+
+  .metrics dd {
+    margin-top: 23px;
+  }
+
+  .rail-heading,
+  .panel-heading {
+    padding: 23px 20px;
+  }
+
+  .panel-heading {
+    min-height: 135px;
+  }
+
+  .message-list {
+    padding: 22px 18px 40px;
+  }
+
+  .message-card,
+  .message-card.search-hit {
+    width: 94%;
+  }
+
+  footer {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/internal/webui/static/app.js
+++ b/internal/webui/static/app.js
@@ -1,0 +1,318 @@
+(() => {
+  "use strict";
+
+  const hashToken = window.location.hash.startsWith("#") ? window.location.hash.slice(1) : "";
+  if (hashToken) {
+    window.history.replaceState(null, "", window.location.pathname);
+  }
+  const token = hashToken;
+
+  const locked = document.querySelector("#locked");
+  const app = document.querySelector("#app");
+  if (!token) {
+    locked.hidden = false;
+    return;
+  }
+  app.hidden = false;
+
+  const elements = {
+    archiveRange: document.querySelector("#archive-range"),
+    chatCount: document.querySelector("#chat-count"),
+    chatList: document.querySelector("#chat-list"),
+    clearSearch: document.querySelector("#clear-search"),
+    messageList: document.querySelector("#message-list"),
+    messagePanel: document.querySelector(".message-panel"),
+    metrics: document.querySelector("#metrics"),
+    panelKicker: document.querySelector("#panel-kicker"),
+    panelSubtitle: document.querySelector("#panel-subtitle"),
+    panelTitle: document.querySelector("#panel-title"),
+    refresh: document.querySelector("#refresh-button"),
+    searchForm: document.querySelector("#search-form"),
+    searchInput: document.querySelector("#search-input"),
+    syncNote: document.querySelector("#sync-note"),
+    toast: document.querySelector("#toast"),
+  };
+
+  const state = {
+    chats: [],
+    selectedChat: "",
+    searching: false,
+  };
+
+  async function api(path) {
+    const response = await window.fetch(path, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    });
+    if (response.status === 401) {
+      throw new Error("The private viewer key expired. Restart wacrawl web.");
+    }
+    if (!response.ok) {
+      const detail = (await response.text()).trim();
+      throw new Error(detail || `Request failed (${response.status})`);
+    }
+    return response.json();
+  }
+
+  function formatCount(value) {
+    return new Intl.NumberFormat().format(Number(value || 0));
+  }
+
+  function formatDay(value) {
+    if (!value || value.startsWith("0001-")) return "No date";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "No date";
+    return new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+      year: date.getFullYear() === new Date().getFullYear() ? undefined : "numeric",
+    }).format(date);
+  }
+
+  function formatTime(value) {
+    if (!value || value.startsWith("0001-")) return "Unknown time";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "Unknown time";
+    return new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    }).format(date);
+  }
+
+  function initials(value) {
+    const words = (value || "?").trim().split(/\s+/).filter(Boolean);
+    return words.slice(0, 2).map((word) => word[0]).join("") || "?";
+  }
+
+  function chatName(chat) {
+    return chat.name || chat.jid || "Untitled chat";
+  }
+
+  function showToast(message) {
+    elements.toast.textContent = message;
+    elements.toast.hidden = false;
+    window.clearTimeout(showToast.timer);
+    showToast.timer = window.setTimeout(() => {
+      elements.toast.hidden = true;
+    }, 4800);
+  }
+
+  function clear(node) {
+    node.replaceChildren();
+  }
+
+  function renderStatus(status) {
+    const values = [status.messages, status.chats, status.contacts, status.media_messages];
+    elements.metrics.querySelectorAll("dd").forEach((node, index) => {
+      node.textContent = formatCount(values[index]);
+    });
+    elements.archiveRange.textContent = status.messages
+      ? `${formatDay(status.oldest_message)} — ${formatDay(status.newest_message)}`
+      : "Archive is ready for its first sync.";
+    elements.syncNote.textContent = status.last_import_at && !status.last_import_at.startsWith("0001-")
+      ? `Archive snapshot · ${formatTime(status.last_import_at)}`
+      : "Archive snapshot · not imported yet";
+  }
+
+  function renderChats(chats) {
+    clear(elements.chatList);
+    elements.chatCount.textContent = formatCount(chats.length);
+    if (!chats.length) {
+      const empty = document.createElement("div");
+      empty.className = "empty-state";
+      const text = document.createElement("p");
+      text.textContent = "No chats in this archive.";
+      empty.append(text);
+      elements.chatList.append(empty);
+      return;
+    }
+
+    chats.forEach((chat) => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "chat-row";
+      button.dataset.jid = chat.jid;
+      button.title = chatName(chat);
+      if (chat.jid === state.selectedChat && !state.searching) button.classList.add("active");
+
+      const avatar = document.createElement("span");
+      avatar.className = "avatar";
+      avatar.textContent = initials(chatName(chat));
+
+      const copy = document.createElement("span");
+      copy.className = "chat-copy";
+      const name = document.createElement("span");
+      name.className = "chat-name";
+      name.textContent = chatName(chat);
+      const meta = document.createElement("span");
+      meta.className = "chat-meta";
+      meta.textContent = `${chat.kind || "chat"} · ${formatCount(chat.message_count)} notes · ${formatDay(chat.last_message_at)}`;
+      copy.append(name, meta);
+
+      button.append(avatar, copy);
+      if (chat.unread_count > 0) {
+        const unread = document.createElement("span");
+        unread.className = "unread-dot";
+        unread.textContent = formatCount(chat.unread_count);
+        unread.setAttribute("aria-label", `${chat.unread_count} unread`);
+        button.append(unread);
+      }
+      button.addEventListener("click", () => selectChat(chat));
+      elements.chatList.append(button);
+    });
+  }
+
+  function renderLoading(label) {
+    clear(elements.messageList);
+    const loading = document.createElement("div");
+    loading.className = "loading-state";
+    const mark = document.createElement("span");
+    mark.setAttribute("aria-hidden", "true");
+    mark.textContent = "◌";
+    const text = document.createElement("p");
+    text.textContent = label;
+    loading.append(mark, text);
+    elements.messageList.append(loading);
+  }
+
+  function renderMessages(messages, searchMode = false) {
+    clear(elements.messageList);
+    if (!messages.length) {
+      const empty = document.createElement("div");
+      empty.className = "empty-state";
+      const mark = document.createElement("span");
+      mark.setAttribute("aria-hidden", "true");
+      mark.textContent = "◎";
+      const text = document.createElement("p");
+      text.textContent = searchMode ? "No matching field notes." : "No messages in this thread.";
+      empty.append(mark, text);
+      elements.messageList.append(empty);
+      return;
+    }
+
+    messages.forEach((message) => {
+      const card = document.createElement("article");
+      card.className = "message-card";
+      if (message.from_me) card.classList.add("mine");
+      if (searchMode) card.classList.add("search-hit");
+      const meta = document.createElement("div");
+      meta.className = "message-meta";
+      const sender = document.createElement("span");
+      sender.textContent = message.from_me
+        ? "You"
+        : (message.sender_name || message.sender_jid || "Unknown sender");
+      const time = document.createElement("time");
+      time.dateTime = message.timestamp || "";
+      time.textContent = formatTime(message.timestamp);
+      meta.append(sender, time);
+
+      const body = document.createElement("p");
+      body.className = "message-body";
+      body.textContent = message.text || message.snippet || message.media_title || "No text content";
+      card.append(meta, body);
+
+      if (message.media_type || message.media_title) {
+        const media = document.createElement("span");
+        media.className = "message-media";
+        media.textContent = `Attachment · ${message.media_type || message.media_title}`;
+        card.append(media);
+      }
+      if (searchMode && message.chat_name) {
+        const thread = document.createElement("span");
+        thread.className = "message-media";
+        thread.textContent = `Thread · ${message.chat_name}`;
+        card.append(thread);
+      }
+      elements.messageList.append(card);
+    });
+    elements.messageList.scrollTop = searchMode ? 0 : elements.messageList.scrollHeight;
+  }
+
+  async function selectChat(chat) {
+    state.searching = false;
+    state.selectedChat = chat.jid;
+    elements.clearSearch.hidden = true;
+    elements.panelKicker.textContent = chat.kind === "group" ? "GROUP THREAD" : "DIRECT THREAD";
+    elements.panelTitle.textContent = chatName(chat);
+    elements.panelSubtitle.textContent = `${chat.jid} · ${formatCount(chat.message_count)} archived messages`;
+    renderChats(state.chats);
+    renderLoading("Reading thread…");
+    elements.messagePanel.setAttribute("aria-busy", "true");
+    try {
+      const messages = await api(`/api/messages?chat=${encodeURIComponent(chat.jid)}&limit=150`);
+      renderMessages(messages);
+    } catch (error) {
+      showToast(error.message);
+      renderMessages([]);
+    } finally {
+      elements.messagePanel.setAttribute("aria-busy", "false");
+    }
+  }
+
+  async function runSearch(query) {
+    state.searching = true;
+    elements.clearSearch.hidden = false;
+    elements.panelKicker.textContent = "FULL-TEXT SEARCH";
+    elements.panelTitle.textContent = `“${query}”`;
+    elements.panelSubtitle.textContent = "Matches across message text, chats, senders, and media titles.";
+    renderChats(state.chats);
+    renderLoading("Searching field notes…");
+    elements.messagePanel.setAttribute("aria-busy", "true");
+    try {
+      const messages = await api(`/api/search?q=${encodeURIComponent(query)}&limit=150`);
+      elements.panelSubtitle.textContent = `${formatCount(messages.length)} matches across the local archive.`;
+      renderMessages(messages, true);
+    } catch (error) {
+      showToast(error.message);
+      renderMessages([], true);
+    } finally {
+      elements.messagePanel.setAttribute("aria-busy", "false");
+    }
+  }
+
+  async function load() {
+    elements.refresh.disabled = true;
+    try {
+      const [status, chats] = await Promise.all([api("/api/status"), api("/api/chats?limit=200")]);
+      renderStatus(status);
+      state.chats = chats;
+      renderChats(chats);
+      if (state.searching) {
+        const query = elements.searchInput.value.trim();
+        if (query) await runSearch(query);
+      } else if (state.selectedChat) {
+        const current = chats.find((chat) => chat.jid === state.selectedChat);
+        if (current) await selectChat(current);
+      } else if (chats[0]) {
+        await selectChat(chats[0]);
+      }
+    } catch (error) {
+      showToast(error.message);
+    } finally {
+      elements.refresh.disabled = false;
+    }
+  }
+
+  elements.searchForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const query = elements.searchInput.value.trim();
+    if (!query) {
+      showToast("Enter a search term first.");
+      return;
+    }
+    runSearch(query);
+  });
+
+  elements.clearSearch.addEventListener("click", () => {
+    elements.searchInput.value = "";
+    state.searching = false;
+    elements.clearSearch.hidden = true;
+    const chat = state.chats.find((item) => item.jid === state.selectedChat) || state.chats[0];
+    if (chat) selectChat(chat);
+  });
+
+  elements.refresh.addEventListener("click", () => load());
+  load();
+})();

--- a/internal/webui/static/index.html
+++ b/internal/webui/static/index.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark">
+    <title>wacrawl — local archive</title>
+    <link rel="stylesheet" href="/app.css">
+  </head>
+  <body>
+    <div class="atmosphere" aria-hidden="true"></div>
+
+    <section class="locked" id="locked" hidden>
+      <p class="eyebrow">LOCAL ARCHIVE / ACCESS REQUIRED</p>
+      <h1>This window has no archive key.</h1>
+      <p>Open the private URL printed by <code>wacrawl web</code>. Restart the command if the URL is no longer available.</p>
+    </section>
+
+    <main class="shell" id="app" hidden>
+      <header class="masthead">
+        <a class="wordmark" href="#" aria-label="wacrawl home">
+          <span class="wordmark-mark" aria-hidden="true">W/</span>
+          <span>WACRAWL</span>
+        </a>
+        <form class="search" id="search-form" role="search">
+          <label class="sr-only" for="search-input">Search messages</label>
+          <span class="search-glyph" aria-hidden="true">⌕</span>
+          <input id="search-input" name="q" type="search" autocomplete="off" placeholder="Search the archive">
+          <kbd>↵</kbd>
+        </form>
+        <button class="quiet-button" id="refresh-button" type="button">
+          <span class="refresh-mark" aria-hidden="true">↻</span>
+          Refresh view
+        </button>
+      </header>
+
+      <section class="ledger" aria-label="Archive status">
+        <div class="ledger-heading">
+          <p class="eyebrow">PRIVATE / READ-ONLY / LOOPBACK</p>
+          <h1>Your message<br>field notes.</h1>
+          <p class="ledger-range" id="archive-range">Reading archive…</p>
+        </div>
+        <dl class="metrics" id="metrics">
+          <div><dt>Messages</dt><dd>—</dd></div>
+          <div><dt>Chats</dt><dd>—</dd></div>
+          <div><dt>Contacts</dt><dd>—</dd></div>
+          <div><dt>Media refs</dt><dd>—</dd></div>
+        </dl>
+      </section>
+
+      <section class="workbench">
+        <aside class="chat-rail" aria-label="Chats">
+          <div class="rail-heading">
+            <div>
+              <p class="eyebrow">INDEX 01</p>
+              <h2>Recent chats</h2>
+            </div>
+            <span class="count-badge" id="chat-count">0</span>
+          </div>
+          <div class="chat-list" id="chat-list"></div>
+        </aside>
+
+        <section class="message-panel" aria-live="polite" aria-busy="true">
+          <div class="panel-heading">
+            <div>
+              <p class="eyebrow" id="panel-kicker">ARCHIVE THREAD</p>
+              <h2 id="panel-title">Select a chat</h2>
+              <p class="panel-subtitle" id="panel-subtitle">Messages remain on this machine.</p>
+            </div>
+            <button class="text-button" id="clear-search" type="button" hidden>Back to chats</button>
+          </div>
+          <div class="message-list" id="message-list">
+            <div class="empty-state">
+              <span aria-hidden="true">◎</span>
+              <p>Choose a thread from the index.</p>
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <footer>
+        <span id="sync-note">Archive snapshot</span>
+        <span>Served by wacrawl · no cloud · no writes</span>
+      </footer>
+    </main>
+
+    <div class="toast" id="toast" role="status" aria-live="polite" hidden></div>
+    <script src="/app.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- add `wacrawl web`, an embedded no-dependency archive viewer for status, chats, messages, and full-text search
- preserve the local-inspection boundary: IPv4 loopback only, read-only APIs, no media files or paths, no configuration, scheduling, or write controls
- protect every archive API with a random 256-bit per-run bearer key delivered in the URL fragment, plus strict Host validation and browser security headers
- document the command and its deliberate scope

Closes #10.

## Security

- binds only to `127.0.0.1`; no configurable public listen address
- rejects unexpected Host headers to prevent DNS rebinding
- removes the fragment key from the address bar and keeps it only in page memory
- sends no database path, media path, or media URL through the viewer APIs
- applies CSP, no-store, frame denial, same-origin resource policy, and no-referrer headers

## Proof

- `make check` — lint clean, aggregate coverage 85.5%, built binary
- `go test -count=1 -race ./...`
- `node --check internal/webui/static/app.js`
- built-binary synthetic archive proof: root 200; authenticated status/chats/messages/search 200; unauthenticated API 401; hostile Host 421; listener verified on `127.0.0.1`; private-path redaction PASS
- autoreview (Codex `gpt-5.5`): clean, no accepted/actionable findings
- exact-head CI at `9a98debf06e63c3e1d9ab52592c600d7edbe5cbb`: lint, test, dependency review, release check, and secret scan all green
- `govulncheck ./...`: no known vulnerabilities
- existing-profile Chrome proof at 1440×1000: rendered layout is readable without horizontal overflow; address fragment cleared; local/session storage empty; zero console warnings/errors
- rendered interactions: switched from Design Lab to Weekend Crew, then searched `lantern` and received the single expected cross-chat result; every viewer document, asset, and API request returned 200
- visual verification through Peekaboo at 1680×1103: desktop hierarchy, chat/message columns, badges, message cards, and search controls render without clipping; no media elements served
