### PR TITLE
fix(cli): report source install version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.3.3] - Unreleased
 
+### Fixed
+
+- Report the module version for source-installed binaries instead of a stale hard-coded release fallback.
+
 ## [0.3.2] - 2026-07-09
 
 ### Changed

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -65,7 +65,7 @@ func Run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		return usageErr(err)
 	}
 	if *versionFlag {
-		_, _ = io.WriteString(stdout, version+"\n")
+		_, _ = io.WriteString(stdout, currentVersion()+"\n")
 		return nil
 	}
 	syncMode, err := parseArchiveSyncMode(*syncFlag)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -32,7 +32,7 @@ func TestRunEndToEnd(t *testing.T) {
 		want string
 	}{
 		{"help", []string{"--db", dbPath, "help"}, "wacrawl reads local WhatsApp"},
-		{"version", []string{"--version"}, version},
+		{"version", []string{"--version"}, currentVersion()},
 		{"metadata", []string{"--json", "metadata"}, `"id": "wacrawl"`},
 		{"doctor", []string{"--db", dbPath, "--source", source, "doctor"}, "message_rows"},
 		{"import", []string{"--db", dbPath, "--source", source, "import"}, "messages=3"},

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -1,3 +1,26 @@
 package cli
 
-var version = "0.3.1"
+import (
+	"runtime/debug"
+	"strings"
+)
+
+var version string
+
+func currentVersion() string {
+	moduleVersion := ""
+	if info, ok := debug.ReadBuildInfo(); ok {
+		moduleVersion = info.Main.Version
+	}
+	return resolveVersion(version, moduleVersion)
+}
+
+func resolveVersion(linkerVersion, moduleVersion string) string {
+	if linkerVersion = strings.TrimSpace(linkerVersion); linkerVersion != "" {
+		return strings.TrimPrefix(linkerVersion, "v")
+	}
+	if moduleVersion = strings.TrimSpace(moduleVersion); moduleVersion != "" && moduleVersion != "(devel)" {
+		return strings.TrimPrefix(moduleVersion, "v")
+	}
+	return "devel"
+}

--- a/internal/cli/version_test.go
+++ b/internal/cli/version_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import "testing"
+
+func TestResolveVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		linkerVersion string
+		moduleVersion string
+		want          string
+	}{
+		{name: "release linker override", linkerVersion: "0.4.0", moduleVersion: "v0.3.3", want: "0.4.0"},
+		{name: "release linker override with prefix", linkerVersion: "v0.4.0", moduleVersion: "v0.3.3", want: "0.4.0"},
+		{name: "installed tagged module", moduleVersion: "v0.3.3", want: "0.3.3"},
+		{name: "installed pseudo-version", moduleVersion: "v0.3.3-0.20260716120000-deadbeefcafe", want: "0.3.3-0.20260716120000-deadbeefcafe"},
+		{name: "local build", moduleVersion: "(devel)", want: "devel"},
+		{name: "missing build info", want: "devel"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveVersion(tc.linkerVersion, tc.moduleVersion); got != tc.want {
+				t.Fatalf("resolveVersion(%q, %q) = %q, want %q", tc.linkerVersion, tc.moduleVersion, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- prefer the release-time linker version when present
- otherwise report the Go module version embedded in source-installed binaries
- report `devel` only when no versioned build metadata exists

The v0.3.2 tag retained the v0.3.1 hard-coded fallback, so binaries installed with `go install` could report the prior release. Deriving the fallback from Go build metadata removes that manual release step and prevents the same drift in future tags.

## Proof

- `go test -count=1 ./...`
- `go test -count=1 -race ./...`
- `./scripts/coverage.sh 85.0` (`85.3%`)
- `go vet ./...`
- `go mod verify`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `golangci-lint run --allow-parallel-runners ./...` (`0 issues`)
- source-blind CLI contract: unversioned build reports `devel`; linker-injected build reports `9.8.7`; repeated, extra-token, and help probes pass
- `GOPROXY=direct GONOSUMDB=github.com/openclaw/wacrawl go install github.com/openclaw/wacrawl/cmd/wacrawl@3f70bd3c115d553bf302a931ce098dcd3bb8cf10`; the installed binary reports `0.3.3-0.20260716173609-3f70bd3c115d`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output`: clean, no accepted/actionable findings
