### PR TITLE
fix: checkout release tags for manual reruns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Checkout release tag
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: git checkout -- "$RELEASE_TAG"
+        run: git checkout --detach "$RELEASE_TAG"
 
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3


### PR DESCRIPTION
## Summary

Fix manual release workflow reruns so the validated release tag is checked out as a Git ref. The prior `git checkout -- "$RELEASE_TAG"` used pathspec mode and failed because no file named after the tag exists.

No release, tag, version bump, or publish action is performed by this PR.

## Proof

- `actionlint .github/workflows/release.yml`
- `git rev-parse 'v0.3.0^{commit}'` resolves the latest release tag to `343bb9c96f787784a7fd1f8cd2b674c4922097dd`
- Codex autoreview: clean; no accepted/actionable findings

No changelog entry: release-infrastructure fix only; product behavior is unchanged.
