### PR TITLE
fix: support relative SQLite paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Accept relative archive and WhatsApp source paths anywhere SQLite file URIs are constructed (#41).
 - Report the module version for source-installed binaries instead of a stale hard-coded release fallback.
 
 ## [0.3.2] - 2026-07-09

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -60,6 +60,71 @@ func TestRunEndToEnd(t *testing.T) {
 	}
 }
 
+func TestRunRelativeAndAbsolutePathContracts(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	if err := os.MkdirAll(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	createDesktopFixture(t, source)
+	t.Chdir(root)
+
+	for _, tc := range []struct {
+		name   string
+		source string
+		dbPath string
+		dbFile string
+	}{
+		{name: "relative", source: "./source", dbPath: "./relative.db", dbFile: filepath.Join(root, "relative.db")},
+		{name: "absolute", source: source, dbPath: filepath.Join(root, "absolute.db"), dbFile: filepath.Join(root, "absolute.db")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runJSON := func(args []string, target any) {
+				t.Helper()
+				var stdout, stderr bytes.Buffer
+				if err := Run(ctx, args, &stdout, &stderr); err != nil {
+					t.Fatalf("Run(%q) error = %v stderr=%s", args, err, stderr.String())
+				}
+				if err := json.Unmarshal(stdout.Bytes(), target); err != nil {
+					t.Fatalf("Run(%q) JSON = %s error = %v", args, stdout.String(), err)
+				}
+			}
+
+			var doctor struct {
+				Desktop whatsappdb.Source `json:"desktop"`
+			}
+			runJSON([]string{"--json", "--source", tc.source, "doctor"}, &doctor)
+			if !doctor.Desktop.Available || doctor.Desktop.MessageRows != 3 || doctor.Desktop.ChatRows != 2 || doctor.Desktop.ContactRows != 2 {
+				t.Fatalf("doctor = %+v", doctor.Desktop)
+			}
+
+			var imported store.ImportStats
+			runJSON([]string{"--json", "--source", tc.source, "--db", tc.dbPath, "import"}, &imported)
+			if imported.SourcePath != tc.source || imported.DBPath != tc.dbPath || imported.Messages != 3 {
+				t.Fatalf("import = %+v", imported)
+			}
+			if _, err := os.Stat(tc.dbFile); err != nil {
+				t.Fatalf("archive path = %q: %v", tc.dbFile, err)
+			}
+
+			var status store.Status
+			runJSON([]string{"--json", "--db", tc.dbPath, "--sync", "never", "status"}, &status)
+			if status.DBPath != tc.dbPath || status.Messages != 3 || status.Contacts != 2 {
+				t.Fatalf("status = %+v", status)
+			}
+
+			var rows []struct {
+				Messages int `json:"messages"`
+			}
+			runJSON([]string{"--json", "--db", tc.dbPath, "--sync", "never", "sql", "SELECT count(*) AS messages FROM messages"}, &rows)
+			if len(rows) != 1 || rows[0].Messages != 3 {
+				t.Fatalf("sql rows = %+v", rows)
+			}
+		})
+	}
+}
+
 func TestRunSQLJSONAndReadOnlyValidation(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "archive.db")

--- a/internal/cli/sql.go
+++ b/internal/cli/sql.go
@@ -61,13 +61,16 @@ func queryReadOnlySQL(ctx context.Context, dbPath string, query string) (sqlQuer
 	if err := validateReadOnlySQL(query); err != nil {
 		return sqlQueryResult{}, err
 	}
-	dsn := sqlitedsn.File(
+	dsn, err := sqlitedsn.File(
 		dbPath,
 		sqlitedsn.P("mode", "ro"),
 		sqlitedsn.P("_pragma", "query_only(1)"),
 		sqlitedsn.P("_pragma", "busy_timeout(5000)"),
 		sqlitedsn.P("_pragma", "temp_store(MEMORY)"),
 	)
+	if err != nil {
+		return sqlQueryResult{}, err
+	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return sqlQueryResult{}, fmt.Errorf("open sqlite: %w", err)

--- a/internal/sqlitedsn/dsn.go
+++ b/internal/sqlitedsn/dsn.go
@@ -1,7 +1,11 @@
 package sqlitedsn
 
 import (
+	"fmt"
 	"net/url"
+	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 type Param struct {
@@ -13,12 +17,25 @@ func P(key, value string) Param {
 	return Param{Key: key, Value: value}
 }
 
-func File(path string, params ...Param) string {
-	u := url.URL{Scheme: "file", Path: path}
+func File(path string, params ...Param) (string, error) {
+	u := url.URL{Scheme: "file"}
+	if path == ":memory:" {
+		u.Opaque = path
+	} else {
+		absolutePath, err := filepath.Abs(path)
+		if err != nil {
+			return "", fmt.Errorf("resolve sqlite path: %w", err)
+		}
+		uriPath := filepath.ToSlash(absolutePath)
+		if runtime.GOOS == "windows" && filepath.VolumeName(absolutePath) != "" && !strings.HasPrefix(uriPath, "/") {
+			uriPath = "/" + uriPath
+		}
+		u.Path = uriPath
+	}
 	query := url.Values{}
 	for _, param := range params {
 		query.Add(param.Key, param.Value)
 	}
 	u.RawQuery = query.Encode()
-	return u.String()
+	return u.String(), nil
 }

--- a/internal/sqlitedsn/dsn_test.go
+++ b/internal/sqlitedsn/dsn_test.go
@@ -2,20 +2,53 @@ package sqlitedsn
 
 import (
 	"net/url"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
-func TestFileBuildsSQLiteURI(t *testing.T) {
-	got := File("/tmp/archive one.db", P("mode", "ro"), P("_pragma", "query_only(1)"))
-	u, err := url.Parse(got)
+func TestFileBuildsAbsoluteSQLiteURI(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	for _, tc := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "relative", path: "./relative one?#.db", want: filepath.Join(root, "relative one?#.db")},
+		{name: "absolute", path: filepath.Join(root, "absolute one?#.db"), want: filepath.Join(root, "absolute one?#.db")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := File(tc.path, P("mode", "ro"), P("_pragma", "query_only(1)"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			u, err := url.Parse(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantURIPath := filepath.ToSlash(tc.want)
+			if runtime.GOOS == "windows" && filepath.VolumeName(tc.want) != "" && !strings.HasPrefix(wantURIPath, "/") {
+				wantURIPath = "/" + wantURIPath
+			}
+			if u.Scheme != "file" || u.Host != "" || u.Path != wantURIPath {
+				t.Fatalf("uri = %q, path = %q, want %q", got, u.Path, wantURIPath)
+			}
+			query := u.Query()
+			if query.Get("mode") != "ro" || query.Get("_pragma") != "query_only(1)" {
+				t.Fatalf("query = %#v", query)
+			}
+		})
+	}
+}
+
+func TestFilePreservesInMemoryDatabase(t *testing.T) {
+	got, err := File(":memory:", P("cache", "shared"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if u.Scheme != "file" || u.Path != "/tmp/archive one.db" {
+	if got != "file::memory:?cache=shared" {
 		t.Fatalf("uri = %q", got)
-	}
-	query := u.Query()
-	if query.Get("mode") != "ro" || query.Get("_pragma") != "query_only(1)" {
-		t.Fatalf("query = %#v", query)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -158,13 +158,16 @@ func Open(ctx context.Context, path string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return nil, fmt.Errorf("mkdir db dir: %w", err)
 	}
-	dsn := sqlitedsn.File(
+	dsn, err := sqlitedsn.File(
 		path,
 		sqlitedsn.P("_pragma", "foreign_keys(1)"),
 		sqlitedsn.P("_pragma", "journal_mode(WAL)"),
 		sqlitedsn.P("_pragma", "synchronous(NORMAL)"),
 		sqlitedsn.P("_pragma", "busy_timeout(5000)"),
 	)
+	if err != nil {
+		return nil, err
+	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open sqlite: %w", err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -155,6 +156,21 @@ func TestOpenRequiresPath(t *testing.T) {
 	}
 	if !fromUnix(0).IsZero() {
 		t.Fatal("zero unix should be zero time")
+	}
+}
+
+func TestOpenInMemoryDoesNotCreateFile(t *testing.T) {
+	root := t.TempDir()
+	t.Chdir(root)
+	st, err := Open(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, ":memory:")); !os.IsNotExist(err) {
+		t.Fatalf("in-memory archive created a disk file: %v", err)
 	}
 }
 

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -746,13 +746,16 @@ func openReadOnly(path string) (*sql.DB, func(), error) {
 	if _, err := os.Stat(path); err != nil {
 		return nil, nil, err
 	}
-	dsn := sqlitedsn.File(
+	dsn, err := sqlitedsn.File(
 		path,
 		sqlitedsn.P("mode", "ro"),
 		sqlitedsn.P("_pragma", "query_only(1)"),
 		sqlitedsn.P("_pragma", "busy_timeout(5000)"),
 		sqlitedsn.P("_pragma", "temp_store(MEMORY)"),
 	)
+	if err != nil {
+		return nil, nil, err
+	}
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Fixes #41.

## Summary

- Resolve SQLite filesystem paths to absolute, platform-correct file URIs at the shared DSN boundary.
- Apply the corrected boundary to archive stores, WhatsApp source inspection, and read-only SQL.
- Preserve SQLite's special `:memory:` URI form.
- Cover relative and absolute `--source` / `--db` contracts through doctor, import, status, and SQL.

## Root cause

`internal/sqlitedsn.File` encoded relative filesystem paths directly as `file:` URIs. SQLite interpreted `file://./...` as an authority-bearing URI and rejected `.` as an invalid authority. Source discovery suppresses optional inspection errors, so the same failure appeared as missing row counts there.

## Proof

- `go mod tidy -diff` — clean
- `go mod verify` — all modules verified
- `go vet ./...` — clean
- `go test -count=1 ./...` — pass
- `go test -count=1 -race ./...` — pass
- `./scripts/coverage.sh 85.0` — 85.1%
- `golangci-lint run --allow-parallel-runners ./...` — 0 issues
- autoreview — clean, no actionable findings

Real built-binary smoke from an isolated fixture directory:

```text
$ ./wacrawl-fixed --json --source ./source doctor
available=true messages=3 chats=2 contacts=2
$ ./wacrawl-fixed --json --db ./archive.db --sync never status
messages=0 chats=0 contacts=0
$ ./wacrawl-fixed --json --source ./source --db ./archive.db import
messages=3 chats=2 contacts=2
$ ./wacrawl-fixed --json --db ./archive.db --sync never status
db_path=./archive.db messages=3 chats=2 contacts=2
```

Absolute-path controls produced the same source counts and opened an empty archive successfully.
