### PR TITLE
docs: credit atomic backup config fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Save backup configuration atomically with owner-only permissions to protect existing settings from interrupted writes (#25, thanks @TurboTheTurtle).
 - Prevent stale web viewer responses from replacing active content, and preserve the current view when refresh metadata is temporarily unavailable.
 
 ## [0.3.0] - 2026-06-19


### PR DESCRIPTION
## Summary

- add the missing 0.3.1 release-note entry for https://github.com/openclaw/wacrawl/pull/25
- credit contributor @TurboTheTurtle
- record both atomic replacement and owner-only backup-config permissions

## Proof

- reviewed the full PR #25 discussion and merged diff
- `git diff --check`
- changelog bullet follows the existing one-line style

Documentation-only release closeout; no product code changes.
