### PR TITLE
docs: credit archive hardening fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Harden archive reads and restores for URI-sensitive paths, no-media backups, and alternate WhatsApp media relationships (thanks @vincentkoc).
 - Save backup configuration atomically with owner-only permissions to protect existing settings from interrupted writes (#25, thanks @TurboTheTurtle).
 - Prevent stale web viewer responses from replacing active content, and preserve the current view when refresh metadata is temporarily unavailable.
 


### PR DESCRIPTION
## Summary

- add the missing 0.3.1 release-note entry for https://github.com/openclaw/wacrawl/commit/005753e92997b052076b520532ac6e1a198a9bef
- cover the user-visible archive path, no-media restore, and alternate media-link fixes
- credit @vincentkoc

## Proof

- reviewed the complete post-v0.3.0 commit diff
- `git diff --check`
- changelog bullet follows the existing one-line style

Documentation-only release closeout; no product code changes.
