### PR TITLE
fix: ignore stale web viewer responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add a private loopback-only web viewer for archive status, chats, messages, and search, with per-run access keys and no media/configuration/write surface (#10, thanks @greenido).
 
+### Fixed
+
+- Prevent slower web viewer responses from replacing the active chat or search results.
+
 ## [0.3.0] - 2026-06-19
 
 ### Added

--- a/internal/webui/static/app.js
+++ b/internal/webui/static/app.js
@@ -37,6 +37,7 @@
     chats: [],
     selectedChat: "",
     searching: false,
+    viewRequest: 0,
   };
 
   async function api(path) {
@@ -231,6 +232,7 @@
   }
 
   async function selectChat(chat) {
+    const request = ++state.viewRequest;
     state.searching = false;
     state.selectedChat = chat.jid;
     elements.clearSearch.hidden = true;
@@ -242,16 +244,21 @@
     elements.messagePanel.setAttribute("aria-busy", "true");
     try {
       const messages = await api(`/api/messages?chat=${encodeURIComponent(chat.jid)}&limit=150`);
+      if (request !== state.viewRequest) return;
       renderMessages(messages);
     } catch (error) {
+      if (request !== state.viewRequest) return;
       showToast(error.message);
       renderMessages([]);
     } finally {
-      elements.messagePanel.setAttribute("aria-busy", "false");
+      if (request === state.viewRequest) {
+        elements.messagePanel.setAttribute("aria-busy", "false");
+      }
     }
   }
 
   async function runSearch(query) {
+    const request = ++state.viewRequest;
     state.searching = true;
     elements.clearSearch.hidden = false;
     elements.panelKicker.textContent = "FULL-TEXT SEARCH";
@@ -262,20 +269,27 @@
     elements.messagePanel.setAttribute("aria-busy", "true");
     try {
       const messages = await api(`/api/search?q=${encodeURIComponent(query)}&limit=150`);
+      if (request !== state.viewRequest) return;
       elements.panelSubtitle.textContent = `${formatCount(messages.length)} matches across the local archive.`;
       renderMessages(messages, true);
     } catch (error) {
+      if (request !== state.viewRequest) return;
       showToast(error.message);
       renderMessages([], true);
     } finally {
-      elements.messagePanel.setAttribute("aria-busy", "false");
+      if (request === state.viewRequest) {
+        elements.messagePanel.setAttribute("aria-busy", "false");
+      }
     }
   }
 
   async function load() {
+    const request = ++state.viewRequest;
     elements.refresh.disabled = true;
+    elements.messagePanel.setAttribute("aria-busy", "true");
     try {
       const [status, chats] = await Promise.all([api("/api/status"), api("/api/chats?limit=200")]);
+      if (request !== state.viewRequest) return;
       renderStatus(status);
       state.chats = chats;
       renderChats(chats);
@@ -289,9 +303,13 @@
         await selectChat(chats[0]);
       }
     } catch (error) {
+      if (request !== state.viewRequest) return;
       showToast(error.message);
     } finally {
       elements.refresh.disabled = false;
+      if (request === state.viewRequest) {
+        elements.messagePanel.setAttribute("aria-busy", "false");
+      }
     }
   }
 

--- a/internal/webui/static/app.js
+++ b/internal/webui/static/app.js
@@ -283,6 +283,18 @@
     }
   }
 
+  async function reloadCurrentView(chats) {
+    if (state.searching) {
+      const query = elements.searchInput.value.trim();
+      if (query) {
+        await runSearch(query);
+        return;
+      }
+    }
+    const chat = chats.find((item) => item.jid === state.selectedChat) || chats[0];
+    if (chat) await selectChat(chat);
+  }
+
   async function load() {
     const request = ++state.viewRequest;
     elements.refresh.disabled = true;
@@ -293,18 +305,11 @@
       renderStatus(status);
       state.chats = chats;
       renderChats(chats);
-      if (state.searching) {
-        const query = elements.searchInput.value.trim();
-        if (query) await runSearch(query);
-      } else if (state.selectedChat) {
-        const current = chats.find((chat) => chat.jid === state.selectedChat);
-        if (current) await selectChat(current);
-      } else if (chats[0]) {
-        await selectChat(chats[0]);
-      }
+      await reloadCurrentView(chats);
     } catch (error) {
       if (request !== state.viewRequest) return;
       showToast(error.message);
+      await reloadCurrentView(state.chats);
     } finally {
       elements.refresh.disabled = false;
       if (request === state.viewRequest) {


### PR DESCRIPTION
## Summary

- ignore async chat/search responses once a newer view request owns the message panel
- invalidate an in-flight view immediately when Refresh starts, while allowing later user interaction to supersede Refresh
- keep stale success, error, and completion paths from replacing content, showing irrelevant errors, or clearing the current loading state

Follow-up to https://github.com/openclaw/wacrawl/pull/26#discussion_r3503852423.

## Root cause

Chat, search, and refresh requests rendered unconditionally after `await`. A slower earlier request could therefore finish last and replace the currently selected thread or search results.

## Proof

- deterministic controlled-promise harness: stale chat→chat, chat→search, chat→refresh, and failed-refresh responses all ignored/recovered; newest response owns final content and `aria-busy`
- `make check` — lint clean; aggregate coverage 85.5%; binary built
- `go test -count=1 -race ./...`
- focused `go test -count=1 ./internal/webui ./internal/cli`
- `node --check internal/webui/static/app.js`
- `govulncheck ./...` — no vulnerabilities
- final built-binary synthetic archive: embedded `app.js` byte-identical to source; root/app/API 200; unauthenticated API 401; hostile Host 421; IPv4 loopback listener; search and private-path redaction PASS
- autoreview (Codex `gpt-5.5`): accepted the refresh race, then the PR review's failed-refresh edge; both fixed, with the final run clean and no accepted/actionable findings

No real WhatsApp archive or private content was used or uploaded.
