### PR TITLE
build: notarize macOS release binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [0.3.4] - Unreleased
 
+### Changed
+
+- Notarize every signed macOS release binary and verify Apple's assessment before packaging and release validation.
+
 ## [0.3.3] - 2026-07-17
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -742,14 +742,18 @@ make release-artifacts VERSION=v0.3.3
 `make release-artifacts` wraps GoReleaser with the shared `release-mac-app codesign-run`
 helper. The helper loads the managed OpenClaw identity from the
 authorized Mac's runtime configuration; keychain locations and credentials do
-not belong in the repository. Both Darwin binaries are signed with the stable
-identifier `org.openclaw.wacrawl` and exact identity `Developer ID Application:
-OpenClaw Foundation (FWJYW4S8P8)`.
+not belong in the repository. Set `NOTARYTOOL_KEYCHAIN_PROFILE` at runtime to a
+notarytool profile stored in the login keychain; release packaging fails closed
+when it is absent. Both Darwin binaries are signed with the hardened runtime,
+stable identifier `org.openclaw.wacrawl`, and exact identity `Developer ID
+Application: OpenClaw Foundation (FWJYW4S8P8)`, then submitted to Apple and
+required to pass the notarization assessment before they enter an archive.
 
 Create a draft GitHub release and attach the archives plus `checksums.txt` from
 `dist/`. Run the `release` workflow from protected `main` with the tag and
 `draft=true` to verify the unpublished draft, then publish it. Publication
-reruns signature verification before dispatching the Homebrew update.
+reruns signature, hardened-runtime, and notarization verification before
+dispatching the Homebrew update.
 
 Local builds and GoReleaser snapshots do not require signing credentials. They
 remain suitable for development and cross-platform CI, but are not official

--- a/scripts/codesign-macos.sh
+++ b/scripts/codesign-macos.sh
@@ -32,20 +32,66 @@ if [[ "$identity" != "$expected_authority" ]]; then
   echo "official macOS releases require $expected_authority" >&2
   exit 1
 fi
+if [[ -z "${NOTARYTOOL_KEYCHAIN_PROFILE:-}" ]]; then
+  echo "official macOS release signing requires NOTARYTOOL_KEYCHAIN_PROFILE" >&2
+  exit 1
+fi
 if [[ ! -f "$binary" ]]; then
   echo "macOS release binary not found: $binary" >&2
   exit 1
 fi
 
-codesign --force --options runtime --timestamp \
-  --identifier "$identifier" --sign "$identity" "$binary"
-codesign --verify --strict -R="$requirement" --verbose=2 "$binary"
+for tool in codesign cp ditto mktemp mv plutil xcrun; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "missing required tool: $tool" >&2
+    exit 1
+  }
+done
 
-signature=$(codesign -dvvv "$binary" 2>&1)
+binary_dir=$(cd "$(dirname "$binary")" && pwd)
+binary_name=$(basename "$binary")
+work_dir=$(mktemp -d "$binary_dir/.wacrawl-notary.XXXXXX")
+candidate="$work_dir/$binary_name"
+submission="$work_dir/$binary_name.zip"
+trap 'rm -rf "$work_dir"' EXIT
+
+# Do not replace the release artifact until signing, notarization, and Apple's
+# assessment have all succeeded.
+cp -p "$binary" "$candidate"
+codesign --force --options runtime --timestamp \
+  --identifier "$identifier" --sign "$identity" "$candidate"
+
+ditto -c -k --sequesterRsrc --keepParent "$candidate" "$submission"
+notary_result=$(xcrun notarytool submit "$submission" \
+  --keychain-profile "$NOTARYTOOL_KEYCHAIN_PROFILE" \
+  --no-s3-acceleration \
+  --wait \
+  --output-format json)
+notary_status=$(plutil -extract status raw -o - - <<<"$notary_result")
+notary_id=$(plutil -extract id raw -o - - <<<"$notary_result")
+if [[ "$notary_status" != Accepted ]]; then
+  echo "macOS release notarization status is ${notary_status:-missing}, expected Accepted" >&2
+  exit 1
+fi
+if [[ ! "$notary_id" =~ ^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$ ]]; then
+  echo "macOS release notarization response has an invalid submission id" >&2
+  exit 1
+fi
+
+codesign --verify --strict -R="$requirement" --verbose=2 "$candidate"
+
+signature=$(codesign -dvvv "$candidate" 2>&1)
 grep -Fx "Identifier=$identifier" <<<"$signature" >/dev/null
 grep -Fx "TeamIdentifier=$team_id" <<<"$signature" >/dev/null
 grep -Fx "Authority=$expected_authority" <<<"$signature" >/dev/null
+grep -Eq '^CodeDirectory .*flags=.*\([^)]*runtime[^)]*\)' <<<"$signature" || {
+  echo "macOS release binary is missing the hardened runtime" >&2
+  exit 1
+}
 if grep -Fx "Signature=adhoc" <<<"$signature" >/dev/null; then
   echo "macOS release binary is ad-hoc signed" >&2
   exit 1
 fi
+codesign --verify --strict --check-notarization -R=notarized "$candidate"
+
+mv -f "$candidate" "$binary"

--- a/scripts/codesign-macos.sh
+++ b/scripts/codesign-macos.sh
@@ -58,8 +58,8 @@ trap 'rm -rf "$work_dir"' EXIT
 # Do not replace the release artifact until signing, notarization, and Apple's
 # assessment have all succeeded.
 cp -p "$binary" "$candidate"
-codesign --force --options runtime --timestamp \
-  --identifier "$identifier" --sign "$identity" "$candidate"
+codesign --force --sign "$identity" --timestamp --options runtime \
+  --identifier "$identifier" "$candidate"
 
 ditto -c -k --sequesterRsrc --keepParent "$candidate" "$submission"
 notary_result=$(xcrun notarytool submit "$submission" \

--- a/scripts/package-wacrawl-release.sh
+++ b/scripts/package-wacrawl-release.sh
@@ -23,8 +23,12 @@ usage() {
   echo "official wacrawl releases require $expected_authority" >&2
   exit 1
 }
+[[ -n "${NOTARYTOOL_KEYCHAIN_PROFILE:-}" ]] || {
+  echo "official wacrawl releases require NOTARYTOOL_KEYCHAIN_PROFILE" >&2
+  exit 1
+}
 
-for tool in codesign git go goreleaser lipo shasum tar; do
+for tool in codesign ditto git go goreleaser lipo plutil shasum tar xcrun; do
   command -v "$tool" >/dev/null || {
     echo "missing required tool: $tool" >&2
     exit 1
@@ -53,6 +57,7 @@ git -C "$root" tag -v "$version" >/dev/null 2>&1 || {
   cd "$root"
   WACRAWL_REQUIRE_CODESIGN=1 \
     WACRAWL_CODESIGN_IDENTITY="$CODESIGN_IDENTITY" \
+    NOTARYTOOL_KEYCHAIN_PROFILE="$NOTARYTOOL_KEYCHAIN_PROFILE" \
     goreleaser release --clean --skip=publish
 )
 

--- a/scripts/test-macos-release.sh
+++ b/scripts/test-macos-release.sh
@@ -32,14 +32,53 @@ EOF
 
 cat > "$fake_bin/codesign" <<'EOF'
 #!/usr/bin/env bash
+printf 'codesign %s\n' "$*" >> "${MOCK_CODESIGN_LOG:?}"
 case " $* " in
+  *' --sign '*)
+    printf '\n# mock signed\n' >> "${!#}"
+    ;;
+  *' --check-notarization '*)
+    [[ "${MOCK_NOTARY_TICKET:-accepted}" == accepted ]]
+    ;;
   *' -dvvv '*)
     {
+      if [[ "${MOCK_CODESIGN_RUNTIME:-present}" == present ]]; then
+        echo 'CodeDirectory v=20500 size=512 flags=0x10000(runtime) hashes=1+0 location=embedded'
+      else
+        echo 'CodeDirectory v=20500 size=512 flags=0x0(none) hashes=1+0 location=embedded'
+      fi
       echo 'Identifier=org.openclaw.wacrawl'
       echo "Authority=${MOCK_CODESIGN_AUTHORITY:-Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)}"
       echo 'TeamIdentifier=FWJYW4S8P8'
     } >&2
     ;;
+esac
+EOF
+
+cat > "$fake_bin/ditto" <<'EOF'
+#!/usr/bin/env bash
+printf 'ditto %s\n' "$*" >> "${MOCK_DITTO_LOG:?}"
+while (( $# > 2 )); do
+  shift
+done
+cp "$1" "$2"
+EOF
+
+cat > "$fake_bin/xcrun" <<'EOF'
+#!/usr/bin/env bash
+printf 'xcrun %s\n' "$*" >> "${MOCK_XCRUN_LOG:?}"
+printf '{"id":"%s","status":"%s"}\n' \
+  "${MOCK_NOTARY_ID:-12345678-1234-1234-1234-123456789abc}" \
+  "${MOCK_NOTARY_STATUS:-Accepted}"
+EOF
+
+cat > "$fake_bin/plutil" <<'EOF'
+#!/usr/bin/env bash
+cat >/dev/null
+case "${2:-}" in
+  status) printf '%s\n' "${MOCK_NOTARY_STATUS:-Accepted}" ;;
+  id) printf '%s\n' "${MOCK_NOTARY_ID:-12345678-1234-1234-1234-123456789abc}" ;;
+  *) exit 2 ;;
 esac
 EOF
 
@@ -69,21 +108,72 @@ EOF
 
 chmod 0755 "$fake_bin"/*
 export PATH="$fake_bin:$PATH"
+unset NOTARYTOOL_KEYCHAIN_PROFILE
+export MOCK_CODESIGN_LOG="$work_dir/codesign.log"
+export MOCK_DITTO_LOG="$work_dir/ditto.log"
+export MOCK_XCRUN_LOG="$work_dir/xcrun.log"
+: > "$MOCK_CODESIGN_LOG"
+: > "$MOCK_DITTO_LOG"
+: > "$MOCK_XCRUN_LOG"
 
+probe_seed="$work_dir/probe-seed"
 probe="$work_dir/probe"
-printf '#!/usr/bin/env bash\nexit 0\n' > "$probe"
-chmod 0755 "$probe"
-WACRAWL_REQUIRE_CODESIGN=1 WACRAWL_CODESIGN_IDENTITY="$expected_authority" \
-  "$root/scripts/codesign-macos.sh" "$probe"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$probe_seed"
+chmod 0755 "$probe_seed"
+cp "$probe_seed" "$probe"
+if WACRAWL_REQUIRE_CODESIGN=1 WACRAWL_CODESIGN_IDENTITY="$expected_authority" \
+  "$root/scripts/codesign-macos.sh" "$probe" >/dev/null 2>&1; then
+  fail "missing notarytool profile was accepted"
+fi
+cmp "$probe_seed" "$probe" || fail "missing profile changed the release binary"
 if WACRAWL_REQUIRE_CODESIGN=1 \
   WACRAWL_CODESIGN_IDENTITY='Developer ID Application: Peter Steinberger (Y5PE65HELJ)' \
   "$root/scripts/codesign-macos.sh" "$probe" >/dev/null 2>&1; then
   fail "personal signing identity was accepted"
 fi
+cp "$probe_seed" "$probe"
+if MOCK_NOTARY_STATUS=Rejected WACRAWL_REQUIRE_CODESIGN=1 \
+  WACRAWL_CODESIGN_IDENTITY="$expected_authority" NOTARYTOOL_KEYCHAIN_PROFILE=test-profile \
+  "$root/scripts/codesign-macos.sh" "$probe" >/dev/null 2>&1; then
+  fail "rejected notarization was accepted"
+fi
+cmp "$probe_seed" "$probe" || fail "rejected notarization changed the release binary"
+cp "$probe_seed" "$probe"
+if MOCK_NOTARY_TICKET=rejected WACRAWL_REQUIRE_CODESIGN=1 \
+  WACRAWL_CODESIGN_IDENTITY="$expected_authority" NOTARYTOOL_KEYCHAIN_PROFILE=test-profile \
+  "$root/scripts/codesign-macos.sh" "$probe" >/dev/null 2>&1; then
+  fail "failed Apple notarization assessment was accepted"
+fi
+cmp "$probe_seed" "$probe" || fail "failed assessment changed the release binary"
+cp "$probe_seed" "$probe"
+if MOCK_CODESIGN_RUNTIME=missing WACRAWL_REQUIRE_CODESIGN=1 \
+  WACRAWL_CODESIGN_IDENTITY="$expected_authority" NOTARYTOOL_KEYCHAIN_PROFILE=test-profile \
+  "$root/scripts/codesign-macos.sh" "$probe" >/dev/null 2>&1; then
+  fail "missing hardened runtime was accepted"
+fi
+cmp "$probe_seed" "$probe" || fail "runtime verification failure changed the release binary"
+cp "$probe_seed" "$probe"
+WACRAWL_REQUIRE_CODESIGN=1 WACRAWL_CODESIGN_IDENTITY="$expected_authority" \
+  NOTARYTOOL_KEYCHAIN_PROFILE=test-profile \
+  "$root/scripts/codesign-macos.sh" "$probe"
+cmp "$probe_seed" "$probe" >/dev/null 2>&1 && fail "successful signing did not replace the binary"
+grep -F 'notarytool submit ' "$MOCK_XCRUN_LOG" >/dev/null
+grep -F -- '--keychain-profile test-profile' "$MOCK_XCRUN_LOG" >/dev/null
+grep -F -- '--wait --output-format json' "$MOCK_XCRUN_LOG" >/dev/null
+grep -F -- '--check-notarization -R=notarized' "$MOCK_CODESIGN_LOG" >/dev/null
+if find "$work_dir" -maxdepth 1 -name '.wacrawl-notary.*' -print -quit | grep -q .; then
+  fail "notarization scratch directory was not removed"
+fi
 if CODESIGN_IDENTITY='Developer ID Application: Peter Steinberger (Y5PE65HELJ)' \
   "$root/scripts/package-wacrawl-release.sh" v0.3.3 >/dev/null 2>&1; then
   fail "personal signing identity reached release packaging"
 fi
+if package_output=$(CODESIGN_IDENTITY="$expected_authority" \
+  "$root/scripts/package-wacrawl-release.sh" v0.3.3 2>&1); then
+  fail "release packaging accepted a missing notarytool profile"
+fi
+grep -F 'require NOTARYTOOL_KEYCHAIN_PROFILE' <<<"$package_output" >/dev/null || \
+  fail "release packaging did not explain the missing notarytool profile"
 
 assets="$work_dir/assets"
 mkdir -p "$assets"
@@ -105,9 +195,17 @@ EOF
   )
 done
 
+: > "$MOCK_CODESIGN_LOG"
 "$root/scripts/verify-macos-release.sh" v0.3.3 \
   "$assets/wacrawl_0.3.3_darwin_arm64.tar.gz" \
   "$assets/wacrawl_0.3.3_darwin_amd64.tar.gz"
+grep -F -- '--check-notarization -R=notarized' "$MOCK_CODESIGN_LOG" >/dev/null || \
+  fail "release verification skipped the Apple notarization assessment"
+if MOCK_NOTARY_TICKET=rejected \
+  "$root/scripts/verify-macos-release.sh" v0.3.3 \
+  "$assets/wacrawl_0.3.3_darwin_arm64.tar.gz" >/dev/null 2>&1; then
+  fail "release verification accepted an unnotarized binary"
+fi
 if MOCK_CODESIGN_AUTHORITY='Developer ID Application: Peter Steinberger (Y5PE65HELJ)' \
   "$root/scripts/verify-macos-release.sh" v0.3.3 \
   "$assets/wacrawl_0.3.3_darwin_arm64.tar.gz" >/dev/null 2>&1; then

--- a/scripts/verify-macos-release.sh
+++ b/scripts/verify-macos-release.sh
@@ -71,10 +71,15 @@ for archive in "$@"; do
   chmod 0755 "$binary"
 
   codesign --verify --strict -R="$requirement" --verbose=2 "$binary"
+  codesign --verify --strict --check-notarization -R=notarized "$binary"
   signature=$(codesign -dvvv "$binary" 2>&1)
   grep -Fx "Identifier=$identifier" <<<"$signature" >/dev/null
   grep -Fx "TeamIdentifier=$team_id" <<<"$signature" >/dev/null
   grep -Fx "Authority=$expected_authority" <<<"$signature" >/dev/null
+  grep -Eq '^CodeDirectory .*flags=.*\([^)]*runtime[^)]*\)' <<<"$signature" || {
+    echo "macOS release binary is missing the hardened runtime: $(basename "$archive")" >&2
+    exit 1
+  }
   if grep -Fx "Signature=adhoc" <<<"$signature" >/dev/null; then
     echo "macOS release binary is ad-hoc signed: $(basename "$archive")" >&2
     exit 1


### PR DESCRIPTION
## Summary

- notarize each GoReleaser Darwin binary with the runtime keychain profile before it enters an archive
- keep the original build artifact unchanged until signing, notarization, hardened-runtime checks, the stable designated requirement, and Apple's assessment all pass
- make release packaging fail closed without `NOTARYTOOL_KEYCHAIN_PROFILE`, and enforce notarization again in published-asset verification
- document the release contract and cover missing credentials, rejection, assessment failure, runtime failure, cleanup, and artifact immutability

## Real macOS proof

On an authorized Apple Silicon maintainer Mac, built fresh `v0.3.4` thin binaries for both shipped Darwin targets and ran the exact release signing script with the managed login-keychain profile:

```bash
CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags '-s -w -X github.com/openclaw/wacrawl/internal/cli.version=0.3.4' -o "$scratch/arm64/wacrawl" ./cmd/wacrawl
CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags '-s -w -X github.com/openclaw/wacrawl/internal/cli.version=0.3.4' -o "$scratch/amd64/wacrawl" ./cmd/wacrawl
WACRAWL_REQUIRE_CODESIGN=1 WACRAWL_CODESIGN_IDENTITY='Developer ID Application: OpenClaw Foundation (FWJYW4S8P8)' NOTARYTOOL_KEYCHAIN_PROFILE='<managed-profile>' ./scripts/codesign-macos.sh "$binary"
codesign --verify --strict --check-notarization -R=notarized "$binary"
```

Observed for both `arm64` and `x86_64`: notarization accepted, hardened-runtime flag present, stable requirement satisfied, version `0.3.4`. Scratch tarballs containing those exact binaries also passed:

```bash
./scripts/verify-macos-release.sh v0.3.4 wacrawl_0.3.4_darwin_arm64.tar.gz wacrawl_0.3.4_darwin_amd64.tar.gz
```

## Gates

```bash
go mod tidy -diff
go mod verify
go vet ./...
go test -count=1 ./...
go test -count=1 -race ./...
./scripts/coverage.sh 85.0
make lint
make build
govulncheck ./...
goreleaser release --snapshot --clean --skip=publish
NOTARYTOOL_KEYCHAIN_PROFILE=ambient-profile bash scripts/test-macos-release.sh
shellcheck scripts/codesign-macos.sh scripts/package-wacrawl-release.sh scripts/verify-macos-release.sh scripts/test-macos-release.sh
```

Observed: all green; coverage `85.1%`; zero lint issues; zero reachable vulnerabilities; both Darwin snapshot hooks executed; release-script regressions passed even with an inherited profile injected. Final branch AutoReview: clean, no accepted/actionable findings.
