### PR TITLE
fix: preserve viewer content on refresh errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Prevent slower web viewer responses from replacing the active chat or search results.
+- Prevent stale web viewer responses from replacing active content, and preserve the current view when refresh metadata is temporarily unavailable.
 
 ## [0.3.0] - 2026-06-19
 

--- a/internal/webui/static/app.js
+++ b/internal/webui/static/app.js
@@ -297,6 +297,7 @@
 
   async function load() {
     const request = ++state.viewRequest;
+    const interruptedLoadingView = elements.messagePanel.getAttribute("aria-busy") === "true";
     elements.refresh.disabled = true;
     elements.messagePanel.setAttribute("aria-busy", "true");
     try {
@@ -309,7 +310,7 @@
     } catch (error) {
       if (request !== state.viewRequest) return;
       showToast(error.message);
-      await reloadCurrentView(state.chats);
+      if (interruptedLoadingView) await reloadCurrentView(state.chats);
     } finally {
       elements.refresh.disabled = false;
       if (request === state.viewRequest) {


### PR DESCRIPTION
## Summary

- preserve already-rendered chat or search content when refresh metadata fails
- retry the active view only when refresh interrupted an in-flight loading placeholder
- clarify the unreleased changelog entry for both stale-response and refresh-failure behavior

Follow-up to https://github.com/openclaw/wacrawl/pull/28#discussion_r3504539987.

## Proof

- `make coverage build` (85.5%)
- `golangci-lint run ./...`
- `go test -race ./...`
- `node --check internal/webui/static/app.js`
- deterministic fake-DOM race harness: stale chat, chat-to-search, successful refresh, failed loading refresh, and failed rendered refresh all pass
- `go run golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./...` (no vulnerabilities)
- `actionlint`
- `goreleaser release --snapshot --clean --skip=publish` (six archives)
- disposable synthetic archive: root/API 200, unauthenticated API 401, hostile Host 421, loopback-only listener, byte-identical embedded app asset, status/chat/message/search/redaction assertions pass

No real WhatsApp content was read or included in test artifacts.
