### PR TITLE
fix: qualify manual release tag checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Checkout release tag
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: git checkout --detach "$RELEASE_TAG"
+        run: git checkout --detach "refs/tags/$RELEASE_TAG"
 
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3


### PR DESCRIPTION
## Summary

- follow up the actionable review on https://github.com/openclaw/wacrawl/pull/33#discussion_r3506223995
- detach the fully qualified validated tag ref during manual release reruns
- prevent a same-named local branch from redirecting GoReleaser to the wrong commit

No release, tag, version bump, or publish action is performed by this PR.

## Root cause

The workflow verifies `refs/tags/$RELEASE_TAG^{commit}` but previously checked out the ambiguous short name. Git prefers a same-named local branch and only warns, so a manual rerun could publish artifacts from the branch commit instead of the validated tag.

## Proof

- `actionlint .github/workflows/release.yml`
- synthetic branch/tag collision: short checkout selected the branch commit; `refs/tags/v1.2.3` selected the tag commit
- `make check` — lint clean, coverage 85.5%, build passed
- `go test -count=1 -race ./...`
- `go mod verify`
- `go run golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./...` — no vulnerabilities
- `./bin/wacrawl doctor`
- `./bin/wacrawl --sync never status`
- Codex autoreview — clean; no accepted/actionable findings

No changelog entry: release-infrastructure correction only; product behavior is unchanged.