### PR TITLE
refactor: convert imports to tombstone-safe merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [0.3.5] - Unreleased
 
+### Highlights
+
+- Preserve cumulative WhatsApp history with tombstone-safe merge imports, explicit exact restores, stable message event identity, and retained edit/delete revisions (#38).
+
+### Changed
+
+- Make `import` and `sync` merge by default so rows missing from an incomplete Desktop snapshot remain searchable, bind merges to hashed account and source-store fingerprints, provide explicit `--adopt-source` for legacy archives, and use `--restore` for intentional exact replacement.
+- Add source-attributed tombstones to contacts, chats, groups, participants, and messages, including subordinate tombstones for deleted parents and explicit WhatsApp removal, inactivity, and cleared-message signals.
+- Migrate existing archives in place without rewriting canonical rows, retain prior message payloads in `message_revisions`, and exclude tombstoned rows from normal reads while keeping them in encrypted backups.
+
 ## [0.3.4] - 2026-07-17
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -145,11 +145,13 @@ range, and importer schema notes.
 
 ### `import`
 
-Snapshot WhatsApp Desktop data and replace the local archive in one transaction:
+Snapshot WhatsApp Desktop data and merge it into the local archive in one
+transaction:
 
 ```bash
 wacrawl import
 wacrawl import --copy-media
+wacrawl import --restore
 ```
 
 `sync` is the same command with a clearer name:
@@ -158,6 +160,33 @@ wacrawl import --copy-media
 wacrawl sync
 wacrawl sync --copy-media
 ```
+
+Routine imports merge by stable row identity. Rows absent from the current
+Desktop snapshot remain in the archive because absence is not a deletion
+signal. This preserves older history after WhatsApp evicts it from local
+storage. The archive binds both the canonical Desktop path and a hashed,
+portable CoreData store marker. That marker identifies the store, not the
+WhatsApp account inside it; the importer separately hashes the account-owned
+JID in `Axolotl.sqlite`. A nonempty archive without that verified account
+binding refuses routine merges, even when events overlap. Use a one-time
+`--adopt-source` to bind a legacy archive that has no verified account binding
+while retaining its rows. Established account and store fingerprints remain
+strict across encrypted backup restore.
+Replacing or repopulating the same store with a different account therefore
+cannot silently combine histories. Pass `--restore` only when the archive must
+exactly match the current snapshot or intentionally switch sources; exact
+restore removes destination-only rows and local revision history.
+
+Explicit WhatsApp signals create source-attributed tombstones instead of
+deleting rows. Removed chats tombstone their archived groups, participants,
+and messages; inactive group members are tombstoned; and an observed plain-text
+message payload changing to SQL `NULL` is retained as a deleted message with
+its previous payload in `message_revisions`. Message tombstones are sticky during
+merge imports; an exact `--restore` is authoritative if a source replacement
+must revive one. A removed chat can begin a new live lifecycle when WhatsApp
+reports post-tombstone activity, without reviving its historical messages.
+Normal list, search, status, and web reads exclude tombstones, while encrypted
+backups retain them.
 
 Imports:
 
@@ -181,8 +210,8 @@ Show archive counts and import metadata:
 wacrawl status
 ```
 
-Includes chat, unread-chat, unread-message, contact, group, participant,
-message, media-message, oldest, newest, last-import, and source fields.
+Includes live and deleted entity counts, message revision count, unread counts,
+media-message count, oldest, newest, last-import, and source fields.
 
 By default, `status` first syncs the archive when the last sync is older than
 `--sync-max-age` and the WhatsApp Desktop source has newer data.
@@ -345,6 +374,7 @@ data/contacts.jsonl.gz.age
 data/groups.jsonl.gz.age
 data/group_participants.jsonl.gz.age
 data/messages/YYYY/MM.jsonl.gz.age
+data/message_revisions.jsonl.gz.age
 data/files/index*.jsonl.gz.age
 data/files/objects/OPAQUE_ID.gz.age
 ```
@@ -675,6 +705,8 @@ Import/sync flags:
 
 ```text
 --copy-media            Copy referenced media during import/sync.
+--adopt-source          Bind an unverified archive to this account and merge.
+--restore               Exactly replace archive rows instead of merging.
 ```
 
 ## Data Format Notes
@@ -688,13 +720,26 @@ ZWAMESSAGE
 ZWAMEDIAITEM
 ZWAGROUPINFO
 ZWAGROUPMEMBER
+Axolotl.sqlite: ZWAZMDACCOUNT (account identity only)
 ```
 
 Important details:
 
 - WhatsApp timestamps are seconds since `2001-01-01T00:00:00Z`.
-- `ZWAMESSAGE.Z_PK` is used as the source row identity.
+- `ZWAMESSAGE.Z_PK` is the stable source row identity inside each separate
+  account archive and maps to `messages.event_id` as `wa:<source_pk>`.
+  Routine merges bind the archive to one canonical Desktop source path and a
+  hashed CoreData store fingerprint, then reject source changes and conflicting
+  event envelopes. A separate hashed account JID is the privacy boundary; event
+  overlap never substitutes for it. Existing archives without that binding
+  require a one-time explicit `--adopt-source`. Use a separate `--db`
+  for another account or `--restore` for an intentional source replacement.
 - `ZSTANZAID` is not unique enough for archive identity.
+- Every canonical entity carries `deleted_at`, `deletion_source`,
+  `deletion_reason`, and `last_seen_at`; an unobserved row is never implicitly
+  tombstoned.
+- Prior observable message payloads are append-only rows in
+  `message_revisions` keyed by stable `event_id`.
 - Group senders are resolved through `ZWAMESSAGE.ZGROUPMEMBER`.
 - Media is joined through both `ZWAMESSAGE.ZMEDIAITEM` and
   `ZWAMEDIAITEM.ZMESSAGE`.

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -34,6 +34,8 @@ type Counts struct {
 	Groups       int `json:"groups"`
 	Participants int `json:"participants"`
 	Messages     int `json:"messages"`
+	Revisions    int `json:"message_revisions,omitempty"`
+	Identity     int `json:"archive_identity,omitempty"`
 	MediaFiles   int `json:"media_files,omitempty"`
 }
 
@@ -51,6 +53,11 @@ type Result struct {
 	MediaFiles int    `json:"media_files"`
 	Ref        string `json:"ref,omitempty"`
 	Tag        string `json:"tag,omitempty"`
+}
+
+type archiveIdentity struct {
+	SourceStoreIdentity string `json:"source_store_identity"`
+	AccountIdentity     string `json:"account_identity"`
 }
 
 func Init(ctx context.Context, opts Options) (Config, string, error) {
@@ -217,11 +224,17 @@ func Status(ctx context.Context, opts Options) (Manifest, string, error) {
 }
 
 func writeSnapshot(ctx context.Context, cfg Config, data store.SnapshotData, files []ckbackup.File, old Manifest) (Manifest, error) {
+	identities := []archiveIdentity(nil)
+	if data.SourceStoreIdentity != "" || data.AccountIdentity != "" {
+		identities = append(identities, archiveIdentity{SourceStoreIdentity: data.SourceStoreIdentity, AccountIdentity: data.AccountIdentity})
+	}
 	shards := []ckbackup.Shard{
 		{Table: "contacts", Path: "data/contacts.jsonl.gz.age", Rows: data.Contacts},
 		{Table: "chats", Path: "data/chats.jsonl.gz.age", Rows: data.Chats},
 		{Table: "groups", Path: "data/groups.jsonl.gz.age", Rows: data.Groups},
 		{Table: "group_participants", CountKey: "participants", Path: "data/group_participants.jsonl.gz.age", Rows: data.Participants},
+		{Table: "message_revisions", CountKey: "message_revisions", Path: "data/message_revisions.jsonl.gz.age", Rows: data.Revisions},
+		{Table: "archive_identity", CountKey: "archive_identity", Path: "data/archive_identity.jsonl.gz.age", Rows: identities},
 	}
 	for _, shard := range messageShards(data.Messages) {
 		shards = append(shards, ckbackup.Shard{Table: "messages", Path: shard.path, Rows: shard.messages})
@@ -239,6 +252,8 @@ func writeSnapshot(ctx context.Context, cfg Config, data store.SnapshotData, fil
 	manifest.Counts["groups"] = len(data.Groups)
 	manifest.Counts["participants"] = len(data.Participants)
 	manifest.Counts["messages"] = len(data.Messages)
+	manifest.Counts["message_revisions"] = len(data.Revisions)
+	manifest.Counts["archive_identity"] = len(identities)
 	if ckbackup.EquivalentManifest(toCrawlkitManifest(old), manifest) {
 		return old, nil
 	}
@@ -282,6 +297,22 @@ func decodeSnapshot(shards []ckbackup.DecodedShard) (store.SnapshotData, error) 
 				return store.SnapshotData{}, err
 			}
 			data.Messages = append(data.Messages, messages...)
+		case "message_revisions":
+			if err := ckbackup.DecodeJSONL(shard.Plaintext, &data.Revisions); err != nil {
+				return store.SnapshotData{}, err
+			}
+		case "archive_identity":
+			var identities []archiveIdentity
+			if err := ckbackup.DecodeJSONL(shard.Plaintext, &identities); err != nil {
+				return store.SnapshotData{}, err
+			}
+			if len(identities) > 1 {
+				return store.SnapshotData{}, errors.New("backup contains multiple archive identities")
+			}
+			if len(identities) == 1 {
+				data.SourceStoreIdentity = identities[0].SourceStoreIdentity
+				data.AccountIdentity = identities[0].AccountIdentity
+			}
 		default:
 			return store.SnapshotData{}, fmt.Errorf("unknown backup table %q", shard.Entry.Table)
 		}
@@ -350,11 +381,13 @@ func toCrawlkitManifest(manifest Manifest) ckbackup.Manifest {
 		Exported:   manifest.Exported,
 		Recipients: manifest.Recipients,
 		Counts: map[string]int{
-			"contacts":     manifest.Counts.Contacts,
-			"chats":        manifest.Counts.Chats,
-			"groups":       manifest.Counts.Groups,
-			"participants": manifest.Counts.Participants,
-			"messages":     manifest.Counts.Messages,
+			"contacts":          manifest.Counts.Contacts,
+			"chats":             manifest.Counts.Chats,
+			"groups":            manifest.Counts.Groups,
+			"participants":      manifest.Counts.Participants,
+			"messages":          manifest.Counts.Messages,
+			"message_revisions": manifest.Counts.Revisions,
+			"archive_identity":  manifest.Counts.Identity,
 		},
 		Shards: manifest.Shards,
 		Files:  manifest.Files,
@@ -377,6 +410,8 @@ func fromCrawlkitManifest(manifest ckbackup.Manifest) Manifest {
 			Groups:       manifest.Counts["groups"],
 			Participants: participants,
 			Messages:     manifest.Counts["messages"],
+			Revisions:    manifest.Counts["message_revisions"],
+			Identity:     manifest.Counts["archive_identity"],
 			MediaFiles:   len(manifest.Files),
 		},
 		Shards: manifest.Shards,

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -22,10 +22,12 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	source := openFixtureStore(t, "source.db")
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	data := store.SnapshotData{
-		Contacts:     []store.Contact{{JID: "alice@s.whatsapp.net", FullName: "Alice", UpdatedAt: now}},
-		Chats:        []store.Chat{{JID: "chat@g.us", Kind: "group", Name: "Launch Group", LastMessageAt: now}},
-		Groups:       []store.Group{{JID: "chat@g.us", Name: "Launch Group", OwnerJID: "owner@s.whatsapp.net", CreatedAt: now}},
-		Participants: []store.GroupParticipant{{GroupJID: "chat@g.us", UserJID: "alice@s.whatsapp.net", ContactName: "Alice", IsAdmin: true, IsActive: true}},
+		SourceStoreIdentity: "wa-store:fixture",
+		AccountIdentity:     "wa-account:fixture",
+		Contacts:            []store.Contact{{JID: "alice@s.whatsapp.net", FullName: "Alice", UpdatedAt: now}},
+		Chats:               []store.Chat{{JID: "chat@g.us", Kind: "group", Name: "Launch Group", LastMessageAt: now}},
+		Groups:              []store.Group{{JID: "chat@g.us", Name: "Launch Group", OwnerJID: "owner@s.whatsapp.net", CreatedAt: now}},
+		Participants:        []store.GroupParticipant{{GroupJID: "chat@g.us", UserJID: "alice@s.whatsapp.net", ContactName: "Alice", IsAdmin: true, IsActive: true}},
 		Messages: []store.Message{
 			{SourcePK: 1, ChatJID: "chat@g.us", ChatName: "Launch Group", MessageID: "a", SenderJID: "alice@s.whatsapp.net", SenderName: "Alice", Timestamp: now, Text: "secret launch text", RawType: 0, MessageType: "text"},
 		},
@@ -40,6 +42,11 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	data.Messages[0].MediaType = "image"
 	data.Messages[0].MediaPath = mediaPath
 	if err := source.ImportSnapshot(ctx, data, "/fixture", now); err != nil {
+		t.Fatal(err)
+	}
+	edited := data.Messages[0]
+	edited.Text = "edited launch text"
+	if err := source.MergeAll(ctx, store.ImportStats{SourcePath: "/fixture", SourceStoreIdentity: data.SourceStoreIdentity, AccountIdentity: data.AccountIdentity, Messages: 1, FinishedAt: now.Add(time.Minute)}, nil, nil, nil, nil, []store.Message{edited}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -74,14 +81,14 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if statusRepo != repo || status.Counts.Messages != 1 || status.Counts.MediaFiles != 1 {
+	if statusRepo != repo || status.Counts.Messages != 1 || status.Counts.Revisions != 1 || status.Counts.MediaFiles != 1 {
 		t.Fatalf("unexpected backup status repo=%s status=%+v", statusRepo, status)
 	}
 	manifest, err := readManifest(repo)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !manifest.Encrypted || manifest.Counts.Messages != 1 || len(manifest.Files) != 1 {
+	if !manifest.Encrypted || manifest.Counts.Messages != 1 || manifest.Counts.Revisions != 1 || manifest.Counts.Identity != 1 || len(manifest.Files) != 1 {
 		t.Fatalf("unexpected manifest: %+v", manifest)
 	}
 	ciphertext, err := os.ReadFile(filepath.Join(repo, filepath.FromSlash(manifest.Shards[len(manifest.Shards)-1].Path))) // #nosec G304 -- test reads a generated shard path from its temp repo manifest.
@@ -107,12 +114,26 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	if pulled.Messages != 1 || pulled.MediaFiles != 1 {
 		t.Fatalf("unexpected pull result: %+v", pulled)
 	}
-	results, err := restored.Search(ctx, store.MessageFilter{Query: "secret", Limit: 10})
+	results, err := restored.Search(ctx, store.MessageFilter{Query: "edited", Limit: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(results) != 1 || results[0].Text != "secret launch text" {
+	if len(results) != 1 || results[0].Text != "edited launch text" {
 		t.Fatalf("restore search mismatch: %+v", results)
+	}
+	restoredStatus, err := restored.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restoredStatus.MessageRevisions != 1 {
+		t.Fatalf("restored revisions = %d", restoredStatus.MessageRevisions)
+	}
+	restoredData, err := restored.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(restoredData.Revisions) != 1 || !strings.Contains(restoredData.Revisions[0].PayloadJSON, "secret launch text") || restoredData.AccountIdentity != data.AccountIdentity || restoredData.SourceStoreIdentity != data.SourceStoreIdentity {
+		t.Fatalf("restored revision = %+v", restoredData.Revisions)
 	}
 	wantRestoredMedia := filepath.Join(filepath.Dir(restored.Path()), "media", "photo.jpg ")
 	if results[0].MediaPath != wantRestoredMedia {
@@ -131,7 +152,7 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	if noMediaPulled.Messages != 1 || noMediaPulled.MediaFiles != 1 {
 		t.Fatalf("unexpected no-media pull result: %+v", noMediaPulled)
 	}
-	noMediaResults, err := noMediaRestored.Search(ctx, store.MessageFilter{Query: "secret", Limit: 10})
+	noMediaResults, err := noMediaRestored.Search(ctx, store.MessageFilter{Query: "edited", Limit: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,11 +191,11 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 	if secondPulled.Messages != 1 {
 		t.Fatalf("unexpected second-recipient pull result: %+v", secondPulled)
 	}
-	secondResults, err := secondRestored.Search(ctx, store.MessageFilter{Query: "secret", Limit: 10})
+	secondResults, err := secondRestored.Search(ctx, store.MessageFilter{Query: "edited", Limit: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(secondResults) != 1 || secondResults[0].Text != "secret launch text" {
+	if len(secondResults) != 1 || secondResults[0].Text != "edited launch text" {
 		t.Fatalf("second-recipient restore mismatch: %+v", secondResults)
 	}
 	sameRecipients, err := Push(ctx, source, opts)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -189,6 +189,8 @@ func (a *app) runImport(ctx context.Context, command string, args []string) erro
 	fs.SetOutput(io.Discard)
 	source := fs.String("source", a.source, "")
 	copyMedia := fs.Bool("copy-media", false, "")
+	restore := fs.Bool("restore", false, "")
+	adoptSource := fs.Bool("adopt-source", false, "")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			printCommandUsage(a.stdout, command)
@@ -199,8 +201,11 @@ func (a *app) runImport(ctx context.Context, command string, args []string) erro
 	if fs.NArg() != 0 {
 		return usageErr(fmt.Errorf("%s takes flags only", command))
 	}
+	if *restore && *adoptSource {
+		return usageErr(errors.New("--restore and --adopt-source are mutually exclusive"))
+	}
 	return a.withStore(ctx, func(st *store.Store) error {
-		stats, err := whatsappdb.ImportWithOptions(ctx, st, whatsappdb.ImportOptions{SourcePath: *source, CopyMedia: *copyMedia})
+		stats, err := whatsappdb.ImportWithOptions(ctx, st, whatsappdb.ImportOptions{SourcePath: *source, CopyMedia: *copyMedia, Restore: *restore, AdoptSource: *adoptSource})
 		if err != nil {
 			return err
 		}
@@ -544,12 +549,12 @@ func (a *app) print(value any) error {
 	}
 	switch v := value.(type) {
 	case store.ImportStats:
-		_, err := fmt.Fprintf(a.stdout, "source=%s\ndb=%s\nchats=%d\ncontacts=%d\ngroups=%d\nparticipants=%d\nmessages=%d\nmedia_messages=%d\nmedia_copied=%d\nmedia_missing=%d\n",
-			v.SourcePath, v.DBPath, v.Chats, v.Contacts, v.Groups, v.Participants, v.Messages, v.MediaMessages, v.MediaCopied, v.MediaMissing)
+		_, err := fmt.Fprintf(a.stdout, "mode=%s\nsource=%s\ndb=%s\nchats=%d\ncontacts=%d\ngroups=%d\nparticipants=%d\nmessages=%d\nmedia_messages=%d\nmedia_copied=%d\nmedia_missing=%d\n",
+			v.Mode, v.SourcePath, v.DBPath, v.Chats, v.Contacts, v.Groups, v.Participants, v.Messages, v.MediaMessages, v.MediaCopied, v.MediaMissing)
 		return err
 	case store.Status:
-		_, err := fmt.Fprintf(a.stdout, "db=%s\nchats=%d\nunread_chats=%d\nunread_messages=%d\ncontacts=%d\ngroups=%d\nparticipants=%d\nmessages=%d\nmedia_messages=%d\noldest=%s\nnewest=%s\nlast_import=%s\nsource=%s\n",
-			v.DBPath, v.Chats, v.UnreadChats, v.UnreadMessages, v.Contacts, v.Groups, v.Participants, v.Messages, v.MediaMessages, formatTime(v.OldestMessage), formatTime(v.NewestMessage), formatTime(v.LastImportAt), v.LastSource)
+		_, err := fmt.Fprintf(a.stdout, "db=%s\nchats=%d\nunread_chats=%d\nunread_messages=%d\ncontacts=%d\ngroups=%d\nparticipants=%d\nmessages=%d\nmedia_messages=%d\ndeleted_chats=%d\ndeleted_contacts=%d\ndeleted_groups=%d\ndeleted_participants=%d\ndeleted_messages=%d\nmessage_revisions=%d\noldest=%s\nnewest=%s\nlast_import=%s\nsource=%s\n",
+			v.DBPath, v.Chats, v.UnreadChats, v.UnreadMessages, v.Contacts, v.Groups, v.Participants, v.Messages, v.MediaMessages, v.DeletedChats, v.DeletedContacts, v.DeletedGroups, v.DeletedParticipants, v.DeletedMessages, v.MessageRevisions, formatTime(v.OldestMessage), formatTime(v.NewestMessage), formatTime(v.LastImportAt), v.LastSource)
 		return err
 	case []store.Chat:
 		tw := tabwriter.NewWriter(a.stdout, 2, 4, 2, ' ', 0)
@@ -643,6 +648,8 @@ Options:
 
 Import flags:
   --copy-media              Copy referenced media files into the archive media directory.
+  --adopt-source            Bind an existing unverified archive to this account and merge.
+  --restore                 Exactly replace archive rows instead of merging.
 
 Examples:
   wacrawl doctor
@@ -685,17 +692,21 @@ Examples:
 		_, _ = fmt.Fprintf(w, `Snapshot WhatsApp Desktop SQLite data into the archive.
 
 Usage:
-  wacrawl %s [--source PATH] [--copy-media]
+  wacrawl %s [--source PATH] [--copy-media] [--adopt-source] [--restore]
 
 Flags:
   --source PATH   WhatsApp Desktop source path.
   --copy-media    Copy referenced media files into media/ next to the archive DB.
+  --adopt-source  Bind an existing unverified archive to this account and merge.
+  --restore       Exactly replace archive rows instead of merging.
 
 Examples:
   wacrawl %s
   wacrawl %s --copy-media
+  wacrawl %s --adopt-source
+  wacrawl %s --restore
   wacrawl --db /tmp/wacrawl.db %s
-`, name, name, name, name)
+`, name, name, name, name, name, name)
 	case "status":
 		_, _ = fmt.Fprint(w, `Show archive status, counts, date span, unread counts, and last import metadata.
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -60,6 +60,139 @@ func TestRunEndToEnd(t *testing.T) {
 	}
 }
 
+func TestRunImportMergesByDefaultAndRestoreReplaces(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createDesktopFixture(t, source)
+	dbPath := filepath.Join(t.TempDir(), "archive.db")
+	var stdout, stderr bytes.Buffer
+	if err := Run(ctx, []string{"--db", dbPath, "--source", source, "import", "--restore", "--adopt-source"}, &stdout, &stderr); err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("restore/adopt conflict = %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"--db", dbPath, "--source", source, "import"}, &stdout, &stderr); err != nil {
+		t.Fatalf("initial import: %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "mode=merge") {
+		t.Fatalf("initial import mode: %s", stdout.String())
+	}
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 18, 15, 0, 0, 0, time.UTC)
+	var sourceIdentity, sourceStoreIdentity, accountIdentity string
+	if err := st.DB().QueryRowContext(ctx, `select value from sync_state where key='merge_source_path'`).Scan(&sourceIdentity); err != nil {
+		t.Fatal(err)
+	}
+	existing, err := st.MessageBySourcePK(ctx, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select value from sync_state where key='merge_account_identity'`).Scan(&accountIdentity); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select value from sync_state where key='merge_source_store_identity'`).Scan(&sourceStoreIdentity); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MergeAll(ctx, store.ImportStats{SourcePath: source, SourceIdentity: sourceIdentity, SourceStoreIdentity: sourceStoreIdentity, AccountIdentity: accountIdentity, FinishedAt: now, Messages: 2}, nil,
+		[]store.Chat{{JID: "historical", Kind: "dm"}}, nil, nil,
+		[]store.Message{existing, {SourcePK: 99, ChatJID: "historical", MessageID: "historical", Timestamp: now, Text: "retained history", RawType: 0}}); err != nil {
+		_ = st.Close()
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"--db", dbPath, "--source", source, "sync"}, &stdout, &stderr); err != nil {
+		t.Fatalf("merge sync: %v stderr=%s", err, stderr.String())
+	}
+	st, err = store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		_ = st.Close()
+		t.Fatal(err)
+	}
+	if status.Messages != 4 {
+		_ = st.Close()
+		t.Fatalf("default merge messages = %d", status.Messages)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"--db", dbPath, "--source", source, "import", "--restore"}, &stdout, &stderr); err != nil {
+		t.Fatalf("restore import: %v stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "mode=restore") {
+		t.Fatalf("restore import mode: %s", stdout.String())
+	}
+	st, err = store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	status, err = st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Messages != 3 {
+		t.Fatalf("exact restore messages = %d", status.Messages)
+	}
+}
+
+func TestRunImportAdoptsLegacyArchiveExplicitly(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createDesktopFixture(t, source)
+	dbPath := filepath.Join(t.TempDir(), "legacy.db")
+	st, err := store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 18, 15, 0, 0, 0, time.UTC)
+	legacy := store.Message{SourcePK: 99, ChatJID: "legacy", MessageID: "legacy", Timestamp: now, Text: "retained legacy history", RawType: 0}
+	if err := st.ReplaceAll(ctx, store.ImportStats{SourcePath: "backup:legacy", FinishedAt: now, Messages: 1}, nil,
+		[]store.Chat{{JID: legacy.ChatJID, Kind: "dm"}}, nil, nil, []store.Message{legacy}); err != nil {
+		_ = st.Close()
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := Run(ctx, []string{"--db", dbPath, "--source", source, "import"}, &stdout, &stderr); err == nil || !strings.Contains(err.Error(), "--adopt-source") {
+		t.Fatalf("unverified import error = %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if err := Run(ctx, []string{"--db", dbPath, "--source", source, "import", "--adopt-source"}, &stdout, &stderr); err != nil {
+		t.Fatalf("adopt source: %v stderr=%s", err, stderr.String())
+	}
+	st, err = store.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	if _, err := st.MessageBySourcePK(ctx, legacy.SourcePK); err != nil {
+		t.Fatalf("adoption dropped legacy history: %v", err)
+	}
+	var accountBinding string
+	if err := st.DB().QueryRowContext(ctx, `select value from sync_state where key='merge_account_identity'`).Scan(&accountBinding); err != nil || !strings.HasPrefix(accountBinding, "wa-account:") {
+		t.Fatalf("account binding = %q, %v", accountBinding, err)
+	}
+}
+
 func TestRunRelativeAndAbsolutePathContracts(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -715,24 +848,57 @@ func TestSyncArchiveKeepsExistingArchiveWhenSourceUnavailable(t *testing.T) {
 
 func TestSyncDecisionHelpers(t *testing.T) {
 	now := time.Now().UTC()
-	status := store.Status{Messages: 3, NewestMessage: now, LastImportAt: now.Add(-time.Hour)}
+	status := store.Status{Messages: 3, NewestMessage: now, NewestObserved: now, LastImportAt: now.Add(-time.Hour)}
 	if !archiveNeedsSyncCheck(status, 15*time.Minute) {
 		t.Fatal("old import should need sync check")
 	}
 	if archiveNeedsSyncCheck(status, -1) {
 		t.Fatal("negative max age should disable auto checks")
 	}
-	if !sourceAheadOfArchive(whatsappdb.Source{MessageRows: 3, NewestMessage: now.Add(time.Second).Format(time.RFC3339)}, status) {
+	if !sourceAheadOfArchive(whatsappdb.Source{MessageRows: 3, MessageRowsKnown: true, NewestMessage: now.Add(time.Second).Format(time.RFC3339)}, status) {
 		t.Fatal("newer source timestamp should be ahead")
 	}
-	if !sourceAheadOfArchive(whatsappdb.Source{MessageRows: 4, NewestMessage: now.Format(time.RFC3339)}, status) {
+	if !sourceAheadOfArchive(whatsappdb.Source{MessageRows: 4, MessageRowsKnown: true, NewestMessage: now.Format(time.RFC3339)}, status) {
 		t.Fatal("different source row count should be ahead")
 	}
-	if sourceAheadOfArchive(whatsappdb.Source{MessageRows: 3, NewestMessage: now.Format(time.RFC3339)}, status) {
+	if sourceAheadOfArchive(whatsappdb.Source{MessageRows: 3, MessageRowsKnown: true, NewestMessage: now.Format(time.RFC3339)}, status) {
 		t.Fatal("equal source should not be ahead")
 	}
-	if sourceAheadOfArchive(whatsappdb.Source{MessageRows: 3, NewestMessage: "not-time"}, status) {
+	chatDB := filepath.Join(t.TempDir(), "ChatStorage.sqlite")
+	if err := os.WriteFile(chatDB, []byte("changed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(chatDB, now, now); err != nil {
+		t.Fatal(err)
+	}
+	if !sourceAheadOfArchive(whatsappdb.Source{ChatDB: chatDB, MessageRows: 3, MessageRowsKnown: true, NewestMessage: now.Format(time.RFC3339)}, status) {
+		t.Fatal("in-place ChatStorage change should be ahead")
+	}
+	snapshotStatus := status
+	snapshotStatus.LastImportAt = now.Add(time.Hour)
+	snapshotStatus.LastSourceSnapshot = now.Add(-time.Hour)
+	if !sourceAheadOfArchive(whatsappdb.Source{ChatDB: chatDB, MessageRows: 3, MessageRowsKnown: true, NewestMessage: now.Format(time.RFC3339)}, snapshotStatus) {
+		t.Fatal("source snapshot watermark should cover changes before import completion")
+	}
+	if sourceAheadOfArchive(whatsappdb.Source{MessageRows: 3, MessageRowsKnown: true, NewestMessage: "not-time"}, status) {
 		t.Fatal("invalid source timestamp should not be ahead")
+	}
+	tombstoneOnly := status
+	tombstoneOnly.Messages = 0
+	tombstoneOnly.DeletedMessages = 3
+	if sourceAheadOfArchive(whatsappdb.Source{MessageRows: 3, MessageRowsKnown: true, NewestMessage: now.Format(time.RFC3339)}, tombstoneOnly) {
+		t.Fatal("tombstone-only archive should not be treated as uninitialized")
+	}
+	tombstoneOnly.NewestMessage = time.Time{}
+	tombstoneOnly.NewestObserved = now
+	if sourceAheadOfArchive(whatsappdb.Source{MessageRows: 3, MessageRowsKnown: true, NewestMessage: now.Format(time.RFC3339)}, tombstoneOnly) {
+		t.Fatal("tombstoned newest message should use the observed watermark")
+	}
+	recordedZero := status
+	recordedZero.LastSourceMessages = 0
+	recordedZero.SourceMessagesKnown = true
+	if !sourceAheadOfArchive(whatsappdb.Source{MessageRows: 3, MessageRowsKnown: true, NewestMessage: now.Format(time.RFC3339)}, recordedZero) {
+		t.Fatal("recorded zero source count should not fall back to archive totals")
 	}
 	if !sourceAheadOfArchive(whatsappdb.Source{}, store.Status{}) {
 		t.Fatal("empty archive should sync")
@@ -800,6 +966,8 @@ create table ZWAGROUPINFO (Z_PK integer primary key, ZCHATSESSION integer, ZOWNE
 create table ZWAGROUPMEMBER (Z_PK integer primary key, ZCHATSESSION integer, ZMEMBERJID varchar, ZCONTACTNAME varchar, ZFIRSTNAME varchar, ZISADMIN integer, ZISACTIVE integer);
 create table ZWAMEDIAITEM (Z_PK integer primary key, ZMESSAGE integer, ZMEDIALOCALPATH varchar, ZMEDIAURL varchar, ZTITLE varchar, ZVCARDNAME varchar, ZFILESIZE integer);
 create table ZWAMESSAGE (Z_PK integer primary key, ZCHATSESSION integer, ZGROUPMEMBER integer, ZMEDIAITEM integer, ZSTANZAID varchar, ZISFROMME integer, ZMESSAGEDATE timestamp, ZTEXT varchar, ZMESSAGETYPE integer, ZSTARRED integer, ZFROMJID varchar, ZTOJID varchar, ZPUSHNAME varchar);
+create table Z_METADATA (Z_VERSION integer primary key, Z_UUID varchar(255), Z_PLIST blob);
+insert into Z_METADATA values (1, 'cli-fixture-account', null);
 insert into ZWACHATSESSION values (1, '111@s.whatsapp.net', 'Bob', 700000020, 0, 0, 0, 0, 0);
 insert into ZWACHATSESSION values (2, '123@g.us', 'Launch Group', 700000010, 2, 0, 0, 0, 1);
 insert into ZWAGROUPINFO values (1, 2, 'owner@s.whatsapp.net', 699999000);
@@ -818,6 +986,15 @@ insert into ZWAMESSAGE values (3, 2, 1, 1, 'group-image', 0, 700000002, 'launch 
 create table ZWAADDRESSBOOKCONTACT (ZWHATSAPPID varchar, ZPHONENUMBER varchar, ZFULLNAME varchar, ZGIVENNAME varchar, ZLASTNAME varchar, ZBUSINESSNAME varchar, ZUSERNAME varchar, ZLID varchar, ZABOUTTEXT varchar, ZLASTUPDATED timestamp);
 insert into ZWAADDRESSBOOKCONTACT values ('111@s.whatsapp.net', '+111', 'Bob', 'Bob', '', '', '', '', '', 700000000);
 insert into ZWAADDRESSBOOKCONTACT values ('222@s.whatsapp.net', '+222', 'Alice Contact', 'Alice', '', '', '', '222', '', 700000000);
+`)
+	axolotl, err := sql.Open("sqlite", filepath.Join(dir, "Axolotl.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = axolotl.Close() }()
+	mustExec(t, axolotl, `
+create table ZWAZMDACCOUNT (Z_PK integer primary key, ZACCOUNTJIDSTRING varchar, ZUSERJIDSTRING varchar);
+insert into ZWAZMDACCOUNT values (1, 'cli-owner@s.whatsapp.net', 'cli-owner@s.whatsapp.net');
 `)
 	mediaPath := filepath.Join(dir, "Media", "123@g.us", "a", "test.jpg")
 	if err := os.MkdirAll(filepath.Dir(mediaPath), 0o700); err != nil {

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -82,16 +82,31 @@ func archiveNeedsSyncCheck(status store.Status, maxAge time.Duration) bool {
 }
 
 func sourceAheadOfArchive(source whatsappdb.Source, status store.Status) bool {
-	if status.LastImportAt.IsZero() || status.Messages == 0 {
+	if status.LastImportAt.IsZero() {
 		return true
 	}
-	if source.MessageRows != 0 && source.MessageRows != status.Messages {
+	lastMessages := status.LastSourceMessages
+	if !status.SourceMessagesKnown {
+		lastMessages = status.Messages + status.DeletedMessages
+	}
+	if source.MessageRowsKnown && source.MessageRows != lastMessages {
 		return true
 	}
-	if source.ContactRows != 0 && source.ContactRows != status.Contacts {
+	lastContacts := status.LastSourceContacts
+	if !status.SourceContactsKnown {
+		lastContacts = status.Contacts + status.DeletedContacts
+	}
+	if source.ContactRowsKnown && source.ContactRows != lastContacts {
 		return true
 	}
-	if cache.SQLiteModifiedAfter(source.ContactsDB, status.LastImportAt) {
+	snapshotAt := status.LastSourceSnapshot
+	if snapshotAt.IsZero() {
+		snapshotAt = status.LastImportAt
+	}
+	if cache.SQLiteModifiedAfter(source.ContactsDB, snapshotAt) {
+		return true
+	}
+	if cache.SQLiteModifiedAfter(source.ChatDB, snapshotAt) {
 		return true
 	}
 	if strings.TrimSpace(source.NewestMessage) == "" {
@@ -101,7 +116,11 @@ func sourceAheadOfArchive(source whatsappdb.Source, status store.Status) bool {
 	if err != nil {
 		return false
 	}
-	return sourceNewest.After(status.NewestMessage)
+	watermark := status.LastSourceNewest
+	if watermark.IsZero() {
+		watermark = status.NewestObserved
+	}
+	return sourceNewest.After(watermark)
 }
 
 func (a *app) warnSync(format string, args ...any) {

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -14,6 +14,7 @@ type SnapshotData struct {
 	Groups       []Group
 	Participants []GroupParticipant
 	Messages     []Message
+	Revisions    []MessageRevision
 }
 
 func (d SnapshotData) ImportStats(sourcePath, dbPath string, finishedAt time.Time) ImportStats {
@@ -57,19 +58,54 @@ func (s *Store) ExportAll(ctx context.Context) (SnapshotData, error) {
 	if err != nil {
 		return SnapshotData{}, err
 	}
-	messages, err := s.Messages(ctx, MessageFilter{Limit: int(^uint(0) >> 1), Asc: true})
+	messages, err := s.Messages(ctx, MessageFilter{Limit: int(^uint(0) >> 1), Asc: true, IncludeDeleted: true})
 	if err != nil {
 		return SnapshotData{}, err
 	}
-	return SnapshotData{Contacts: contacts, Chats: chats, Groups: groups, Participants: participants, Messages: messages}, nil
+	revisions, err := s.exportMessageRevisions(ctx)
+	if err != nil {
+		return SnapshotData{}, err
+	}
+	return SnapshotData{Contacts: contacts, Chats: chats, Groups: groups, Participants: participants, Messages: messages, Revisions: revisions}, nil
 }
 
 func (s *Store) Contacts(ctx context.Context) ([]Contact, error) {
-	return s.exportContacts(ctx)
+	contacts, err := s.exportContacts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	live := contacts[:0]
+	for _, contact := range contacts {
+		if contact.DeletedAt.IsZero() {
+			live = append(live, contact)
+		}
+	}
+	return live, nil
 }
 
 func (s *Store) ImportSnapshot(ctx context.Context, data SnapshotData, sourcePath string, finishedAt time.Time) error {
-	return s.ReplaceAll(ctx, data.ImportStats(sourcePath, s.Path(), finishedAt), data.Contacts, data.Chats, data.Groups, data.Participants, data.Messages)
+	stats := data.ImportStats(sourcePath, s.Path(), finishedAt)
+	stats.Mode = "restore"
+	return s.importAll(ctx, true, stats, data.Contacts, data.Chats, data.Groups, data.Participants, data.Messages, data.Revisions)
+}
+
+func (s *Store) exportMessageRevisions(ctx context.Context) ([]MessageRevision, error) {
+	rows, err := s.db.QueryContext(ctx, `select event_id,payload_json,recorded_at,event_source,reason from message_revisions order by id`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []MessageRevision
+	for rows.Next() {
+		var revision MessageRevision
+		var recordedAt int64
+		if err := rows.Scan(&revision.EventID, &revision.PayloadJSON, &recordedAt, &revision.EventSource, &revision.Reason); err != nil {
+			return nil, err
+		}
+		revision.RecordedAt = fromUnix(recordedAt)
+		out = append(out, revision)
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) exportContacts(ctx context.Context) ([]Contact, error) {
@@ -122,6 +158,7 @@ func (s *Store) exportParticipants(ctx context.Context) ([]GroupParticipant, err
 
 func (d SnapshotData) Validate() error {
 	seen := map[int64]struct{}{}
+	events := map[string]struct{}{}
 	for _, message := range d.Messages {
 		if message.SourcePK == 0 {
 			return fmt.Errorf("message with empty source_pk")
@@ -130,12 +167,29 @@ func (d SnapshotData) Validate() error {
 			return fmt.Errorf("duplicate message source_pk %d", message.SourcePK)
 		}
 		seen[message.SourcePK] = struct{}{}
+		eventID := message.EventID
+		if eventID == "" {
+			eventID = messageEventID(message.SourcePK)
+		}
+		if _, ok := events[eventID]; ok {
+			return fmt.Errorf("duplicate message event_id %q", eventID)
+		}
+		events[eventID] = struct{}{}
+	}
+	for _, revision := range d.Revisions {
+		if _, ok := events[revision.EventID]; !ok {
+			return fmt.Errorf("message revision references unknown event_id %q", revision.EventID)
+		}
+		if revision.PayloadJSON == "" || revision.EventSource == "" || revision.Reason == "" {
+			return fmt.Errorf("message revision %q is incomplete", revision.EventID)
+		}
 	}
 	return nil
 }
 
 func contactFromRow(row storedb.ExportContactsRow) Contact {
 	return Contact{
+		Tombstone:    Tombstone{DeletedAt: fromUnix(row.DeletedAt), DeletionSource: row.DeletionSource, DeletionReason: row.DeletionReason, LastSeenAt: fromUnix(row.LastSeenAt)},
 		JID:          row.Jid,
 		Phone:        row.Phone,
 		FullName:     row.FullName,
@@ -151,6 +205,7 @@ func contactFromRow(row storedb.ExportContactsRow) Contact {
 
 func exportChatFromRow(row storedb.ExportChatsRow) Chat {
 	return Chat{
+		Tombstone:      Tombstone{DeletedAt: fromUnix(row.DeletedAt), DeletionSource: row.DeletionSource, DeletionReason: row.DeletionReason, LastSeenAt: fromUnix(row.LastSeenAt)},
 		JID:            row.Jid,
 		Kind:           row.Kind,
 		Name:           row.Name,
@@ -165,6 +220,7 @@ func exportChatFromRow(row storedb.ExportChatsRow) Chat {
 
 func groupFromRow(row storedb.ExportGroupsRow) Group {
 	return Group{
+		Tombstone: Tombstone{DeletedAt: fromUnix(row.DeletedAt), DeletionSource: row.DeletionSource, DeletionReason: row.DeletionReason, LastSeenAt: fromUnix(row.LastSeenAt)},
 		JID:       row.Jid,
 		Name:      row.Name,
 		OwnerJID:  row.OwnerJid,
@@ -174,6 +230,7 @@ func groupFromRow(row storedb.ExportGroupsRow) Group {
 
 func participantFromRow(row storedb.ExportParticipantsRow) GroupParticipant {
 	return GroupParticipant{
+		Tombstone:   Tombstone{DeletedAt: fromUnix(row.DeletedAt), DeletionSource: row.DeletionSource, DeletionReason: row.DeletionReason, LastSeenAt: fromUnix(row.LastSeenAt)},
 		GroupJID:    row.GroupJid,
 		UserJID:     row.UserJid,
 		ContactName: row.ContactName,

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -2,19 +2,24 @@ package store
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/openclaw/wacrawl/internal/store/storedb"
 )
 
 type SnapshotData struct {
-	Contacts     []Contact
-	Chats        []Chat
-	Groups       []Group
-	Participants []GroupParticipant
-	Messages     []Message
-	Revisions    []MessageRevision
+	Contacts            []Contact
+	Chats               []Chat
+	Groups              []Group
+	Participants        []GroupParticipant
+	Messages            []Message
+	Revisions           []MessageRevision
+	SourceStoreIdentity string `json:"source_store_identity,omitempty"`
+	AccountIdentity     string `json:"account_identity,omitempty"`
 }
 
 func (d SnapshotData) ImportStats(sourcePath, dbPath string, finishedAt time.Time) ImportStats {
@@ -28,16 +33,18 @@ func (d SnapshotData) ImportStats(sourcePath, dbPath string, finishedAt time.Tim
 		}
 	}
 	return ImportStats{
-		SourcePath:    sourcePath,
-		DBPath:        dbPath,
-		Chats:         len(d.Chats),
-		Contacts:      len(d.Contacts),
-		Groups:        len(d.Groups),
-		Participants:  len(d.Participants),
-		Messages:      len(d.Messages),
-		MediaMessages: mediaMessages,
-		StartedAt:     finishedAt,
-		FinishedAt:    finishedAt,
+		SourcePath:          sourcePath,
+		SourceStoreIdentity: d.SourceStoreIdentity,
+		AccountIdentity:     d.AccountIdentity,
+		DBPath:              dbPath,
+		Chats:               len(d.Chats),
+		Contacts:            len(d.Contacts),
+		Groups:              len(d.Groups),
+		Participants:        len(d.Participants),
+		Messages:            len(d.Messages),
+		MediaMessages:       mediaMessages,
+		StartedAt:           finishedAt,
+		FinishedAt:          finishedAt,
 	}
 }
 
@@ -66,7 +73,30 @@ func (s *Store) ExportAll(ctx context.Context) (SnapshotData, error) {
 	if err != nil {
 		return SnapshotData{}, err
 	}
-	return SnapshotData{Contacts: contacts, Chats: chats, Groups: groups, Participants: participants, Messages: messages, Revisions: revisions}, nil
+	sourceStoreIdentity, err := s.syncStateValue(ctx, "merge_source_store_identity")
+	if err != nil {
+		return SnapshotData{}, err
+	}
+	accountIdentity, err := s.syncStateValue(ctx, "merge_account_identity")
+	if err != nil {
+		return SnapshotData{}, err
+	}
+	if strings.HasPrefix(accountIdentity, "wa-store:") {
+		if sourceStoreIdentity == "" {
+			sourceStoreIdentity = accountIdentity
+		}
+		accountIdentity = ""
+	}
+	return SnapshotData{Contacts: contacts, Chats: chats, Groups: groups, Participants: participants, Messages: messages, Revisions: revisions, SourceStoreIdentity: sourceStoreIdentity, AccountIdentity: accountIdentity}, nil
+}
+
+func (s *Store) syncStateValue(ctx context.Context, key string) (string, error) {
+	var value string
+	err := s.db.QueryRowContext(ctx, `select value from sync_state where key=?`, key).Scan(&value)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return value, err
 }
 
 func (s *Store) Contacts(ctx context.Context) ([]Contact, error) {
@@ -157,6 +187,12 @@ func (s *Store) exportParticipants(ctx context.Context) ([]GroupParticipant, err
 }
 
 func (d SnapshotData) Validate() error {
+	if d.AccountIdentity != "" && !strings.HasPrefix(d.AccountIdentity, "wa-account:") {
+		return errors.New("invalid WhatsApp account identity")
+	}
+	if d.SourceStoreIdentity != "" && !strings.HasPrefix(d.SourceStoreIdentity, "wa-store:") {
+		return errors.New("invalid WhatsApp source-store identity")
+	}
 	seen := map[int64]struct{}{}
 	events := map[string]struct{}{}
 	for _, message := range d.Messages {

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -12,7 +12,11 @@ create table if not exists chats (
 	archived integer not null default 0,
 	removed integer not null default 0,
 	hidden integer not null default 0,
-	raw_session_type integer not null default 0
+	raw_session_type integer not null default 0,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
+	last_seen_at integer not null default 0
 );
 
 create table if not exists contacts (
@@ -25,14 +29,22 @@ create table if not exists contacts (
 	username text,
 	lid text,
 	about_text text,
-	updated_at integer
+	updated_at integer,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
+	last_seen_at integer not null default 0
 );
 
 create table if not exists groups (
 	jid text primary key,
 	name text,
 	owner_jid text,
-	created_at integer
+	created_at integer,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
+	last_seen_at integer not null default 0
 );
 
 create table if not exists group_participants (
@@ -42,12 +54,17 @@ create table if not exists group_participants (
 	first_name text,
 	is_admin integer not null default 0,
 	is_active integer not null default 0,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
+	last_seen_at integer not null default 0,
 	primary key (group_jid, user_jid)
 );
 
 create table if not exists messages (
 	rowid integer primary key autoincrement,
 	source_pk integer not null unique,
+	event_id text not null,
 	chat_jid text not null,
 	chat_name text,
 	msg_id text not null,
@@ -63,7 +80,11 @@ create table if not exists messages (
 	media_path text,
 	media_url text,
 	media_size integer,
-	starred integer not null default 0
+	starred integer not null default 0,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
+	last_seen_at integer not null default 0
 );
 
 create index if not exists idx_messages_chat_ts on messages(chat_jid, ts);
@@ -72,6 +93,17 @@ create index if not exists idx_messages_ts on messages(ts);
 create index if not exists idx_messages_sender on messages(sender_jid);
 
 create virtual table if not exists messages_fts using fts5(text, chat, sender, media);
+
+create table if not exists message_revisions (
+	id integer primary key autoincrement,
+	event_id text not null,
+	payload_json text not null,
+	recorded_at integer not null,
+	event_source text not null,
+	reason text not null
+);
+
+create index if not exists idx_message_revisions_event on message_revisions(event_id, recorded_at desc, id desc);
 
 create table if not exists sync_state (
 	key text primary key,

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -1,32 +1,33 @@
 -- name: CountChats :one
-select count(*) from chats;
+select count(*) from chats where deleted_at is null;
 
 -- name: CountUnreadChats :one
-select count(*) from chats where unread_count > 0;
+select count(*) from chats where deleted_at is null and unread_count > 0;
 
 -- name: CountUnreadMessages :one
-select cast(coalesce(sum(unread_count), 0) as integer) as unread_messages from chats;
+select cast(coalesce(sum(unread_count), 0) as integer) as unread_messages from chats where deleted_at is null;
 
 -- name: CountContacts :one
-select count(*) from contacts;
+select count(*) from contacts where deleted_at is null;
 
 -- name: CountGroups :one
-select count(*) from groups;
+select count(*) from groups where deleted_at is null;
 
 -- name: CountParticipants :one
-select count(*) from group_participants;
+select count(*) from group_participants where deleted_at is null;
 
 -- name: CountMessages :one
-select count(*) from messages;
+select count(*) from messages where deleted_at is null;
 
 -- name: CountMediaMessages :one
-select count(*) from messages where media_type <> '' or media_path <> '' or media_url <> '';
+select count(*) from messages where deleted_at is null and (media_type <> '' or media_path <> '' or media_url <> '');
 
 -- name: GetMessageTimeBounds :one
 select
 	cast(coalesce(min(case when ts > 0 and ts <= 253402300799 then ts end), 0) as integer) as oldest_ts,
 	cast(coalesce(max(case when ts > 0 and ts <= 253402300799 then ts end), 0) as integer) as newest_ts
-from messages;
+from messages
+where deleted_at is null;
 
 -- name: GetSyncState :one
 select value from sync_state where key = sqlc.arg(key);
@@ -44,7 +45,8 @@ select
 	c.raw_session_type,
 	count(m.rowid) as message_count
 from chats c
-left join messages m on m.chat_jid = c.jid
+left join messages m on m.chat_jid = c.jid and m.deleted_at is null
+where c.deleted_at is null
 group by c.jid, c.kind, c.name, c.last_message_at, c.unread_count, c.archived, c.removed, c.hidden, c.raw_session_type
 order by case when c.last_message_at > 0 and c.last_message_at <= 253402300799 then c.last_message_at else 0 end desc
 limit sqlc.arg(limit);
@@ -62,8 +64,8 @@ select
 	c.raw_session_type,
 	count(m.rowid) as message_count
 from chats c
-left join messages m on m.chat_jid = c.jid
-where c.unread_count > 0
+left join messages m on m.chat_jid = c.jid and m.deleted_at is null
+where c.deleted_at is null and c.unread_count > 0
 group by c.jid, c.kind, c.name, c.last_message_at, c.unread_count, c.archived, c.removed, c.hidden, c.raw_session_type
 order by case when c.last_message_at > 0 and c.last_message_at <= 253402300799 then c.last_message_at else 0 end desc
 limit sqlc.arg(limit);
@@ -79,7 +81,11 @@ select
 	coalesce(username, '') as username,
 	coalesce(lid, '') as lid,
 	coalesce(about_text, '') as about_text,
-	coalesce(updated_at, 0) as updated_at
+	coalesce(updated_at, 0) as updated_at,
+	coalesce(deleted_at, 0) as deleted_at,
+	coalesce(deletion_source, '') as deletion_source,
+	coalesce(deletion_reason, '') as deletion_reason,
+	last_seen_at
 from contacts
 order by jid;
 
@@ -93,7 +99,11 @@ select
 	archived,
 	removed,
 	hidden,
-	raw_session_type
+	raw_session_type,
+	coalesce(deleted_at, 0) as deleted_at,
+	coalesce(deletion_source, '') as deletion_source,
+	coalesce(deletion_reason, '') as deletion_reason,
+	last_seen_at
 from chats
 order by jid;
 
@@ -102,7 +112,11 @@ select
 	jid,
 	coalesce(name, '') as name,
 	coalesce(owner_jid, '') as owner_jid,
-	coalesce(created_at, 0) as created_at
+	coalesce(created_at, 0) as created_at,
+	coalesce(deleted_at, 0) as deleted_at,
+	coalesce(deletion_source, '') as deletion_source,
+	coalesce(deletion_reason, '') as deletion_reason,
+	last_seen_at
 from groups
 order by jid;
 
@@ -113,7 +127,11 @@ select
 	coalesce(contact_name, '') as contact_name,
 	coalesce(first_name, '') as first_name,
 	is_admin,
-	is_active
+	is_active,
+	coalesce(deleted_at, 0) as deleted_at,
+	coalesce(deletion_source, '') as deletion_source,
+	coalesce(deletion_reason, '') as deletion_reason,
+	last_seen_at
 from group_participants
 order by group_jid, user_jid;
 
@@ -155,8 +173,8 @@ insert into group_participants(group_jid, user_jid, contact_name, first_name, is
 values(sqlc.arg(group_jid), sqlc.arg(user_jid), sqlc.arg(contact_name), sqlc.arg(first_name), sqlc.arg(is_admin), sqlc.arg(is_active));
 
 -- name: InsertMessage :exec
-insert into messages(source_pk, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
-values(sqlc.arg(source_pk), sqlc.arg(chat_jid), sqlc.arg(chat_name), sqlc.arg(msg_id), sqlc.arg(sender_jid), sqlc.arg(sender_name), sqlc.arg(ts), sqlc.arg(from_me), sqlc.arg(text), sqlc.arg(raw_type), sqlc.arg(message_type), sqlc.arg(media_type), sqlc.arg(media_title), sqlc.arg(media_path), sqlc.arg(media_url), sqlc.arg(media_size), sqlc.arg(starred));
+insert into messages(source_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
+values(sqlc.arg(source_pk), sqlc.arg(event_id), sqlc.arg(chat_jid), sqlc.arg(chat_name), sqlc.arg(msg_id), sqlc.arg(sender_jid), sqlc.arg(sender_name), sqlc.arg(ts), sqlc.arg(from_me), sqlc.arg(text), sqlc.arg(raw_type), sqlc.arg(message_type), sqlc.arg(media_type), sqlc.arg(media_title), sqlc.arg(media_path), sqlc.arg(media_url), sqlc.arg(media_size), sqlc.arg(starred));
 
 -- name: InsertMessageFTS :exec
 insert into messages_fts(rowid, text, chat, sender, media)

--- a/internal/store/sqlc/schema.sql
+++ b/internal/store/sqlc/schema.sql
@@ -10,7 +10,11 @@ create table chats (
 	archived integer not null default 0,
 	removed integer not null default 0,
 	hidden integer not null default 0,
-	raw_session_type integer not null default 0
+	raw_session_type integer not null default 0,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
+	last_seen_at integer not null default 0
 );
 
 create table contacts (
@@ -23,14 +27,22 @@ create table contacts (
 	username text,
 	lid text,
 	about_text text,
-	updated_at integer
+	updated_at integer,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
+	last_seen_at integer not null default 0
 );
 
 create table groups (
 	jid text primary key,
 	name text,
 	owner_jid text,
-	created_at integer
+	created_at integer,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
+	last_seen_at integer not null default 0
 );
 
 create table group_participants (
@@ -40,12 +52,17 @@ create table group_participants (
 	first_name text,
 	is_admin integer not null default 0,
 	is_active integer not null default 0,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
+	last_seen_at integer not null default 0,
 	primary key (group_jid, user_jid)
 );
 
 create table messages (
 	rowid integer primary key autoincrement,
 	source_pk integer not null unique,
+	event_id text not null,
 	chat_jid text not null,
 	chat_name text,
 	msg_id text not null,
@@ -61,7 +78,11 @@ create table messages (
 	media_path text,
 	media_url text,
 	media_size integer,
-	starred integer not null default 0
+	starred integer not null default 0,
+	deleted_at integer,
+	deletion_source text,
+	deletion_reason text,
+	last_seen_at integer not null default 0
 );
 
 create index idx_messages_chat_ts on messages(chat_jid, ts);
@@ -78,6 +99,17 @@ create table messages_fts (
 	sender text,
 	media text
 );
+
+create table message_revisions (
+	id integer primary key autoincrement,
+	event_id text not null,
+	payload_json text not null,
+	recorded_at integer not null,
+	event_source text not null,
+	reason text not null
+);
+
+create index idx_message_revisions_event on message_revisions(event_id, recorded_at desc, id desc);
 
 create table sync_state (
 	key text primary key,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -181,10 +181,11 @@ type MessageFilter struct {
 	// ts < Before, or ts == Before with source_pk < BeforePK. Without it,
 	// paging by timestamp alone can stall when a page boundary lands inside
 	// a run of messages that share the same second.
-	BeforePK int64
-	FromMe   *bool
-	HasMedia bool
-	Asc      bool
+	BeforePK       int64
+	FromMe         *bool
+	HasMedia       bool
+	Asc            bool
+	IncludeDeleted bool
 	// SnippetStart and SnippetEnd wrap search matches inside snippets.
 	// Both default to the CLI-friendly "[" and "]" markers.
 	SnippetStart string
@@ -243,124 +244,138 @@ func (s *Store) Path() string {
 }
 
 func (s *Store) migrate(ctx context.Context) error {
-	if _, err := s.db.ExecContext(ctx, schemaSQL); err != nil {
-		return fmt.Errorf("migrate schema: %w", err)
+	var current int
+	if err := s.db.QueryRowContext(ctx, "pragma user_version").Scan(&current); err != nil {
+		return fmt.Errorf("read schema version: %w", err)
 	}
-	if _, err := s.db.ExecContext(ctx, fmt.Sprintf("pragma user_version = %d", schemaVersion)); err != nil {
-		return fmt.Errorf("set schema version: %w", err)
+	if current > schemaVersion {
+		return fmt.Errorf("database schema version %d is newer than this wacrawl build supports (%d)", current, schemaVersion)
 	}
-	return nil
-}
-
-func (s *Store) ReplaceAll(ctx context.Context, stats ImportStats, contacts []Contact, chats []Chat, groups []Group, participants []GroupParticipant, messages []Message) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer rollback(tx)
-	q := s.q.WithTx(tx)
+	if _, err := tx.ExecContext(ctx, schemaSQL); err != nil {
+		return fmt.Errorf("migrate schema: %w", err)
+	}
+	for _, table := range []string{"contacts", "chats", "groups", "group_participants", "messages"} {
+		for _, column := range []struct{ name, definition string }{
+			{"deleted_at", "integer"},
+			{"deletion_source", "text"},
+			{"deletion_reason", "text"},
+			{"last_seen_at", "integer not null default 0"},
+		} {
+			if err := ensureColumn(ctx, tx, table, column.name, column.definition); err != nil {
+				return err
+			}
+		}
+	}
+	if err := ensureColumn(ctx, tx, "messages", "event_id", "text"); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `update messages set event_id = printf('wa:%lld', source_pk) where event_id is null or trim(event_id) = ''`); err != nil {
+		return fmt.Errorf("backfill message event identity: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `create unique index if not exists idx_messages_event_id on messages(event_id)`); err != nil {
+		return fmt.Errorf("index message event identity: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+create trigger if not exists messages_event_id_required_insert
+before insert on messages when new.event_id is null or trim(new.event_id) = ''
+begin select raise(abort, 'messages.event_id is required'); end;
+create trigger if not exists messages_event_id_required_update
+before update of event_id on messages when new.event_id is null or trim(new.event_id) = ''
+begin select raise(abort, 'messages.event_id is required'); end;`); err != nil {
+		return fmt.Errorf("enforce message event identity: %w", err)
+	}
+	for _, table := range []string{"contacts", "chats", "groups", "group_participants", "messages"} {
+		statement := fmt.Sprintf(`update %s set last_seen_at = coalesce((select max(updated_at) from sync_state), 0) where last_seen_at = 0`, table) // #nosec G201 -- table is from the fixed list above.
+		if _, err := tx.ExecContext(ctx, statement); err != nil {                                                                                    //nolint:gosec // table is from the fixed list above.
+			return fmt.Errorf("backfill %s last_seen_at: %w", table, err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("pragma user_version = %d", schemaVersion)); err != nil {
+		return fmt.Errorf("set schema version: %w", err)
+	}
+	return tx.Commit()
+}
 
-	for _, deleteQuery := range []func(context.Context) error{
-		q.DeleteMessagesFTS,
-		q.DeleteMessages,
-		q.DeleteGroupParticipants,
-		q.DeleteGroups,
-		q.DeleteChats,
-		q.DeleteContacts,
-		q.DeleteSyncState,
-	} {
-		if err := deleteQuery(ctx); err != nil {
+func ensureColumn(ctx context.Context, tx *sql.Tx, table, column, definition string) error {
+	rows, err := tx.QueryContext(ctx, "pragma table_info("+table+")") //nolint:gosec // fixed migration identifiers only.
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var cid, notNull, primaryKey int
+		var name, columnType string
+		var defaultValue any
+		if err := rows.Scan(&cid, &name, &columnType, &notNull, &defaultValue, &primaryKey); err != nil {
 			return err
+		}
+		if name == column {
+			return rows.Err()
 		}
 	}
-	for _, c := range contacts {
-		err := q.InsertContact(ctx, storedb.InsertContactParams{
-			Jid:          c.JID,
-			Phone:        nullString(c.Phone),
-			FullName:     nullString(c.FullName),
-			FirstName:    nullString(c.FirstName),
-			LastName:     nullString(c.LastName),
-			BusinessName: nullString(c.BusinessName),
-			Username:     nullString(c.Username),
-			Lid:          nullString(c.LID),
-			AboutText:    nullString(c.AboutText),
-			UpdatedAt:    nullInt64(unix(c.UpdatedAt)),
-		})
-		if err != nil {
-			return err
-		}
+	if err := rows.Err(); err != nil {
+		return err
 	}
-	for _, c := range chats {
-		err := q.InsertChat(ctx, storedb.InsertChatParams{
-			Jid:            c.JID,
-			Kind:           c.Kind,
-			Name:           nullString(c.Name),
-			LastMessageAt:  nullInt64(unix(c.LastMessageAt)),
-			UnreadCount:    int64(c.UnreadCount),
-			Archived:       int64(boolInt(c.Archived)),
-			Removed:        int64(boolInt(c.Removed)),
-			Hidden:         int64(boolInt(c.Hidden)),
-			RawSessionType: int64(c.RawSessionType),
-		})
-		if err != nil {
-			return err
-		}
+	if err := rows.Close(); err != nil {
+		return err
 	}
-	for _, g := range groups {
-		err := q.InsertGroup(ctx, storedb.InsertGroupParams{
-			Jid:       g.JID,
-			Name:      nullString(g.Name),
-			OwnerJid:  nullString(g.OwnerJID),
-			CreatedAt: nullInt64(unix(g.CreatedAt)),
-		})
-		if err != nil {
-			return err
-		}
+	if _, err := tx.ExecContext(ctx, "alter table "+table+" add column "+column+" "+definition); err != nil { //nolint:gosec // fixed migration identifiers only.
+		return fmt.Errorf("add %s.%s: %w", table, column, err)
 	}
-	for _, p := range participants {
-		err := q.InsertParticipant(ctx, storedb.InsertParticipantParams{
-			GroupJid:    p.GroupJID,
-			UserJid:     p.UserJID,
-			ContactName: nullString(p.ContactName),
-			FirstName:   nullString(p.FirstName),
-			IsAdmin:     int64(boolInt(p.IsAdmin)),
-			IsActive:    int64(boolInt(p.IsActive)),
-		})
-		if err != nil {
-			return err
-		}
+	return nil
+}
+
+func (s *Store) ReplaceAll(ctx context.Context, stats ImportStats, contacts []Contact, chats []Chat, groups []Group, participants []GroupParticipant, messages []Message) error {
+	stats.Mode = "restore"
+	return s.importAll(ctx, true, stats, contacts, chats, groups, participants, messages, nil)
+}
+
+func (s *Store) MergeAll(ctx context.Context, stats ImportStats, contacts []Contact, chats []Chat, groups []Group, participants []GroupParticipant, messages []Message) error {
+	stats.Mode = "merge"
+	return s.importAll(ctx, false, stats, contacts, chats, groups, participants, messages, nil)
+}
+
+func (s *Store) ValidateImport(ctx context.Context, stats ImportStats, messages []Message, restore bool) error {
+	if err := validateImportMessages(messages); err != nil {
+		return err
 	}
-	for _, m := range messages {
-		err := q.InsertMessage(ctx, storedb.InsertMessageParams{
-			SourcePk:    m.SourcePK,
-			ChatJid:     m.ChatJID,
-			ChatName:    nullString(m.ChatName),
-			MsgID:       m.MessageID,
-			SenderJid:   nullString(m.SenderJID),
-			SenderName:  nullString(m.SenderName),
-			Ts:          unix(m.Timestamp),
-			FromMe:      int64(boolInt(m.FromMe)),
-			Text:        nullString(m.Text),
-			RawType:     int64(m.RawType),
-			MessageType: nullString(m.MessageType),
-			MediaType:   nullString(m.MediaType),
-			MediaTitle:  nullString(m.MediaTitle),
-			MediaPath:   nullString(m.MediaPath),
-			MediaUrl:    nullString(m.MediaURL),
-			MediaSize:   nullInt64(m.MediaSize),
-			Starred:     int64(boolInt(m.Starred)),
-		})
-		if err != nil {
-			return err
-		}
-		err = q.InsertMessageFTS(ctx, storedb.InsertMessageFTSParams{
-			SourcePk: m.SourcePK,
-			Text:     nullString(strings.TrimSpace(m.Text + " " + m.MediaTitle)),
-			Chat:     nullString(m.ChatName),
-			Sender:   nullString(m.SenderName),
-			Media:    nullString(m.MediaType),
-		})
-		if err != nil {
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	_, err = validateImportSource(ctx, tx, restore, stats, messages)
+	return err
+}
+
+func (s *Store) importAll(ctx context.Context, restore bool, stats ImportStats, contacts []Contact, chats []Chat, groups []Group, participants []GroupParticipant, messages []Message, revisions []MessageRevision) error {
+	if err := validateImportMessages(messages); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer rollback(tx)
+	mergeSource, err := validateImportSource(ctx, tx, restore, stats, messages)
+	if err != nil {
+		return err
+	}
+	if restore {
+		if _, err := tx.ExecContext(ctx, `
+delete from messages_fts;
+delete from message_revisions;
+delete from messages;
+delete from group_participants;
+delete from groups;
+delete from chats;
+delete from contacts;
+delete from sync_state;`); err != nil {
 			return err
 		}
 	}
@@ -368,20 +383,584 @@ func (s *Store) ReplaceAll(ctx context.Context, stats ImportStats, contacts []Co
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
+	observedAt := unix(now)
+	prepareImportTombstones(now, chats, groups, participants, messages)
+	if err := prepareStoredParentTombstones(ctx, tx, chats, groups, participants, messages); err != nil {
+		return err
+	}
+	for _, c := range contacts {
+		t := normalizedTombstone(c.Tombstone, now)
+		if _, err := tx.ExecContext(ctx, `insert into contacts(
+jid, phone, full_name, first_name, last_name, business_name, username, lid, about_text, updated_at,
+deleted_at, deletion_source, deletion_reason, last_seen_at)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+on conflict(jid) do update set
+phone=excluded.phone, full_name=excluded.full_name, first_name=excluded.first_name,
+last_name=excluded.last_name, business_name=excluded.business_name, username=excluded.username,
+lid=excluded.lid, about_text=excluded.about_text, updated_at=excluded.updated_at,
+deleted_at=case when contacts.deleted_at is not null then contacts.deleted_at else excluded.deleted_at end,
+deletion_source=case when contacts.deleted_at is not null then contacts.deletion_source else excluded.deletion_source end,
+deletion_reason=case when contacts.deleted_at is not null then contacts.deletion_reason else excluded.deletion_reason end,
+last_seen_at=excluded.last_seen_at`,
+			c.JID, c.Phone, c.FullName, c.FirstName, c.LastName, c.BusinessName, c.Username, c.LID, c.AboutText, unix(c.UpdatedAt),
+			nullableUnix(t.DeletedAt), nullableString(t.DeletionSource), nullableString(t.DeletionReason), unix(t.LastSeenAt)); err != nil {
+			return err
+		}
+	}
+	for _, c := range chats {
+		t := normalizedTombstone(c.Tombstone, now)
+		if _, err := tx.ExecContext(ctx, `insert into chats(
+jid, kind, name, last_message_at, unread_count, archived, removed, hidden, raw_session_type,
+deleted_at, deletion_source, deletion_reason, last_seen_at)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?)
+on conflict(jid) do update set
+kind=excluded.kind, name=excluded.name, last_message_at=excluded.last_message_at,
+unread_count=excluded.unread_count, archived=excluded.archived, removed=excluded.removed,
+hidden=excluded.hidden, raw_session_type=excluded.raw_session_type,
+deleted_at=case when chats.deleted_at is not null and excluded.deleted_at is null and excluded.last_message_at > chats.deleted_at then null when chats.deleted_at is not null then chats.deleted_at else excluded.deleted_at end,
+deletion_source=case when chats.deleted_at is not null and excluded.deleted_at is null and excluded.last_message_at > chats.deleted_at then null when chats.deleted_at is not null then chats.deletion_source else excluded.deletion_source end,
+deletion_reason=case when chats.deleted_at is not null and excluded.deleted_at is null and excluded.last_message_at > chats.deleted_at then null when chats.deleted_at is not null then chats.deletion_reason else excluded.deletion_reason end,
+last_seen_at=excluded.last_seen_at`,
+			c.JID, c.Kind, c.Name, unix(c.LastMessageAt), c.UnreadCount, boolInt(c.Archived), boolInt(c.Removed), boolInt(c.Hidden), c.RawSessionType,
+			nullableUnix(t.DeletedAt), nullableString(t.DeletionSource), nullableString(t.DeletionReason), unix(t.LastSeenAt)); err != nil {
+			return err
+		}
+	}
+	for _, g := range groups {
+		t := normalizedTombstone(g.Tombstone, now)
+		if _, err := tx.ExecContext(ctx, `insert into groups(
+jid, name, owner_jid, created_at, deleted_at, deletion_source, deletion_reason, last_seen_at)
+values(?,?,?,?,?,?,?,?)
+on conflict(jid) do update set name=excluded.name, owner_jid=excluded.owner_jid,
+created_at=excluded.created_at,
+deleted_at=case when groups.deleted_at is not null and excluded.deleted_at is null and exists(select 1 from chats where jid=excluded.jid and deleted_at is null) then null when groups.deleted_at is not null then groups.deleted_at else excluded.deleted_at end,
+deletion_source=case when groups.deleted_at is not null and excluded.deleted_at is null and exists(select 1 from chats where jid=excluded.jid and deleted_at is null) then null when groups.deleted_at is not null then groups.deletion_source else excluded.deletion_source end,
+deletion_reason=case when groups.deleted_at is not null and excluded.deleted_at is null and exists(select 1 from chats where jid=excluded.jid and deleted_at is null) then null when groups.deleted_at is not null then groups.deletion_reason else excluded.deletion_reason end,
+last_seen_at=excluded.last_seen_at`,
+			g.JID, g.Name, g.OwnerJID, unix(g.CreatedAt), nullableUnix(t.DeletedAt), nullableString(t.DeletionSource), nullableString(t.DeletionReason), unix(t.LastSeenAt)); err != nil {
+			return err
+		}
+	}
+	for _, p := range participants {
+		t := normalizedTombstone(p.Tombstone, now)
+		if _, err := tx.ExecContext(ctx, `insert into group_participants(
+group_jid, user_jid, contact_name, first_name, is_admin, is_active,
+deleted_at, deletion_source, deletion_reason, last_seen_at)
+values(?,?,?,?,?,?,?,?,?,?)
+on conflict(group_jid,user_jid) do update set contact_name=excluded.contact_name,
+first_name=excluded.first_name, is_admin=excluded.is_admin, is_active=excluded.is_active,
+deleted_at=case when group_participants.deleted_at is not null and excluded.deleted_at is null and excluded.is_active=1 and exists(select 1 from groups where jid=excluded.group_jid and deleted_at is null) then null when group_participants.deleted_at is not null then group_participants.deleted_at else excluded.deleted_at end,
+deletion_source=case when group_participants.deleted_at is not null and excluded.deleted_at is null and excluded.is_active=1 and exists(select 1 from groups where jid=excluded.group_jid and deleted_at is null) then null when group_participants.deleted_at is not null then group_participants.deletion_source else excluded.deletion_source end,
+deletion_reason=case when group_participants.deleted_at is not null and excluded.deleted_at is null and excluded.is_active=1 and exists(select 1 from groups where jid=excluded.group_jid and deleted_at is null) then null when group_participants.deleted_at is not null then group_participants.deletion_reason else excluded.deletion_reason end,
+last_seen_at=excluded.last_seen_at`,
+			p.GroupJID, p.UserJID, p.ContactName, p.FirstName, boolInt(p.IsAdmin), boolInt(p.IsActive),
+			nullableUnix(t.DeletedAt), nullableString(t.DeletionSource), nullableString(t.DeletionReason), unix(t.LastSeenAt)); err != nil {
+			return err
+		}
+	}
+	for _, m := range messages {
+		if err := upsertMessage(ctx, tx, m, now); err != nil {
+			return err
+		}
+	}
+	for _, revision := range revisions {
+		if _, err := tx.ExecContext(ctx, `insert into message_revisions(event_id,payload_json,recorded_at,event_source,reason) values(?,?,?,?,?)`,
+			revision.EventID, revision.PayloadJSON, unix(revision.RecordedAt), revision.EventSource, revision.Reason); err != nil {
+			return err
+		}
+	}
+	if err := tombstoneSubordinates(ctx, tx, now); err != nil {
+		return err
+	}
 	for key, value := range map[string]string{
-		"last_import_at": now.Format(time.RFC3339Nano),
-		"source_path":    stats.SourcePath,
+		"last_import_at":        now.Format(time.RFC3339Nano),
+		"source_path":           stats.SourcePath,
+		"import_mode":           stats.Mode,
+		"source_messages":       fmt.Sprintf("%d", stats.Messages),
+		"source_contacts":       fmt.Sprintf("%d", stats.Contacts),
+		"source_newest_message": formatSyncTime(stats.SourceNewestMessage),
 	} {
-		err := q.InsertSyncState(ctx, storedb.InsertSyncStateParams{
-			Key:       key,
-			Value:     value,
-			UpdatedAt: unix(now),
-		})
-		if err != nil {
+		if _, err := tx.ExecContext(ctx, `insert into sync_state(key,value,updated_at) values(?,?,?)
+on conflict(key) do update set value=excluded.value, updated_at=excluded.updated_at`, key, value, observedAt); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(mergeSource) != "" {
+		if _, err := tx.ExecContext(ctx, `insert into sync_state(key,value,updated_at) values('merge_source_path',?,?)
+on conflict(key) do update set value=excluded.value, updated_at=excluded.updated_at`, mergeSource, observedAt); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(stats.AccountIdentity) != "" {
+		if _, err := tx.ExecContext(ctx, `insert into sync_state(key,value,updated_at) values('merge_account_identity',?,?)
+on conflict(key) do update set value=excluded.value, updated_at=excluded.updated_at`, strings.TrimSpace(stats.AccountIdentity), observedAt); err != nil {
 			return err
 		}
 	}
 	return tx.Commit()
+}
+
+func validateImportSource(ctx context.Context, tx *sql.Tx, restore bool, stats ImportStats, messages []Message) (string, error) {
+	strongSource := strings.TrimSpace(stats.SourceIdentity)
+	weakSource := legacySourceIdentity(stats.SourcePath)
+	if restore {
+		return strongSource, nil
+	}
+	var existingStrong string
+	err := tx.QueryRowContext(ctx, `select value from sync_state where key='merge_source_path'`).Scan(&existingStrong)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", err
+	}
+	var existingWeak string
+	if existingStrong == "" {
+		err = tx.QueryRowContext(ctx, `select value from sync_state where key='source_path'`).Scan(&existingWeak)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return "", err
+		}
+		existingWeak = legacySourceIdentity(existingWeak)
+	}
+	if strongSource != "" && existingStrong != "" && strongSource != existingStrong {
+		return "", fmt.Errorf("archive is bound to WhatsApp source %q, not %q; use a separate --db or import --restore", existingStrong, strongSource)
+	}
+	if existingStrong == "" && existingWeak != "" && weakSource != existingWeak {
+		return "", fmt.Errorf("archive is bound to WhatsApp source path %q, not %q; use a separate --db or import --restore", existingWeak, weakSource)
+	}
+	accountIdentity := strings.TrimSpace(stats.AccountIdentity)
+	var existingAccount string
+	err := tx.QueryRowContext(ctx, `select value from sync_state where key='merge_account_identity'`).Scan(&existingAccount)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", err
+	}
+	existingAccount = strings.TrimSpace(existingAccount)
+	if existingAccount != "" {
+		if accountIdentity == "" || existingAccount != accountIdentity {
+			return "", errors.New("archive is bound to a different WhatsApp account; use a separate --db or import --restore")
+		}
+	} else if strongSource != "" && accountIdentity == "" {
+		return "", errors.New("cannot establish WhatsApp account identity for merge; use a separate --db or import --restore")
+	} else if accountIdentity != "" {
+		proven, err := archiveContinuityProven(ctx, tx, messages)
+		if err != nil {
+			return "", err
+		}
+		if !proven {
+			return "", errors.New("cannot verify that this WhatsApp account matches the existing archive; use a separate --db or import --restore")
+		}
+	} else if strongSource == "" {
+		proven, err := archiveContinuityProven(ctx, tx, messages)
+		if err != nil {
+			return "", err
+		}
+		if !proven {
+			return "", errors.New("cannot merge into an existing archive without source identity or overlapping stable events; use a separate --db or import --restore")
+		}
+	}
+	for _, message := range messages {
+		existing, found, err := messageBySourcePK(ctx, tx, message.SourcePK)
+		if err != nil {
+			return "", err
+		}
+		if found && messageIdentityConflict(existing, message) {
+			return "", fmt.Errorf("message source_pk %d belongs to a different event; use a separate archive or import --restore", message.SourcePK)
+		}
+	}
+	if strongSource != "" {
+		return strongSource, nil
+	}
+	return existingStrong, nil
+}
+
+func archiveContinuityProven(ctx context.Context, tx *sql.Tx, incoming []Message) (bool, error) {
+	var entityRows int
+	if err := tx.QueryRowContext(ctx, `select
+(select count(*) from contacts)+(select count(*) from chats)+(select count(*) from groups)+
+(select count(*) from group_participants)+(select count(*) from messages)`).Scan(&entityRows); err != nil {
+		return false, err
+	}
+	if entityRows == 0 {
+		return true, nil
+	}
+	for _, candidate := range incoming {
+		existing, found, err := messageBySourcePK(ctx, tx, candidate.SourcePK)
+		if err != nil {
+			return false, err
+		}
+		if found && !messageIdentityConflict(existing, candidate) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func formatSyncTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func legacySourceIdentity(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" || strings.HasPrefix(source, "backup:") {
+		return ""
+	}
+	absolute, err := filepath.Abs(source)
+	if err != nil {
+		return filepath.Clean(source)
+	}
+	if evaluated, err := filepath.EvalSymlinks(absolute); err == nil {
+		absolute = evaluated
+	}
+	return filepath.Clean(absolute)
+}
+
+func validateImportMessages(messages []Message) error {
+	seen := make(map[int64]struct{}, len(messages))
+	seenEvents := make(map[string]struct{}, len(messages))
+	for _, message := range messages {
+		if message.SourcePK == 0 {
+			return errors.New("message with empty source_pk")
+		}
+		if _, ok := seen[message.SourcePK]; ok {
+			return fmt.Errorf("duplicate message source_pk %d", message.SourcePK)
+		}
+		seen[message.SourcePK] = struct{}{}
+		eventID := message.EventID
+		if eventID == "" {
+			eventID = messageEventID(message.SourcePK)
+		} else if strings.TrimSpace(eventID) == "" {
+			return fmt.Errorf("message source_pk %d has empty event_id", message.SourcePK)
+		}
+		if _, ok := seenEvents[eventID]; ok {
+			return fmt.Errorf("duplicate message event_id %q", eventID)
+		}
+		seenEvents[eventID] = struct{}{}
+	}
+	return nil
+}
+
+func prepareImportTombstones(now time.Time, chats []Chat, groups []Group, participants []GroupParticipant, messages []Message) {
+	deletedChats := make(map[string]Tombstone)
+	for i := range chats {
+		if chats[i].Removed && chats[i].DeletedAt.IsZero() {
+			chats[i].Tombstone = sourceTombstone(now, "whatsapp_removed")
+		}
+		if !chats[i].DeletedAt.IsZero() {
+			deletedChats[chats[i].JID] = chats[i].Tombstone
+		}
+	}
+	deletedGroups := make(map[string]Tombstone)
+	for i := range groups {
+		if parent, ok := deletedChats[groups[i].JID]; ok && groups[i].DeletedAt.IsZero() {
+			groups[i].Tombstone = childTombstone(parent, "parent_chat_deleted")
+		}
+		if !groups[i].DeletedAt.IsZero() {
+			deletedGroups[groups[i].JID] = groups[i].Tombstone
+		}
+	}
+	for i := range participants {
+		if parent, ok := deletedGroups[participants[i].GroupJID]; ok && participants[i].DeletedAt.IsZero() {
+			participants[i].Tombstone = childTombstone(parent, "parent_group_deleted")
+		} else if !participants[i].IsActive && participants[i].DeletedAt.IsZero() {
+			participants[i].Tombstone = sourceTombstone(now, "whatsapp_inactive")
+		}
+	}
+	for i := range messages {
+		if parent, ok := deletedChats[messages[i].ChatJID]; ok && messages[i].DeletedAt.IsZero() {
+			messages[i].Tombstone = childTombstone(parent, "parent_chat_deleted")
+		}
+	}
+}
+
+func prepareStoredParentTombstones(ctx context.Context, tx *sql.Tx, chats []Chat, groups []Group, participants []GroupParticipant, messages []Message) error {
+	liveChats := make(map[string]struct{})
+	for _, chat := range chats {
+		if chat.DeletedAt.IsZero() {
+			liveChats[chat.JID] = struct{}{}
+		}
+	}
+	for i := range groups {
+		if !groups[i].DeletedAt.IsZero() {
+			continue
+		}
+		if _, live := liveChats[groups[i].JID]; live {
+			continue
+		}
+		parent, found, err := storedTombstone(ctx, tx, "chats", "jid", groups[i].JID)
+		if err != nil {
+			return err
+		}
+		if found {
+			groups[i].Tombstone = childTombstone(parent, "parent_chat_deleted")
+		}
+	}
+	liveGroups := make(map[string]struct{})
+	for _, group := range groups {
+		if group.DeletedAt.IsZero() {
+			liveGroups[group.JID] = struct{}{}
+		}
+	}
+	for i := range participants {
+		if !participants[i].DeletedAt.IsZero() {
+			continue
+		}
+		if _, live := liveGroups[participants[i].GroupJID]; live {
+			continue
+		}
+		parent, found, err := storedTombstone(ctx, tx, "groups", "jid", participants[i].GroupJID)
+		if err != nil {
+			return err
+		}
+		if found {
+			participants[i].Tombstone = childTombstone(parent, "parent_group_deleted")
+		}
+	}
+	for i := range messages {
+		if !messages[i].DeletedAt.IsZero() {
+			continue
+		}
+		if _, live := liveChats[messages[i].ChatJID]; live {
+			continue
+		}
+		parent, found, err := storedTombstone(ctx, tx, "chats", "jid", messages[i].ChatJID)
+		if err != nil {
+			return err
+		}
+		if found {
+			messages[i].Tombstone = childTombstone(parent, "parent_chat_deleted")
+		}
+	}
+	return nil
+}
+
+func storedTombstone(ctx context.Context, tx *sql.Tx, table, key, value string) (Tombstone, bool, error) {
+	var deletedAt, lastSeenAt int64
+	var source, reason string
+	query := "select deleted_at,coalesce(deletion_source,''),coalesce(deletion_reason,''),last_seen_at from " + table + " where " + key + "=? and deleted_at is not null" //nolint:gosec // fixed internal table and key names only.
+	err := tx.QueryRowContext(ctx, query, value).Scan(&deletedAt, &source, &reason, &lastSeenAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Tombstone{}, false, nil
+	}
+	if err != nil {
+		return Tombstone{}, false, err
+	}
+	return Tombstone{DeletedAt: fromUnix(deletedAt), DeletionSource: source, DeletionReason: reason, LastSeenAt: fromUnix(lastSeenAt)}, true, nil
+}
+
+func sourceTombstone(at time.Time, reason string) Tombstone {
+	return Tombstone{DeletedAt: at, DeletionSource: "whatsapp-desktop", DeletionReason: reason, LastSeenAt: at}
+}
+
+func childTombstone(parent Tombstone, reason string) Tombstone {
+	return Tombstone{DeletedAt: parent.DeletedAt, DeletionSource: parent.DeletionSource, DeletionReason: reason, LastSeenAt: parent.LastSeenAt}
+}
+
+func normalizedTombstone(t Tombstone, observedAt time.Time) Tombstone {
+	if t.LastSeenAt.IsZero() {
+		t.LastSeenAt = observedAt
+	}
+	if !t.DeletedAt.IsZero() {
+		if t.DeletionSource == "" {
+			t.DeletionSource = "snapshot"
+		}
+		if t.DeletionReason == "" {
+			t.DeletionReason = "explicit_tombstone"
+		}
+	}
+	return t
+}
+
+func messageEventID(sourcePK int64) string {
+	return fmt.Sprintf("wa:%d", sourcePK)
+}
+
+func upsertMessage(ctx context.Context, tx *sql.Tx, m Message, observedAt time.Time) error {
+	sourcePayloadCleared := m.SourceTextNull && m.RawType == 0 && m.MediaTitle == "" && m.MediaType == "" && m.MediaPath == "" && m.MediaURL == "" && m.DeletedAt.IsZero()
+	if m.EventID == "" {
+		m.EventID = messageEventID(m.SourcePK)
+	}
+	m.Tombstone = normalizedTombstone(m.Tombstone, observedAt)
+	existing, found, err := messageBySourcePK(ctx, tx, m.SourcePK)
+	if err != nil {
+		return err
+	}
+	if found {
+		if messageIdentityConflict(existing, m) {
+			return fmt.Errorf("message source_pk %d belongs to a different event; use a separate archive or import --restore", m.SourcePK)
+		}
+		if !existing.DeletedAt.IsZero() && m.DeletedAt.IsZero() {
+			return nil
+		}
+		if sourcePayloadCleared && (!existing.DeletedAt.IsZero() || messageHasPayload(existing)) {
+			m.Tombstone = sourceTombstone(observedAt, "whatsapp_payload_cleared")
+		}
+		m.EventID = existing.EventID
+		if !existing.DeletedAt.IsZero() && !m.DeletedAt.IsZero() {
+			m.DeletedAt = existing.DeletedAt
+			m.DeletionSource = existing.DeletionSource
+			m.DeletionReason = existing.DeletionReason
+		}
+		previous, err := canonicalMessageJSON(existing)
+		if err != nil {
+			return err
+		}
+		incoming, err := canonicalMessageJSON(m)
+		if err != nil {
+			return err
+		}
+		if previous != incoming {
+			reason := "whatsapp_edit"
+			if !m.DeletedAt.IsZero() && existing.DeletedAt.IsZero() {
+				reason = m.DeletionReason
+			} else if m.DeletedAt.IsZero() && !existing.DeletedAt.IsZero() {
+				reason = "whatsapp_restore"
+			}
+			if _, err := tx.ExecContext(ctx, `insert into message_revisions(event_id,payload_json,recorded_at,event_source,reason) values(?,?,?,?,?)`,
+				existing.EventID, previous, unix(observedAt), "whatsapp-desktop", reason); err != nil {
+				return err
+			}
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `insert into messages(
+source_pk,event_id,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,
+raw_type,message_type,media_type,media_title,media_path,media_url,media_size,starred,
+deleted_at,deletion_source,deletion_reason,last_seen_at)
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+on conflict(source_pk) do update set event_id=excluded.event_id, chat_jid=excluded.chat_jid,
+chat_name=excluded.chat_name, msg_id=excluded.msg_id, sender_jid=excluded.sender_jid,
+sender_name=excluded.sender_name, ts=excluded.ts, from_me=excluded.from_me, text=excluded.text,
+raw_type=excluded.raw_type, message_type=excluded.message_type, media_type=excluded.media_type,
+media_title=excluded.media_title, media_path=excluded.media_path, media_url=excluded.media_url,
+media_size=excluded.media_size, starred=excluded.starred, deleted_at=excluded.deleted_at,
+deletion_source=excluded.deletion_source, deletion_reason=excluded.deletion_reason,
+last_seen_at=excluded.last_seen_at`,
+		m.SourcePK, m.EventID, m.ChatJID, m.ChatName, m.MessageID, m.SenderJID, m.SenderName, messageUnix(m), boolInt(m.FromMe), m.Text,
+		m.RawType, m.MessageType, m.MediaType, m.MediaTitle, m.MediaPath, m.MediaURL, m.MediaSize, boolInt(m.Starred),
+		nullableUnix(m.DeletedAt), nullableString(m.DeletionSource), nullableString(m.DeletionReason), unix(m.LastSeenAt)); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `delete from messages_fts where rowid=(select rowid from messages where source_pk=?)`, m.SourcePK); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `insert into messages_fts(rowid,text,chat,sender,media)
+values((select rowid from messages where source_pk=?),?,?,?,?)`, m.SourcePK,
+		strings.TrimSpace(m.Text+" "+m.MediaTitle), m.ChatName, m.SenderName, m.MediaType); err != nil {
+		return err
+	}
+	return nil
+}
+
+func messageHasPayload(message Message) bool {
+	return strings.TrimSpace(message.Text) != "" || strings.TrimSpace(message.MediaTitle) != "" || message.MediaType != "" || message.MediaPath != "" || message.MediaURL != ""
+}
+
+func messageIdentityConflict(existing, incoming Message) bool {
+	return existing.ChatJID != incoming.ChatJID || existing.MessageID != incoming.MessageID || existing.FromMe != incoming.FromMe || messageUnix(existing) != messageUnix(incoming)
+}
+
+func tombstoneSubordinates(ctx context.Context, tx *sql.Tx, observedAt time.Time) error {
+	rows, err := tx.QueryContext(ctx, `select `+messageSelectColumns+` from messages m
+where m.deleted_at is null and exists (select 1 from chats c where c.jid=m.chat_jid and c.deleted_at is not null)`)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	var messages []Message
+	for rows.Next() {
+		m, err := scanMessage(rows)
+		if err != nil {
+			return err
+		}
+		messages = append(messages, m)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, m := range messages {
+		var deletedAt int64
+		var source string
+		if err := tx.QueryRowContext(ctx, `select deleted_at,coalesce(deletion_source,'whatsapp-desktop') from chats where jid=?`, m.ChatJID).Scan(&deletedAt, &source); err != nil {
+			return err
+		}
+		m.Tombstone = Tombstone{DeletedAt: fromUnix(deletedAt), DeletionSource: source, DeletionReason: "parent_chat_deleted", LastSeenAt: observedAt}
+		if err := upsertMessage(ctx, tx, m, observedAt); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `update groups set
+deleted_at=coalesce(deleted_at,(select deleted_at from chats where chats.jid=groups.jid)),
+deletion_source=coalesce(deletion_source,(select deletion_source from chats where chats.jid=groups.jid),'whatsapp-desktop'),
+deletion_reason=coalesce(deletion_reason,'parent_chat_deleted')
+where deleted_at is null and exists(select 1 from chats where chats.jid=groups.jid and chats.deleted_at is not null)`); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `update group_participants set
+deleted_at=coalesce(deleted_at,(select deleted_at from groups where groups.jid=group_participants.group_jid)),
+deletion_source=coalesce(deletion_source,(select deletion_source from groups where groups.jid=group_participants.group_jid),'whatsapp-desktop'),
+deletion_reason=coalesce(deletion_reason,'parent_group_deleted')
+where deleted_at is null and exists(select 1 from groups where groups.jid=group_participants.group_jid and groups.deleted_at is not null)`); err != nil {
+		return err
+	}
+	return nil
+}
+
+func canonicalMessageJSON(m Message) (string, error) {
+	payload := struct {
+		SourcePK       int64  `json:"source_pk"`
+		EventID        string `json:"event_id"`
+		ChatJID        string `json:"chat_jid"`
+		ChatName       string `json:"chat_name,omitempty"`
+		MessageID      string `json:"message_id"`
+		SenderJID      string `json:"sender_jid,omitempty"`
+		SenderName     string `json:"sender_name,omitempty"`
+		Timestamp      int64  `json:"timestamp_unix"`
+		FromMe         bool   `json:"from_me"`
+		Text           string `json:"text,omitempty"`
+		RawType        int    `json:"raw_type"`
+		MessageType    string `json:"message_type,omitempty"`
+		MediaType      string `json:"media_type,omitempty"`
+		MediaTitle     string `json:"media_title,omitempty"`
+		MediaPath      string `json:"media_path,omitempty"`
+		MediaURL       string `json:"media_url,omitempty"`
+		MediaSize      int64  `json:"media_size,omitempty"`
+		Starred        bool   `json:"starred,omitempty"`
+		DeletedAt      int64  `json:"deleted_at,omitempty"`
+		DeletionSource string `json:"deletion_source,omitempty"`
+		DeletionReason string `json:"deletion_reason,omitempty"`
+	}{
+		SourcePK: m.SourcePK, EventID: m.EventID, ChatJID: m.ChatJID, ChatName: m.ChatName,
+		MessageID: m.MessageID, SenderJID: m.SenderJID, SenderName: m.SenderName,
+		Timestamp: messageUnix(m), FromMe: m.FromMe, Text: m.Text, RawType: m.RawType,
+		MessageType: m.MessageType, MediaType: m.MediaType, MediaTitle: m.MediaTitle,
+		MediaPath: m.MediaPath, MediaURL: m.MediaURL, MediaSize: m.MediaSize, Starred: m.Starred,
+		DeletedAt: unix(m.DeletedAt), DeletionSource: m.DeletionSource, DeletionReason: m.DeletionReason,
+	}
+	data, err := json.Marshal(payload)
+	return string(data), err
+}
+
+func messageUnix(message Message) int64 {
+	if message.storedUnix != 0 || message.Timestamp.IsZero() {
+		return message.storedUnix
+	}
+	return unix(message.Timestamp)
+}
+
+func nullableUnix(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return unix(t)
+}
+
+func nullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
 }
 
 func (s *Store) Status(ctx context.Context) (Status, error) {
@@ -411,17 +990,47 @@ func (s *Store) Status(ctx context.Context) (Status, error) {
 	if out.MediaMessages, err = countInt(ctx, s.q.CountMediaMessages); err != nil {
 		return out, err
 	}
+	for query, destination := range map[string]*int{
+		`select count(*) from chats where deleted_at is not null`:              &out.DeletedChats,
+		`select count(*) from contacts where deleted_at is not null`:           &out.DeletedContacts,
+		`select count(*) from groups where deleted_at is not null`:             &out.DeletedGroups,
+		`select count(*) from group_participants where deleted_at is not null`: &out.DeletedParticipants,
+		`select count(*) from messages where deleted_at is not null`:           &out.DeletedMessages,
+		`select count(*) from message_revisions`:                               &out.MessageRevisions,
+	} {
+		if err := s.db.QueryRowContext(ctx, query).Scan(destination); err != nil {
+			return out, err
+		}
+	}
 	bounds, err := s.q.GetMessageTimeBounds(ctx)
 	if err != nil {
 		return out, err
 	}
 	out.OldestMessage = fromUnix(bounds.OldestTs)
 	out.NewestMessage = fromUnix(bounds.NewestTs)
+	var newestObserved int64
+	if err := s.db.QueryRowContext(ctx, `select cast(coalesce(max(case when ts > 0 and ts <= 253402300799 then ts end),0) as integer) from messages`).Scan(&newestObserved); err != nil {
+		return out, err
+	}
+	out.NewestObserved = fromUnix(newestObserved)
 	lastImport, _ := s.q.GetSyncState(ctx, "last_import_at")
 	if t, err := time.Parse(time.RFC3339Nano, lastImport); err == nil {
 		out.LastImportAt = t
 	}
 	out.LastSource, _ = s.q.GetSyncState(ctx, "source_path")
+	if value, err := s.q.GetSyncState(ctx, "source_messages"); err == nil {
+		if out.LastSourceMessages, err = strconv.Atoi(value); err == nil {
+			out.SourceMessagesKnown = true
+		}
+	}
+	if value, err := s.q.GetSyncState(ctx, "source_contacts"); err == nil {
+		if out.LastSourceContacts, err = strconv.Atoi(value); err == nil {
+			out.SourceContactsKnown = true
+		}
+	}
+	if value, err := s.q.GetSyncState(ctx, "source_newest_message"); err == nil {
+		out.LastSourceNewest, _ = time.Parse(time.RFC3339Nano, value)
+	}
 	return out, nil
 }
 
@@ -470,7 +1079,7 @@ func (s *Store) Messages(ctx context.Context, filter MessageFilter) ([]Message, 
 // MessageBySourcePK returns the single message stored under the given source
 // primary key, or sql.ErrNoRows when it does not exist.
 func (s *Store) MessageBySourcePK(ctx context.Context, sourcePK int64) (Message, error) {
-	messages, err := scanMessages(ctx, s.db, "select "+messageSelectColumns+" from messages where source_pk = ?", sourcePK)
+	messages, err := scanMessages(ctx, s.db, "select "+messageSelectColumns+" from messages where source_pk = ? and deleted_at is null", sourcePK)
 	if err != nil {
 		return Message{}, err
 	}
@@ -541,7 +1150,7 @@ func (s *Store) Search(ctx context.Context, filter MessageFilter) ([]Message, er
 	if snippetEnd == "" {
 		snippetEnd = "]"
 	}
-	query := `select m.source_pk, m.chat_jid, m.chat_name, m.msg_id, m.sender_jid, m.sender_name, m.ts, m.from_me, m.text, m.raw_type, m.message_type, m.media_type, m.media_title, m.media_path, m.media_url, m.media_size, m.starred, snippet(messages_fts, 0, ?, ?, '...', 12) from messages_fts f join messages m on m.rowid=f.rowid where messages_fts match ?`
+	query := `select m.source_pk, m.event_id, m.chat_jid, coalesce(m.chat_name,''), m.msg_id, coalesce(m.sender_jid,''), coalesce(m.sender_name,''), m.ts, m.from_me, coalesce(m.text,''), m.raw_type, coalesce(m.message_type,''), coalesce(m.media_type,''), coalesce(m.media_title,''), coalesce(m.media_path,''), coalesce(m.media_url,''), coalesce(m.media_size,0), m.starred, coalesce(m.deleted_at,0), coalesce(m.deletion_source,''), coalesce(m.deletion_reason,''), m.last_seen_at, snippet(messages_fts, 0, ?, ?, '...', 12) from messages_fts f join messages m on m.rowid=f.rowid where messages_fts match ?`
 	args := []any{snippetStart, snippetEnd, ftsQuery}
 	query, args = applyMessageFilters(query, args, filter, true)
 	query += " order by bm25(messages_fts) limit ?"
@@ -553,6 +1162,9 @@ func applyMessageFilters(query string, args []any, filter MessageFilter, joined 
 	prefix := ""
 	if joined {
 		prefix = "m."
+	}
+	if !filter.IncludeDeleted {
+		query += " and " + prefix + "deleted_at is null"
 	}
 	if strings.TrimSpace(filter.ChatJID) != "" {
 		query += " and " + prefix + "chat_jid = ?"
@@ -593,18 +1205,44 @@ func scanMessages(ctx context.Context, db *sql.DB, query string, args ...any) ([
 	defer func() { _ = rows.Close() }()
 	var out []Message
 	for rows.Next() {
-		var m Message
-		var ts int64
-		var fromMe, starred int
-		if err := rows.Scan(&m.SourcePK, &m.ChatJID, &m.ChatName, &m.MessageID, &m.SenderJID, &m.SenderName, &ts, &fromMe, &m.Text, &m.RawType, &m.MessageType, &m.MediaType, &m.MediaTitle, &m.MediaPath, &m.MediaURL, &m.MediaSize, &starred, &m.Snippet); err != nil {
+		m, err := scanMessage(rows)
+		if err != nil {
 			return nil, err
 		}
-		m.Timestamp = fromUnix(ts)
-		m.FromMe = fromMe != 0
-		m.Starred = starred != 0
 		out = append(out, m)
 	}
 	return out, rows.Err()
+}
+
+type messageScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanMessage(row messageScanner) (Message, error) {
+	var m Message
+	var ts, deletedAt, lastSeenAt int64
+	var fromMe, starred int
+	if err := row.Scan(&m.SourcePK, &m.EventID, &m.ChatJID, &m.ChatName, &m.MessageID, &m.SenderJID, &m.SenderName,
+		&ts, &fromMe, &m.Text, &m.RawType, &m.MessageType, &m.MediaType, &m.MediaTitle, &m.MediaPath, &m.MediaURL,
+		&m.MediaSize, &starred, &deletedAt, &m.DeletionSource, &m.DeletionReason, &lastSeenAt, &m.Snippet); err != nil {
+		return Message{}, err
+	}
+	m.Timestamp = fromUnix(ts)
+	m.storedUnix = ts
+	m.FromMe = fromMe != 0
+	m.Starred = starred != 0
+	m.DeletedAt = fromUnix(deletedAt)
+	m.LastSeenAt = fromUnix(lastSeenAt)
+	return m, nil
+}
+
+func messageBySourcePK(ctx context.Context, tx *sql.Tx, sourcePK int64) (Message, bool, error) {
+	row := tx.QueryRowContext(ctx, "select "+messageSelectColumns+" from messages where source_pk = ?", sourcePK)
+	m, err := scanMessage(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Message{}, false, nil
+	}
+	return m, err == nil, err
 }
 
 func boolInt(v bool) int {
@@ -638,14 +1276,6 @@ func validUnixPredicate(column string) string {
 
 func invalidUnixPredicate(column string) string {
 	return fmt.Sprintf("(%s <= 0 or %s > %d)", column, column, maxJSONUnixSecond)
-}
-
-func nullString(v string) sql.NullString {
-	return sql.NullString{String: v, Valid: true}
-}
-
-func nullInt64(v int64) sql.NullInt64 {
-	return sql.NullInt64{Int64: v, Valid: true}
 }
 
 func countInt(ctx context.Context, count func(context.Context) (int64, error)) (int, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -35,7 +35,10 @@ type Store struct {
 type ImportStats struct {
 	Mode                string    `json:"mode"`
 	SourceIdentity      string    `json:"-"`
+	SourceStoreIdentity string    `json:"-"`
 	AccountIdentity     string    `json:"-"`
+	AdoptSource         bool      `json:"-"`
+	SourceSnapshotAt    time.Time `json:"-"`
 	SourceNewestMessage time.Time `json:"-"`
 	SourcePath          string    `json:"source_path"`
 	DBPath              string    `json:"db_path"`
@@ -70,6 +73,7 @@ type Status struct {
 	OldestMessage       time.Time `json:"oldest_message,omitzero"`
 	NewestMessage       time.Time `json:"newest_message,omitzero"`
 	LastImportAt        time.Time `json:"last_import_at,omitzero"`
+	LastSourceSnapshot  time.Time `json:"-"`
 	LastSource          string    `json:"last_source,omitempty"`
 	LastSourceMessages  int       `json:"last_source_messages,omitempty"`
 	LastSourceContacts  int       `json:"last_source_contacts,omitempty"`
@@ -384,6 +388,10 @@ delete from sync_state;`); err != nil {
 		now = time.Now().UTC()
 	}
 	observedAt := unix(now)
+	sourceSnapshotAt := stats.SourceSnapshotAt
+	if sourceSnapshotAt.IsZero() {
+		sourceSnapshotAt = now
+	}
 	prepareImportTombstones(now, chats, groups, participants, messages)
 	if err := prepareStoredParentTombstones(ctx, tx, chats, groups, participants, messages); err != nil {
 		return err
@@ -479,6 +487,7 @@ last_seen_at=excluded.last_seen_at`,
 		"source_messages":       fmt.Sprintf("%d", stats.Messages),
 		"source_contacts":       fmt.Sprintf("%d", stats.Contacts),
 		"source_newest_message": formatSyncTime(stats.SourceNewestMessage),
+		"source_snapshot_at":    formatSyncTime(sourceSnapshotAt),
 	} {
 		if _, err := tx.ExecContext(ctx, `insert into sync_state(key,value,updated_at) values(?,?,?)
 on conflict(key) do update set value=excluded.value, updated_at=excluded.updated_at`, key, value, observedAt); err != nil {
@@ -488,6 +497,12 @@ on conflict(key) do update set value=excluded.value, updated_at=excluded.updated
 	if strings.TrimSpace(mergeSource) != "" {
 		if _, err := tx.ExecContext(ctx, `insert into sync_state(key,value,updated_at) values('merge_source_path',?,?)
 on conflict(key) do update set value=excluded.value, updated_at=excluded.updated_at`, mergeSource, observedAt); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(stats.SourceStoreIdentity) != "" {
+		if _, err := tx.ExecContext(ctx, `insert into sync_state(key,value,updated_at) values('merge_source_store_identity',?,?)
+on conflict(key) do update set value=excluded.value, updated_at=excluded.updated_at`, strings.TrimSpace(stats.SourceStoreIdentity), observedAt); err != nil {
 			return err
 		}
 	}
@@ -511,6 +526,15 @@ func validateImportSource(ctx context.Context, tx *sql.Tx, restore bool, stats I
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return "", err
 	}
+	var existingStore string
+	err = tx.QueryRowContext(ctx, `select value from sync_state where key='merge_source_store_identity'`).Scan(&existingStore)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", err
+	}
+	if strings.HasPrefix(existingStrong, "wa-store:") {
+		existingStore = existingStrong
+		existingStrong = ""
+	}
 	var existingWeak string
 	if existingStrong == "" {
 		err = tx.QueryRowContext(ctx, `select value from sync_state where key='source_path'`).Scan(&existingWeak)
@@ -522,38 +546,12 @@ func validateImportSource(ctx context.Context, tx *sql.Tx, restore bool, stats I
 	if strongSource != "" && existingStrong != "" && strongSource != existingStrong {
 		return "", fmt.Errorf("archive is bound to WhatsApp source %q, not %q; use a separate --db or import --restore", existingStrong, strongSource)
 	}
+	incomingStore := strings.TrimSpace(stats.SourceStoreIdentity)
+	if existingStore != "" && incomingStore != existingStore {
+		return "", errors.New("archive is bound to a different WhatsApp Desktop store; use a separate --db or import --restore")
+	}
 	if existingStrong == "" && existingWeak != "" && weakSource != existingWeak {
 		return "", fmt.Errorf("archive is bound to WhatsApp source path %q, not %q; use a separate --db or import --restore", existingWeak, weakSource)
-	}
-	accountIdentity := strings.TrimSpace(stats.AccountIdentity)
-	var existingAccount string
-	err := tx.QueryRowContext(ctx, `select value from sync_state where key='merge_account_identity'`).Scan(&existingAccount)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return "", err
-	}
-	existingAccount = strings.TrimSpace(existingAccount)
-	if existingAccount != "" {
-		if accountIdentity == "" || existingAccount != accountIdentity {
-			return "", errors.New("archive is bound to a different WhatsApp account; use a separate --db or import --restore")
-		}
-	} else if strongSource != "" && accountIdentity == "" {
-		return "", errors.New("cannot establish WhatsApp account identity for merge; use a separate --db or import --restore")
-	} else if accountIdentity != "" {
-		proven, err := archiveContinuityProven(ctx, tx, messages)
-		if err != nil {
-			return "", err
-		}
-		if !proven {
-			return "", errors.New("cannot verify that this WhatsApp account matches the existing archive; use a separate --db or import --restore")
-		}
-	} else if strongSource == "" {
-		proven, err := archiveContinuityProven(ctx, tx, messages)
-		if err != nil {
-			return "", err
-		}
-		if !proven {
-			return "", errors.New("cannot merge into an existing archive without source identity or overlapping stable events; use a separate --db or import --restore")
-		}
 	}
 	for _, message := range messages {
 		existing, found, err := messageBySourcePK(ctx, tx, message.SourcePK)
@@ -564,32 +562,46 @@ func validateImportSource(ctx context.Context, tx *sql.Tx, restore bool, stats I
 			return "", fmt.Errorf("message source_pk %d belongs to a different event; use a separate archive or import --restore", message.SourcePK)
 		}
 	}
+	accountIdentity := strings.TrimSpace(stats.AccountIdentity)
+	var existingAccount string
+	err = tx.QueryRowContext(ctx, `select value from sync_state where key='merge_account_identity'`).Scan(&existingAccount)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", err
+	}
+	existingAccount = strings.TrimSpace(existingAccount)
+	if strings.HasPrefix(existingAccount, "wa-store:") {
+		// Early schema-v2 builds mistook Core Data's persistent-store UUID for
+		// an account identity. It is only a source marker and cannot prove that
+		// a logout/login cycle kept the same WhatsApp account.
+		existingAccount = ""
+	}
+	if existingAccount != "" {
+		if accountIdentity == "" || existingAccount != accountIdentity {
+			return "", errors.New("archive is bound to a different WhatsApp account; use a separate --db or import --restore")
+		}
+	} else {
+		entityRows, err := archiveEntityRows(ctx, tx)
+		if err != nil {
+			return "", err
+		}
+		if entityRows > 0 && (!stats.AdoptSource || accountIdentity == "") {
+			return "", errors.New("archive has no verified WhatsApp account binding; rerun an explicit import with --adopt-source, use a separate --db, or import --restore")
+		}
+	}
 	if strongSource != "" {
 		return strongSource, nil
 	}
 	return existingStrong, nil
 }
 
-func archiveContinuityProven(ctx context.Context, tx *sql.Tx, incoming []Message) (bool, error) {
+func archiveEntityRows(ctx context.Context, tx *sql.Tx) (int, error) {
 	var entityRows int
 	if err := tx.QueryRowContext(ctx, `select
 (select count(*) from contacts)+(select count(*) from chats)+(select count(*) from groups)+
 (select count(*) from group_participants)+(select count(*) from messages)`).Scan(&entityRows); err != nil {
-		return false, err
+		return 0, err
 	}
-	if entityRows == 0 {
-		return true, nil
-	}
-	for _, candidate := range incoming {
-		existing, found, err := messageBySourcePK(ctx, tx, candidate.SourcePK)
-		if err != nil {
-			return false, err
-		}
-		if found && !messageIdentityConflict(existing, candidate) {
-			return true, nil
-		}
-	}
-	return false, nil
+	return entityRows, nil
 }
 
 func formatSyncTime(value time.Time) string {
@@ -776,6 +788,7 @@ func messageEventID(sourcePK int64) string {
 
 func upsertMessage(ctx context.Context, tx *sql.Tx, m Message, observedAt time.Time) error {
 	sourcePayloadCleared := m.SourceTextNull && m.RawType == 0 && m.MediaTitle == "" && m.MediaType == "" && m.MediaPath == "" && m.MediaURL == "" && m.DeletedAt.IsZero()
+	preserveExistingFTS := false
 	if m.EventID == "" {
 		m.EventID = messageEventID(m.SourcePK)
 	}
@@ -788,18 +801,14 @@ func upsertMessage(ctx context.Context, tx *sql.Tx, m Message, observedAt time.T
 		if messageIdentityConflict(existing, m) {
 			return fmt.Errorf("message source_pk %d belongs to a different event; use a separate archive or import --restore", m.SourcePK)
 		}
-		if !existing.DeletedAt.IsZero() && m.DeletedAt.IsZero() {
+		if !existing.DeletedAt.IsZero() {
 			return nil
 		}
 		if sourcePayloadCleared && (!existing.DeletedAt.IsZero() || messageHasPayload(existing)) {
 			m.Tombstone = sourceTombstone(observedAt, "whatsapp_payload_cleared")
+			preserveExistingFTS = messageHasPayload(existing)
 		}
 		m.EventID = existing.EventID
-		if !existing.DeletedAt.IsZero() && !m.DeletedAt.IsZero() {
-			m.DeletedAt = existing.DeletedAt
-			m.DeletionSource = existing.DeletionSource
-			m.DeletionReason = existing.DeletionReason
-		}
 		previous, err := canonicalMessageJSON(existing)
 		if err != nil {
 			return err
@@ -812,8 +821,6 @@ func upsertMessage(ctx context.Context, tx *sql.Tx, m Message, observedAt time.T
 			reason := "whatsapp_edit"
 			if !m.DeletedAt.IsZero() && existing.DeletedAt.IsZero() {
 				reason = m.DeletionReason
-			} else if m.DeletedAt.IsZero() && !existing.DeletedAt.IsZero() {
-				reason = "whatsapp_restore"
 			}
 			if _, err := tx.ExecContext(ctx, `insert into message_revisions(event_id,payload_json,recorded_at,event_source,reason) values(?,?,?,?,?)`,
 				existing.EventID, previous, unix(observedAt), "whatsapp-desktop", reason); err != nil {
@@ -839,13 +846,15 @@ last_seen_at=excluded.last_seen_at`,
 		nullableUnix(m.DeletedAt), nullableString(m.DeletionSource), nullableString(m.DeletionReason), unix(m.LastSeenAt)); err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, `delete from messages_fts where rowid=(select rowid from messages where source_pk=?)`, m.SourcePK); err != nil {
-		return err
-	}
-	if _, err := tx.ExecContext(ctx, `insert into messages_fts(rowid,text,chat,sender,media)
+	if !preserveExistingFTS {
+		if _, err := tx.ExecContext(ctx, `delete from messages_fts where rowid=(select rowid from messages where source_pk=?)`, m.SourcePK); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `insert into messages_fts(rowid,text,chat,sender,media)
 values((select rowid from messages where source_pk=?),?,?,?,?)`, m.SourcePK,
-		strings.TrimSpace(m.Text+" "+m.MediaTitle), m.ChatName, m.SenderName, m.MediaType); err != nil {
-		return err
+			strings.TrimSpace(m.Text+" "+m.MediaTitle), m.ChatName, m.SenderName, m.MediaType); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1016,6 +1025,9 @@ func (s *Store) Status(ctx context.Context) (Status, error) {
 	lastImport, _ := s.q.GetSyncState(ctx, "last_import_at")
 	if t, err := time.Parse(time.RFC3339Nano, lastImport); err == nil {
 		out.LastImportAt = t
+	}
+	if value, err := s.q.GetSyncState(ctx, "source_snapshot_at"); err == nil {
+		out.LastSourceSnapshot, _ = time.Parse(time.RFC3339Nano, value)
 	}
 	out.LastSource, _ = s.q.GetSyncState(ctx, "source_path")
 	if value, err := s.q.GetSyncState(ctx, "source_messages"); err == nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,10 +3,12 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,11 +19,11 @@ import (
 )
 
 const (
-	schemaVersion     = 1
+	schemaVersion     = 2
 	maxJSONUnixSecond = 253402300799 // 9999-12-31T23:59:59Z, the largest time.Time JSON can marshal.
 
-	messageSelectColumns = `source_pk, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred, '' as snippet`
-	messageScanColumns   = `source_pk, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred, snippet`
+	messageSelectColumns = `source_pk, event_id, chat_jid, coalesce(chat_name,'') as chat_name, msg_id, coalesce(sender_jid,'') as sender_jid, coalesce(sender_name,'') as sender_name, ts, from_me, coalesce(text,'') as text, raw_type, coalesce(message_type,'') as message_type, coalesce(media_type,'') as media_type, coalesce(media_title,'') as media_title, coalesce(media_path,'') as media_path, coalesce(media_url,'') as media_url, coalesce(media_size,0) as media_size, starred, coalesce(deleted_at,0) as deleted_at, coalesce(deletion_source,'') as deletion_source, coalesce(deletion_reason,'') as deletion_reason, last_seen_at, '' as snippet`
+	messageScanColumns   = `source_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred, deleted_at, deletion_source, deletion_reason, last_seen_at, snippet`
 )
 
 type Store struct {
@@ -31,37 +33,61 @@ type Store struct {
 }
 
 type ImportStats struct {
-	SourcePath    string    `json:"source_path"`
-	DBPath        string    `json:"db_path"`
-	Chats         int       `json:"chats"`
-	Contacts      int       `json:"contacts"`
-	Groups        int       `json:"groups"`
-	Participants  int       `json:"participants"`
-	Messages      int       `json:"messages"`
-	MediaMessages int       `json:"media_messages"`
-	MediaCopied   int       `json:"media_copied,omitempty"`
-	MediaMissing  int       `json:"media_missing,omitempty"`
-	StartedAt     time.Time `json:"started_at"`
-	FinishedAt    time.Time `json:"finished_at"`
+	Mode                string    `json:"mode"`
+	SourceIdentity      string    `json:"-"`
+	AccountIdentity     string    `json:"-"`
+	SourceNewestMessage time.Time `json:"-"`
+	SourcePath          string    `json:"source_path"`
+	DBPath              string    `json:"db_path"`
+	Chats               int       `json:"chats"`
+	Contacts            int       `json:"contacts"`
+	Groups              int       `json:"groups"`
+	Participants        int       `json:"participants"`
+	Messages            int       `json:"messages"`
+	MediaMessages       int       `json:"media_messages"`
+	MediaCopied         int       `json:"media_copied,omitempty"`
+	MediaMissing        int       `json:"media_missing,omitempty"`
+	StartedAt           time.Time `json:"started_at"`
+	FinishedAt          time.Time `json:"finished_at"`
 }
 
 type Status struct {
-	DBPath         string    `json:"db_path"`
-	Chats          int       `json:"chats"`
-	UnreadChats    int       `json:"unread_chats"`
-	UnreadMessages int       `json:"unread_messages"`
-	Contacts       int       `json:"contacts"`
-	Groups         int       `json:"groups"`
-	Participants   int       `json:"participants"`
-	Messages       int       `json:"messages"`
-	MediaMessages  int       `json:"media_messages"`
-	OldestMessage  time.Time `json:"oldest_message,omitzero"`
-	NewestMessage  time.Time `json:"newest_message,omitzero"`
-	LastImportAt   time.Time `json:"last_import_at,omitzero"`
-	LastSource     string    `json:"last_source,omitempty"`
+	DBPath              string    `json:"db_path"`
+	Chats               int       `json:"chats"`
+	UnreadChats         int       `json:"unread_chats"`
+	UnreadMessages      int       `json:"unread_messages"`
+	Contacts            int       `json:"contacts"`
+	Groups              int       `json:"groups"`
+	Participants        int       `json:"participants"`
+	Messages            int       `json:"messages"`
+	MediaMessages       int       `json:"media_messages"`
+	DeletedChats        int       `json:"deleted_chats"`
+	DeletedContacts     int       `json:"deleted_contacts"`
+	DeletedGroups       int       `json:"deleted_groups"`
+	DeletedParticipants int       `json:"deleted_participants"`
+	DeletedMessages     int       `json:"deleted_messages"`
+	MessageRevisions    int       `json:"message_revisions"`
+	OldestMessage       time.Time `json:"oldest_message,omitzero"`
+	NewestMessage       time.Time `json:"newest_message,omitzero"`
+	LastImportAt        time.Time `json:"last_import_at,omitzero"`
+	LastSource          string    `json:"last_source,omitempty"`
+	LastSourceMessages  int       `json:"last_source_messages,omitempty"`
+	LastSourceContacts  int       `json:"last_source_contacts,omitempty"`
+	SourceMessagesKnown bool      `json:"-"`
+	SourceContactsKnown bool      `json:"-"`
+	LastSourceNewest    time.Time `json:"-"`
+	NewestObserved      time.Time `json:"-"`
+}
+
+type Tombstone struct {
+	DeletedAt      time.Time `json:"deleted_at,omitzero"`
+	DeletionSource string    `json:"deletion_source,omitempty"`
+	DeletionReason string    `json:"deletion_reason,omitempty"`
+	LastSeenAt     time.Time `json:"last_seen_at,omitzero"`
 }
 
 type Chat struct {
+	Tombstone
 	JID            string
 	Kind           string
 	Name           string
@@ -80,6 +106,7 @@ type ChatFilter struct {
 }
 
 type Contact struct {
+	Tombstone
 	JID          string
 	Phone        string
 	FullName     string
@@ -93,6 +120,7 @@ type Contact struct {
 }
 
 type Group struct {
+	Tombstone
 	JID       string
 	Name      string
 	OwnerJID  string
@@ -100,6 +128,7 @@ type Group struct {
 }
 
 type GroupParticipant struct {
+	Tombstone
 	GroupJID    string
 	UserJID     string
 	ContactName string
@@ -109,24 +138,36 @@ type GroupParticipant struct {
 }
 
 type Message struct {
-	SourcePK    int64     `json:"source_pk"`
-	ChatJID     string    `json:"chat_jid"`
-	ChatName    string    `json:"chat_name,omitempty"`
-	MessageID   string    `json:"message_id"`
-	SenderJID   string    `json:"sender_jid,omitempty"`
-	SenderName  string    `json:"sender_name,omitempty"`
-	Timestamp   time.Time `json:"timestamp"`
-	FromMe      bool      `json:"from_me"`
-	Text        string    `json:"text,omitempty"`
-	RawType     int       `json:"raw_type"`
-	MessageType string    `json:"message_type,omitempty"`
-	MediaType   string    `json:"media_type,omitempty"`
-	MediaTitle  string    `json:"media_title,omitempty"`
-	MediaPath   string    `json:"media_path,omitempty"`
-	MediaURL    string    `json:"media_url,omitempty"`
-	MediaSize   int64     `json:"media_size,omitempty"`
-	Starred     bool      `json:"starred,omitempty"`
-	Snippet     string    `json:"snippet,omitempty"`
+	Tombstone
+	SourcePK       int64     `json:"source_pk"`
+	EventID        string    `json:"event_id"`
+	ChatJID        string    `json:"chat_jid"`
+	ChatName       string    `json:"chat_name,omitempty"`
+	MessageID      string    `json:"message_id"`
+	SenderJID      string    `json:"sender_jid,omitempty"`
+	SenderName     string    `json:"sender_name,omitempty"`
+	Timestamp      time.Time `json:"timestamp"`
+	FromMe         bool      `json:"from_me"`
+	Text           string    `json:"text,omitempty"`
+	RawType        int       `json:"raw_type"`
+	MessageType    string    `json:"message_type,omitempty"`
+	MediaType      string    `json:"media_type,omitempty"`
+	MediaTitle     string    `json:"media_title,omitempty"`
+	MediaPath      string    `json:"media_path,omitempty"`
+	MediaURL       string    `json:"media_url,omitempty"`
+	MediaSize      int64     `json:"media_size,omitempty"`
+	Starred        bool      `json:"starred,omitempty"`
+	Snippet        string    `json:"snippet,omitempty"`
+	SourceTextNull bool      `json:"-"`
+	storedUnix     int64
+}
+
+type MessageRevision struct {
+	EventID     string    `json:"event_id"`
+	PayloadJSON string    `json:"payload_json"`
+	RecordedAt  time.Time `json:"recorded_at"`
+	EventSource string    `json:"event_source"`
+	Reason      string    `json:"reason"`
 }
 
 type MessageFilter struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,12 +2,640 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestMergeAllPreservesAbsentRowsAndTracksTombstones(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "merge.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+	chat := Chat{JID: "group@g.us", Kind: "group", Name: "Group", LastMessageAt: now}
+	group := Group{JID: chat.JID, Name: chat.Name, OwnerJID: "owner@s.whatsapp.net", CreatedAt: now.Add(-time.Hour)}
+	participant := GroupParticipant{GroupJID: chat.JID, UserJID: "alice@s.whatsapp.net", ContactName: "Alice", IsActive: true}
+	messages := []Message{
+		{SourcePK: 1, ChatJID: chat.JID, ChatName: chat.Name, MessageID: "a", SenderJID: participant.UserJID, Timestamp: now, Text: "first body", RawType: 0, MessageType: "text"},
+		{SourcePK: 2, ChatJID: chat.JID, ChatName: chat.Name, MessageID: "b", SenderJID: participant.UserJID, Timestamp: now.Add(time.Second), Text: "destination only", RawType: 0, MessageType: "text"},
+	}
+	stats := ImportStats{SourcePath: "/fixture", SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", Contacts: 1, Chats: 1, Groups: 1, Participants: 1, Messages: 2, FinishedAt: now}
+	if err := st.MergeAll(ctx, stats,
+		[]Contact{{JID: participant.UserJID, FullName: "Alice"}}, []Chat{chat}, []Group{group}, []GroupParticipant{participant}, messages); err != nil {
+		t.Fatal(err)
+	}
+	var originalRowID int64
+	var eventID string
+	if err := st.DB().QueryRowContext(ctx, `select rowid,event_id from messages where source_pk=1`).Scan(&originalRowID, &eventID); err != nil {
+		t.Fatal(err)
+	}
+	if eventID != "wa:1" {
+		t.Fatalf("event id = %q", eventID)
+	}
+	bySource, err := st.MessageBySourcePK(ctx, 1)
+	if err != nil || bySource.EventID != eventID {
+		t.Fatalf("message by source = %+v, %v", bySource, err)
+	}
+	if _, err := st.MessageBySourcePK(ctx, 999); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("missing message by source error = %v", err)
+	}
+
+	// An empty observation is not an authoritative deletion set.
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/fixture", SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: now.Add(time.Minute)}, nil, nil, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Messages != 2 || status.Chats != 1 || status.Contacts != 1 || status.DeletedMessages != 0 {
+		t.Fatalf("empty merge changed canonical rows: %+v", status)
+	}
+
+	edited := messages[0]
+	edited.Text = "edited body"
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/fixture", SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", Messages: 1, FinishedAt: now.Add(2 * time.Minute)}, nil, nil, nil, nil, []Message{edited}); err != nil {
+		t.Fatal(err)
+	}
+	var editedRowID int64
+	if err := st.DB().QueryRowContext(ctx, `select rowid from messages where source_pk=1`).Scan(&editedRowID); err != nil {
+		t.Fatal(err)
+	}
+	if editedRowID != originalRowID {
+		t.Fatalf("message row identity changed: before=%d after=%d", originalRowID, editedRowID)
+	}
+	status, err = st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.MessageRevisions != 1 {
+		t.Fatalf("edit revisions = %d", status.MessageRevisions)
+	}
+	var revision string
+	if err := st.DB().QueryRowContext(ctx, `select payload_json from message_revisions where event_id='wa:1'`).Scan(&revision); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(revision, "first body") {
+		t.Fatalf("revision did not retain prior payload: %s", revision)
+	}
+	exported, err := st.ExportAll(ctx)
+	if err != nil || len(exported.Revisions) != 1 || exported.Revisions[0].EventID != eventID {
+		t.Fatalf("revision export = %+v, %v", exported.Revisions, err)
+	}
+
+	chat.Removed = true
+	deletedAt := now.Add(3 * time.Minute)
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/fixture", SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", Chats: 1, FinishedAt: deletedAt}, nil, []Chat{chat}, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	status, err = st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Chats != 0 || status.Groups != 0 || status.Participants != 0 || status.Messages != 0 || status.DeletedChats != 1 || status.DeletedGroups != 1 || status.DeletedParticipants != 1 || status.DeletedMessages != 2 {
+		t.Fatalf("subordinate tombstones = %+v", status)
+	}
+	for table, reason := range map[string]string{
+		"chats": "whatsapp_removed", "groups": "parent_chat_deleted", "group_participants": "parent_group_deleted", "messages": "parent_chat_deleted",
+	} {
+		var missing int
+		query := `select count(*) from ` + table + ` where deleted_at is not null and deletion_source='whatsapp-desktop' and deletion_reason=?`
+		if err := st.DB().QueryRowContext(ctx, query, reason).Scan(&missing); err != nil {
+			t.Fatal(err)
+		}
+		if missing == 0 {
+			t.Fatalf("%s missing tombstone reason %q", table, reason)
+		}
+	}
+	results, err := st.Search(ctx, MessageFilter{Query: "destination", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("tombstoned child remained searchable: %+v", results)
+	}
+
+	var firstDeletedAt int64
+	if err := st.DB().QueryRowContext(ctx, `select deleted_at from chats where jid=?`, chat.JID).Scan(&firstDeletedAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/fixture", SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", Chats: 1, FinishedAt: deletedAt.Add(time.Minute)}, nil, []Chat{chat}, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	var repeatedDeletedAt int64
+	if err := st.DB().QueryRowContext(ctx, `select deleted_at from chats where jid=?`, chat.JID).Scan(&repeatedDeletedAt); err != nil {
+		t.Fatal(err)
+	}
+	if repeatedDeletedAt != firstDeletedAt {
+		t.Fatalf("repeated tombstone moved timestamp: before=%d after=%d", firstDeletedAt, repeatedDeletedAt)
+	}
+	var revisionsBefore int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from message_revisions`).Scan(&revisionsBefore); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/fixture", SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", Messages: 1, FinishedAt: deletedAt.Add(time.Minute)}, nil, nil, nil, nil, []Message{edited}); err != nil {
+		t.Fatal(err)
+	}
+	var revisionsAfter int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from message_revisions`).Scan(&revisionsAfter); err != nil {
+		t.Fatal(err)
+	}
+	if revisionsAfter != revisionsBefore {
+		t.Fatalf("stored parent tombstone created revision: before=%d after=%d", revisionsBefore, revisionsAfter)
+	}
+
+	chat.Removed = false
+	chat.LastMessageAt = deletedAt.Add(time.Minute)
+	participant.IsActive = true
+	newMessage := Message{SourcePK: 3, ChatJID: chat.JID, ChatName: chat.Name, MessageID: "c", SenderJID: participant.UserJID, Timestamp: chat.LastMessageAt, Text: "new lifecycle", RawType: 0, MessageType: "text"}
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/fixture", SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", Chats: 1, Groups: 1, Participants: 1, Messages: 1, FinishedAt: deletedAt.Add(2 * time.Minute)},
+		nil, []Chat{chat}, []Group{group}, []GroupParticipant{participant}, []Message{newMessage}); err != nil {
+		t.Fatal(err)
+	}
+	status, err = st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Chats != 1 || status.Groups != 1 || status.Participants != 1 || status.Messages != 1 || status.DeletedMessages != 2 {
+		t.Fatalf("authoritative resurrection = %+v", status)
+	}
+	results, err = st.Search(ctx, MessageFilter{Query: "lifecycle", Limit: 10})
+	if err != nil || len(results) != 1 {
+		t.Fatalf("resurrected message search = %+v, %v", results, err)
+	}
+}
+
+func TestIncomingParentTombstoneMarksWholeFamily(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "family.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	now := time.Date(2026, 7, 18, 16, 0, 0, 0, time.UTC)
+	chat := Chat{JID: "group@g.us", Kind: "group", Removed: true}
+	group := Group{JID: chat.JID, Name: "Group"}
+	participant := GroupParticipant{GroupJID: chat.JID, UserJID: "member", IsActive: true}
+	message := Message{Tombstone: Tombstone{DeletedAt: now.Add(-time.Minute), DeletionSource: "operator", DeletionReason: "explicit_child"}, SourcePK: 42, ChatJID: chat.JID, MessageID: "message", Timestamp: now, Text: "body", RawType: 0}
+	contact := Contact{Tombstone: Tombstone{DeletedAt: now}, JID: "deleted-contact"}
+	if err := st.MergeAll(ctx, ImportStats{FinishedAt: now, Contacts: 1, Chats: 1, Groups: 1, Participants: 1, Messages: 1},
+		[]Contact{contact}, []Chat{chat}, []Group{group}, []GroupParticipant{participant}, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.DeletedContacts != 1 || status.DeletedChats != 1 || status.DeletedGroups != 1 || status.DeletedParticipants != 1 || status.DeletedMessages != 1 {
+		t.Fatalf("family tombstones = %+v", status)
+	}
+	exported, err := st.ExportAll(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exported.Contacts) != 1 || len(exported.Chats) != 1 || len(exported.Groups) != 1 || len(exported.Participants) != 1 || len(exported.Messages) != 1 {
+		t.Fatalf("tombstone export = %+v", exported)
+	}
+	if exported.Contacts[0].DeletionSource != "snapshot" || exported.Contacts[0].DeletionReason != "explicit_tombstone" {
+		t.Fatalf("default tombstone provenance = %+v", exported.Contacts[0])
+	}
+	if exported.Groups[0].DeletionReason != "parent_chat_deleted" || exported.Participants[0].DeletionReason != "parent_group_deleted" || exported.Messages[0].DeletionSource != "operator" || exported.Messages[0].DeletionReason != "explicit_child" {
+		t.Fatalf("child reasons group=%+v participant=%+v message=%+v", exported.Groups[0], exported.Participants[0], exported.Messages[0])
+	}
+	deleted, err := st.Messages(ctx, MessageFilter{IncludeDeleted: true, Limit: 10})
+	if err != nil || len(deleted) != 1 || deleted[0].EventID != "wa:42" {
+		t.Fatalf("include deleted = %+v, %v", deleted, err)
+	}
+	contacts, err := st.Contacts(ctx)
+	if err != nil || len(contacts) != 0 {
+		t.Fatalf("live contacts = %+v, %v", contacts, err)
+	}
+}
+
+func TestMergeAllTombstonesObservableWhatsAppDeletion(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "delete.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	now := time.Date(2026, 7, 18, 13, 0, 0, 0, time.UTC)
+	message := Message{SourcePK: 9, ChatJID: "chat", ChatName: "Chat", MessageID: "stanza", Timestamp: now, Text: "secret body", RawType: 0, MessageType: "text"}
+	if err := st.MergeAll(ctx, ImportStats{SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: now, Messages: 1}, nil, []Chat{{JID: "chat", Kind: "dm"}}, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	message.Text = ""
+	message.SourceTextNull = true
+	if err := st.MergeAll(ctx, ImportStats{SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: now.Add(time.Minute), Messages: 1}, nil, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Messages != 0 || status.DeletedMessages != 1 || status.MessageRevisions != 1 {
+		t.Fatalf("observable delete status = %+v", status)
+	}
+	results, err := st.Search(ctx, MessageFilter{Query: "secret", Limit: 10})
+	if err != nil || len(results) != 0 {
+		t.Fatalf("normal search exposed tombstone: %+v, %v", results, err)
+	}
+	results, err = st.Search(ctx, MessageFilter{Query: "secret", IncludeDeleted: true, Limit: 10})
+	if err != nil || len(results) != 1 || results[0].EventID != "wa:9" || !strings.Contains(results[0].Snippet, "[secret]") {
+		t.Fatalf("include-deleted search = %+v, %v", results, err)
+	}
+	var reason, payload string
+	if err := st.DB().QueryRowContext(ctx, `select deletion_reason from messages where source_pk=9`).Scan(&reason); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select payload_json from message_revisions where event_id='wa:9'`).Scan(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if reason != "whatsapp_payload_cleared" || !strings.Contains(payload, "secret body") {
+		t.Fatalf("delete reason=%q revision=%s", reason, payload)
+	}
+	firstSeenNull := Message{SourcePK: 10, ChatJID: "chat", MessageID: "empty", Timestamp: now, RawType: 0, SourceTextNull: true}
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/fixture", SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: now.Add(2 * time.Minute), Messages: 2}, nil, nil, nil, nil, []Message{message, firstSeenNull}); err != nil {
+		t.Fatal(err)
+	}
+	status, err = st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Messages != 1 || status.DeletedMessages != 1 {
+		t.Fatalf("first-seen null payload was inferred deleted: %+v", status)
+	}
+}
+
+func TestReplaceAllIsExplicitExactRestore(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "restore.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	now := time.Date(2026, 7, 18, 14, 0, 0, 0, time.UTC)
+	chat := Chat{JID: "chat", Kind: "dm"}
+	first := Message{SourcePK: 1, ChatJID: chat.JID, MessageID: "one", Timestamp: now, Text: "one", RawType: 0}
+	second := Message{SourcePK: 2, ChatJID: chat.JID, MessageID: "two", Timestamp: now, Text: "two", RawType: 0}
+	if err := st.MergeAll(ctx, ImportStats{SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: now, Messages: 2}, nil, []Chat{chat}, nil, nil, []Message{first, second}); err != nil {
+		t.Fatal(err)
+	}
+	first.Text = "edited"
+	if err := st.MergeAll(ctx, ImportStats{SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: now.Add(time.Minute), Messages: 1}, nil, nil, nil, nil, []Message{first}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ReplaceAll(ctx, ImportStats{FinishedAt: now.Add(2 * time.Minute), Messages: 1}, nil, []Chat{chat}, nil, nil, []Message{first}); err != nil {
+		t.Fatal(err)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Messages != 1 || status.MessageRevisions != 0 {
+		t.Fatalf("restore status = %+v", status)
+	}
+	var removed int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from messages where source_pk=2`).Scan(&removed); err != nil {
+		t.Fatal(err)
+	}
+	if removed != 0 {
+		t.Fatalf("restore retained destination-only rows: %d", removed)
+	}
+}
+
+func TestMergeAllRejectsDifferentSourceAndIdentityCollision(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "identity.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	now := time.Date(2026, 7, 18, 17, 0, 0, 0, time.UTC)
+	message := Message{SourcePK: 1, ChatJID: "chat-a", MessageID: "one", Timestamp: now, Text: "original", RawType: 0}
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/account-a", FinishedAt: now, Messages: 1}, nil,
+		[]Chat{{JID: message.ChatJID, Kind: "dm"}}, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/account-b", FinishedAt: now.Add(time.Minute), Messages: 1}, nil, nil, nil, nil, []Message{message}); err == nil || !strings.Contains(err.Error(), "separate --db") {
+		t.Fatalf("different source error = %v", err)
+	}
+	collision := message
+	collision.ChatJID = "chat-b"
+	collision.MessageID = "different"
+	collision.Text = "replacement"
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/account-a", FinishedAt: now.Add(time.Minute), Messages: 1}, nil,
+		[]Chat{{JID: collision.ChatJID, Kind: "dm"}}, nil, nil, []Message{collision}); err == nil || !strings.Contains(err.Error(), "different event") {
+		t.Fatalf("identity collision error = %v", err)
+	}
+	stored, err := st.MessageBySourcePK(ctx, 1)
+	if err != nil || stored.Text != "original" || stored.ChatJID != "chat-a" {
+		t.Fatalf("collision changed stored message: %+v, %v", stored, err)
+	}
+	if err := st.ReplaceAll(ctx, ImportStats{SourcePath: "/account-b", SourceIdentity: "/account-b", AccountIdentity: "account-b", FinishedAt: now.Add(2 * time.Minute), Messages: 1}, nil,
+		[]Chat{{JID: collision.ChatJID, Kind: "dm"}}, nil, nil, []Message{collision}); err != nil {
+		t.Fatalf("explicit restore should switch sources: %v", err)
+	}
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/account-b", SourceIdentity: "/account-b", AccountIdentity: "account-b", FinishedAt: now.Add(3 * time.Minute), Messages: 1}, nil, nil, nil, nil, []Message{collision}); err != nil {
+		t.Fatalf("merge after explicit source switch: %v", err)
+	}
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/account-a", SourceIdentity: "/account-a", AccountIdentity: "account-a", FinishedAt: now.Add(4 * time.Minute), Messages: 1}, nil, nil, nil, nil, []Message{collision}); err == nil || !strings.Contains(err.Error(), "separate --db") {
+		t.Fatalf("restore did not bind replacement source: %v", err)
+	}
+}
+
+func TestPortableRestoreRequiresExplicitSourceAdoption(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "portable.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	now := time.Date(2026, 7, 18, 17, 30, 0, 0, time.UTC)
+	message := Message{SourcePK: 1, ChatJID: "chat", MessageID: "one", Timestamp: now, Text: "body", RawType: 0}
+	if err := st.ReplaceAll(ctx, ImportStats{SourcePath: "backup:/portable", FinishedAt: now, Messages: 1}, nil,
+		[]Chat{{JID: message.ChatJID, Kind: "dm"}}, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	stats := ImportStats{SourcePath: "/account-a", SourceIdentity: "/account-a", AccountIdentity: "account-a", FinishedAt: now.Add(time.Minute), Messages: 1}
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, []Message{message}); err == nil || !strings.Contains(err.Error(), "--adopt-source") {
+		t.Fatalf("portable restore accepted an unverified source: %v", err)
+	}
+	stats.AdoptSource = true
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatalf("explicit source adoption failed: %v", err)
+	}
+}
+
+func TestMergeInheritsLegacySourceBinding(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "legacy-binding.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	now := time.Date(2026, 7, 18, 17, 45, 0, 0, time.UTC)
+	message := Message{SourcePK: 1, ChatJID: "chat", MessageID: "one", Timestamp: now, Text: "body", RawType: 0}
+	if err := st.MergeAll(ctx, ImportStats{FinishedAt: now, Messages: 1}, nil, []Chat{{JID: "chat", Kind: "dm"}}, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DB().ExecContext(ctx, `insert into sync_state(key,value,updated_at) values('source_path','/account-a',?) on conflict(key) do update set value=excluded.value`, now.Unix()); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MergeAll(ctx, ImportStats{SourceIdentity: "/account-b", AccountIdentity: "account-b", FinishedAt: now}, nil, nil, nil, nil, nil); err == nil || !strings.Contains(err.Error(), "separate --db") {
+		t.Fatalf("different source bypassed legacy binding: %v", err)
+	}
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/account-a", SourceIdentity: "/account-a", AccountIdentity: "account-a", AdoptSource: true, FinishedAt: now, Messages: 1}, nil, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatalf("matching source failed legacy binding: %v", err)
+	}
+	var binding string
+	if err := st.DB().QueryRowContext(ctx, `select value from sync_state where key='merge_source_path'`).Scan(&binding); err != nil || binding != "/account-a" {
+		t.Fatalf("seeded binding = %q, %v", binding, err)
+	}
+}
+
+func TestMergeUpgradesAndChecksSourceStoreBinding(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "store-binding.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	now := time.Date(2026, 7, 18, 17, 50, 0, 0, time.UTC)
+	message := Message{SourcePK: 1, ChatJID: "chat", MessageID: "one", Timestamp: now, Text: "body", RawType: 0}
+	base := ImportStats{SourcePath: "/source", SourceIdentity: "/source", AccountIdentity: "wa-account:fixture", FinishedAt: now, Messages: 1}
+	if err := st.MergeAll(ctx, base, nil, []Chat{{JID: "chat", Kind: "dm"}}, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	base.SourceStoreIdentity = "wa-store:first"
+	if err := st.MergeAll(ctx, base, nil, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatalf("store binding upgrade: %v", err)
+	}
+	base.SourceStoreIdentity = ""
+	if err := st.MergeAll(ctx, base, nil, nil, nil, nil, []Message{message}); err == nil || !strings.Contains(err.Error(), "different WhatsApp Desktop store") {
+		t.Fatalf("missing established store error = %v", err)
+	}
+	base.SourceStoreIdentity = "wa-store:second"
+	if err := st.MergeAll(ctx, base, nil, nil, nil, nil, []Message{message}); err == nil || !strings.Contains(err.Error(), "different WhatsApp Desktop store") {
+		t.Fatalf("different store error = %v", err)
+	}
+}
+
+func TestMergeAdoptsEarlyStoreUUIDAccountBinding(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "early-v2.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	now := time.Date(2026, 7, 18, 17, 55, 0, 0, time.UTC)
+	message := Message{SourcePK: 1, ChatJID: "chat", MessageID: "one", Timestamp: now, Text: "body", RawType: 0}
+	if err := st.MergeAll(ctx, ImportStats{FinishedAt: now, Messages: 1}, nil, []Chat{{JID: "chat", Kind: "dm"}}, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	for key, value := range map[string]string{
+		"source_path": "/source", "merge_source_path": "wa-store:legacy", "merge_account_identity": "wa-store:legacy",
+	} {
+		if _, err := st.DB().ExecContext(ctx, `insert into sync_state(key,value,updated_at) values(?,?,?) on conflict(key) do update set value=excluded.value`, key, value, now.Unix()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	exported, err := st.ExportAll(ctx)
+	if err != nil || exported.AccountIdentity != "" || exported.SourceStoreIdentity != "wa-store:legacy" {
+		t.Fatalf("early v2 export identity = %+v, %v", exported, err)
+	}
+	if err := exported.Validate(); err != nil {
+		t.Fatalf("early v2 export validation: %v", err)
+	}
+	stats := ImportStats{SourcePath: "/source", SourceIdentity: "/source", SourceStoreIdentity: "wa-store:legacy", AccountIdentity: "wa-account:verified", AdoptSource: true, FinishedAt: now, Messages: 1}
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatalf("early v2 binding adoption: %v", err)
+	}
+}
+
+func TestStrongSourceIdentityRequiresAccountContinuity(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "continuity.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	now := time.Date(2026, 7, 18, 18, 0, 0, 0, time.UTC)
+	if err := st.ValidateImport(ctx, ImportStats{SourceIdentity: "/source", AccountIdentity: "account-a"}, nil, false); err != nil {
+		t.Fatalf("empty archive preflight: %v", err)
+	}
+	existing := Message{SourcePK: 1, ChatJID: "chat-a", MessageID: "one", Timestamp: now, Text: "body", RawType: 0}
+	if err := st.MergeAll(ctx, ImportStats{FinishedAt: now, Messages: 1}, nil, []Chat{{JID: existing.ChatJID, Kind: "dm"}}, nil, nil, []Message{existing}); err != nil {
+		t.Fatal(err)
+	}
+	disjoint := Message{SourcePK: 2, ChatJID: "chat-b", MessageID: "two", Timestamp: now, Text: "other", RawType: 0}
+	if err := st.ValidateImport(ctx, ImportStats{SourceIdentity: "/source", AccountIdentity: "account-a"}, []Message{disjoint}, false); err == nil || !strings.Contains(err.Error(), "--adopt-source") {
+		t.Fatalf("unverified account binding error = %v", err)
+	}
+	if err := st.ValidateImport(ctx, ImportStats{SourceIdentity: "/source", AccountIdentity: "account-a"}, []Message{existing}, false); err == nil || !strings.Contains(err.Error(), "--adopt-source") {
+		t.Fatalf("event overlap bypassed source adoption: %v", err)
+	}
+	if err := st.MergeAll(ctx, ImportStats{SourceIdentity: "/source", AccountIdentity: "account-a", AdoptSource: true, FinishedAt: now, Messages: 1}, nil, nil, nil, nil, []Message{existing}); err != nil {
+		t.Fatalf("explicit account adoption: %v", err)
+	}
+	if err := st.ValidateImport(ctx, ImportStats{SourceIdentity: "/source"}, []Message{existing}, false); err == nil || !strings.Contains(err.Error(), "different WhatsApp account") {
+		t.Fatalf("missing account identity error = %v", err)
+	}
+	if err := st.ValidateImport(ctx, ImportStats{SourceIdentity: "/source", AccountIdentity: "account-a"}, []Message{disjoint}, false); err != nil {
+		t.Fatalf("bound account identity should admit new events: %v", err)
+	}
+	if err := st.MergeAll(ctx, ImportStats{SourceIdentity: "/source", AccountIdentity: "account-b", FinishedAt: now, Messages: 1}, nil, nil, nil, nil, []Message{existing}); err == nil || !strings.Contains(err.Error(), "different WhatsApp account") {
+		t.Fatalf("different account error = %v", err)
+	}
+	collision := existing
+	collision.MessageID = "different"
+	if err := st.ValidateImport(ctx, ImportStats{SourceIdentity: "/source", AccountIdentity: "account-a"}, []Message{collision}, false); err == nil || !strings.Contains(err.Error(), "different event") {
+		t.Fatalf("collision preflight error = %v", err)
+	}
+	if err := st.ValidateImport(ctx, ImportStats{}, []Message{{SourcePK: 0}}, true); err == nil || !strings.Contains(err.Error(), "empty source_pk") {
+		t.Fatalf("invalid restore preflight error = %v", err)
+	}
+}
+
+func TestSourceIdentityHelpers(t *testing.T) {
+	if got := legacySourceIdentity("  "); got != "" {
+		t.Fatalf("empty legacy identity = %q", got)
+	}
+	if got := legacySourceIdentity("backup:/tmp/repo"); got != "" {
+		t.Fatalf("backup legacy identity = %q", got)
+	}
+	target := t.TempDir()
+	link := filepath.Join(t.TempDir(), "source-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := legacySourceIdentity(link); got != want {
+		t.Fatalf("symlink legacy identity = %q, want %q", got, want)
+	}
+	if got := formatSyncTime(time.Time{}); got != "" {
+		t.Fatalf("zero sync time = %q", got)
+	}
+}
+
+func TestMessageRevisionComparisonUsesPersistedUnixTime(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "timestamps.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	instant := time.Unix(1_752_841_800, 987_654_321).UTC()
+	message := Message{SourcePK: 1, ChatJID: "chat", MessageID: "one", Timestamp: instant, Text: "body", RawType: 0}
+	if err := st.MergeAll(ctx, ImportStats{SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: instant, Messages: 1}, nil, []Chat{{JID: "chat", Kind: "dm"}}, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	message.Timestamp = instant.In(time.FixedZone("fixture", 5*60*60))
+	if err := st.MergeAll(ctx, ImportStats{SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: instant.Add(time.Minute), Messages: 1}, nil, nil, nil, nil, []Message{message}); err != nil {
+		t.Fatal(err)
+	}
+	poisoned := Message{SourcePK: 2, ChatJID: "chat", MessageID: "poisoned", Timestamp: time.Date(12000, 1, 1, 0, 0, 0, 0, time.UTC), Text: "future", RawType: 0}
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/fixture", SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: instant.Add(2 * time.Minute), Messages: 2}, nil, nil, nil, nil, []Message{message, poisoned}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MergeAll(ctx, ImportStats{SourcePath: "/fixture", SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: instant.Add(3 * time.Minute), Messages: 1}, nil, nil, nil, nil, []Message{poisoned}); err != nil {
+		t.Fatalf("repeat poisoned timestamp merge: %v", err)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.MessageRevisions != 0 || status.Messages != 2 {
+		t.Fatalf("timestamp-only revisions = %+v", status)
+	}
+}
+
+func TestMigrateV1ArchiveLosslessly(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "legacy.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := `
+create table chats (jid text primary key, kind text not null, name text, last_message_at integer, unread_count integer not null default 0, archived integer not null default 0, removed integer not null default 0, hidden integer not null default 0, raw_session_type integer not null default 0);
+create table contacts (jid text primary key, phone text, full_name text, first_name text, last_name text, business_name text, username text, lid text, about_text text, updated_at integer);
+create table groups (jid text primary key, name text, owner_jid text, created_at integer);
+create table group_participants (group_jid text not null, user_jid text not null, contact_name text, first_name text, is_admin integer not null default 0, is_active integer not null default 0, primary key(group_jid,user_jid));
+create table messages (rowid integer primary key autoincrement, source_pk integer not null unique, chat_jid text not null, chat_name text, msg_id text not null, sender_jid text, sender_name text, ts integer not null, from_me integer not null, text text, raw_type integer not null, message_type text, media_type text, media_title text, media_path text, media_url text, media_size integer, starred integer not null default 0);
+create virtual table messages_fts using fts5(text, chat, sender, media);
+create table sync_state (key text primary key, value text not null, updated_at integer not null);
+insert into contacts values('alice','1','Alice','','','','','','',100);
+insert into chats values('chat','dm','Chat',200,0,0,0,0,0);
+insert into groups values('chat','Chat','alice',50);
+insert into group_participants values('chat','alice','Alice','',1,1);
+insert into messages(source_pk,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,raw_type,message_type,media_type,media_title,media_path,media_url,media_size,starred) values(7,'chat','Chat','stanza','alice','Alice',200,0,'legacy body',0,'text','','','','',0,0);
+insert into messages_fts(rowid,text,chat,sender,media) values((select rowid from messages where source_pk=7),'legacy body','Chat','Alice','');
+insert into sync_state values('last_import_at','2026-07-17T12:00:00Z',1000);
+pragma user_version=1;`
+	if _, err := db.ExecContext(ctx, legacy); err != nil {
+		t.Fatal(err)
+	}
+	var rowID int64
+	if err := db.QueryRowContext(ctx, `select rowid from messages where source_pk=7`).Scan(&rowID); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := Open(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	var version int
+	var migratedRowID int64
+	var eventID string
+	var tombstones int
+	if err := st.DB().QueryRowContext(ctx, `pragma user_version`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DB().QueryRowContext(ctx, `select rowid,event_id,(deleted_at is not null)+(deletion_source is not null)+(deletion_reason is not null) from messages where source_pk=7`).Scan(&migratedRowID, &eventID, &tombstones); err != nil {
+		t.Fatal(err)
+	}
+	if version != schemaVersion || migratedRowID != rowID || eventID != "wa:7" || tombstones != 0 {
+		t.Fatalf("migration version=%d rowid=%d/%d event=%q tombstones=%d", version, migratedRowID, rowID, eventID, tombstones)
+	}
+	status, err := st.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Contacts != 1 || status.Chats != 1 || status.Groups != 1 || status.Participants != 1 || status.Messages != 1 {
+		t.Fatalf("migrated counts = %+v", status)
+	}
+	results, err := st.Search(ctx, MessageFilter{Query: "legacy", Limit: 10})
+	if err != nil || len(results) != 1 || results[0].Text != "legacy body" {
+		t.Fatalf("migrated search = %+v, %v", results, err)
+	}
+	var quickCheck string
+	if err := st.DB().QueryRowContext(ctx, `pragma quick_check`).Scan(&quickCheck); err != nil {
+		t.Fatal(err)
+	}
+	if quickCheck != "ok" {
+		t.Fatalf("quick_check = %q", quickCheck)
+	}
+	if _, err := st.DB().ExecContext(ctx, `insert into messages(source_pk,event_id,chat_jid,msg_id,ts,from_me,raw_type,starred,last_seen_at) values(8,'','chat','bad',200,0,0,0,1000)`); err == nil {
+		t.Fatal("empty event identity insert should fail")
+	}
+}
 
 func TestStoreReplaceStatusListSearch(t *testing.T) {
 	ctx := context.Background()
@@ -136,8 +764,31 @@ func TestStoreReplaceStatusListSearch(t *testing.T) {
 	if err := (SnapshotData{Messages: []Message{{SourcePK: 1}, {SourcePK: 1}}}).Validate(); err == nil {
 		t.Fatal("expected duplicate source_pk validation error")
 	}
+	if err := (SnapshotData{AccountIdentity: "raw-account"}).Validate(); err == nil {
+		t.Fatal("expected invalid account identity error")
+	}
+	if err := (SnapshotData{SourceStoreIdentity: "raw-store"}).Validate(); err == nil {
+		t.Fatal("expected invalid source-store identity error")
+	}
 	if err := (SnapshotData{Messages: []Message{{}}}).Validate(); err == nil {
 		t.Fatal("expected empty source_pk validation error")
+	}
+	if err := (SnapshotData{Messages: []Message{{SourcePK: 1, EventID: "same"}, {SourcePK: 2, EventID: "same"}}}).Validate(); err == nil {
+		t.Fatal("expected duplicate event_id validation error")
+	}
+	validRevision := MessageRevision{EventID: "wa:1", PayloadJSON: `{}`, RecordedAt: now, EventSource: "fixture", Reason: "edit"}
+	if err := (SnapshotData{Messages: []Message{{SourcePK: 1}}, Revisions: []MessageRevision{validRevision}}).Validate(); err != nil {
+		t.Fatalf("valid revision rejected: %v", err)
+	}
+	unknownRevision := validRevision
+	unknownRevision.EventID = "wa:missing"
+	if err := (SnapshotData{Messages: []Message{{SourcePK: 1}}, Revisions: []MessageRevision{unknownRevision}}).Validate(); err == nil {
+		t.Fatal("expected unknown revision event validation error")
+	}
+	incompleteRevision := validRevision
+	incompleteRevision.Reason = ""
+	if err := (SnapshotData{Messages: []Message{{SourcePK: 1}}, Revisions: []MessageRevision{incompleteRevision}}).Validate(); err == nil {
+		t.Fatal("expected incomplete revision validation error")
 	}
 }
 
@@ -156,6 +807,24 @@ func TestOpenRequiresPath(t *testing.T) {
 	}
 	if !fromUnix(0).IsZero() {
 		t.Fatal("zero unix should be zero time")
+	}
+}
+
+func TestOpenRejectsNewerSchema(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "future.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`pragma user_version=999`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Open(context.Background(), path); err == nil || !strings.Contains(err.Error(), "newer") {
+		t.Fatalf("newer schema error = %v", err)
 	}
 }
 
@@ -219,6 +888,33 @@ func TestReplaceAllDuplicateSourcePKFails(t *testing.T) {
 	}
 	if status.Messages != 0 {
 		t.Fatalf("failed replace should roll back, got %+v", status)
+	}
+}
+
+func TestValidateImportRejectsInvalidEventIdentity(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "store.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	cases := []struct {
+		name     string
+		messages []Message
+		want     string
+	}{
+		{name: "empty source pk", messages: []Message{{EventID: "event"}}, want: "empty source_pk"},
+		{name: "whitespace event id", messages: []Message{{SourcePK: 1, EventID: "  "}}, want: "empty event_id"},
+		{name: "generated event collision", messages: []Message{{SourcePK: 1}, {SourcePK: 2, EventID: "wa:1"}}, want: "duplicate message event_id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := st.ValidateImport(ctx, ImportStats{}, tc.messages, false)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("validation error = %v, want %q", err, tc.want)
+			}
+		})
 	}
 }
 
@@ -374,10 +1070,10 @@ values('c@s.whatsapp.net', 'dm', 'C', ?, 0, 0, 0, 0, 0)
 		t.Fatal(err)
 	}
 	if _, err := st.DB().ExecContext(ctx, `
-insert into messages(source_pk, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
+insert into messages(source_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
 values
-	(1, 'c@s.whatsapp.net', 'C', 'poison', '', '', ?, 0, 'poison', 0, 'text', '', '', '', '', 0, 0),
-	(2, 'c@s.whatsapp.net', 'C', 'valid', '', '', ?, 0, 'valid', 0, 'text', '', '', '', '', 0, 0)
+	(1, 'wa:1', 'c@s.whatsapp.net', 'C', 'poison', '', '', ?, 0, 'poison', 0, 'text', '', '', '', '', 0, 0),
+	(2, 'wa:2', 'c@s.whatsapp.net', 'C', 'valid', '', '', ?, 0, 'valid', 0, 'text', '', '', '', '', 0, 0)
 `, maxJSONUnixSecond+1, valid.Unix()); err != nil {
 		t.Fatal(err)
 	}
@@ -427,10 +1123,10 @@ values('c@s.whatsapp.net', 'dm', 'C', ?, 0, 0, 0, 0, 0)
 		t.Fatal(err)
 	}
 	if _, err := st.DB().ExecContext(ctx, `
-insert into messages(source_pk, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
+insert into messages(source_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
 values
-	(1, 'c@s.whatsapp.net', 'C', 'poison', '', '', ?, 0, 'poison', 0, 'text', '', '', '', '', 0, 0),
-	(2, 'c@s.whatsapp.net', 'C', 'valid', '', '', ?, 0, 'valid', 0, 'text', '', '', '', '', 0, 0)
+	(1, 'wa:1', 'c@s.whatsapp.net', 'C', 'poison', '', '', ?, 0, 'poison', 0, 'text', '', '', '', '', 0, 0),
+	(2, 'wa:2', 'c@s.whatsapp.net', 'C', 'valid', '', '', ?, 0, 'valid', 0, 'text', '', '', '', '', 0, 0)
 `, maxJSONUnixSecond+1, valid.Unix()); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/storedb/models.go
+++ b/internal/store/storedb/models.go
@@ -18,56 +18,86 @@ type Chat struct {
 	Removed        int64
 	Hidden         int64
 	RawSessionType int64
+	DeletedAt      sql.NullInt64
+	DeletionSource sql.NullString
+	DeletionReason sql.NullString
+	LastSeenAt     int64
 }
 
 type Contact struct {
-	Jid          string
-	Phone        sql.NullString
-	FullName     sql.NullString
-	FirstName    sql.NullString
-	LastName     sql.NullString
-	BusinessName sql.NullString
-	Username     sql.NullString
-	Lid          sql.NullString
-	AboutText    sql.NullString
-	UpdatedAt    sql.NullInt64
+	Jid            string
+	Phone          sql.NullString
+	FullName       sql.NullString
+	FirstName      sql.NullString
+	LastName       sql.NullString
+	BusinessName   sql.NullString
+	Username       sql.NullString
+	Lid            sql.NullString
+	AboutText      sql.NullString
+	UpdatedAt      sql.NullInt64
+	DeletedAt      sql.NullInt64
+	DeletionSource sql.NullString
+	DeletionReason sql.NullString
+	LastSeenAt     int64
 }
 
 type Group struct {
-	Jid       string
-	Name      sql.NullString
-	OwnerJid  sql.NullString
-	CreatedAt sql.NullInt64
+	Jid            string
+	Name           sql.NullString
+	OwnerJid       sql.NullString
+	CreatedAt      sql.NullInt64
+	DeletedAt      sql.NullInt64
+	DeletionSource sql.NullString
+	DeletionReason sql.NullString
+	LastSeenAt     int64
 }
 
 type GroupParticipant struct {
-	GroupJid    string
-	UserJid     string
-	ContactName sql.NullString
-	FirstName   sql.NullString
-	IsAdmin     int64
-	IsActive    int64
+	GroupJid       string
+	UserJid        string
+	ContactName    sql.NullString
+	FirstName      sql.NullString
+	IsAdmin        int64
+	IsActive       int64
+	DeletedAt      sql.NullInt64
+	DeletionSource sql.NullString
+	DeletionReason sql.NullString
+	LastSeenAt     int64
 }
 
 type Message struct {
-	Rowid       int64
-	SourcePk    int64
-	ChatJid     string
-	ChatName    sql.NullString
-	MsgID       string
-	SenderJid   sql.NullString
-	SenderName  sql.NullString
-	Ts          int64
-	FromMe      int64
-	Text        sql.NullString
-	RawType     int64
-	MessageType sql.NullString
-	MediaType   sql.NullString
-	MediaTitle  sql.NullString
-	MediaPath   sql.NullString
-	MediaUrl    sql.NullString
-	MediaSize   sql.NullInt64
-	Starred     int64
+	Rowid          int64
+	SourcePk       int64
+	EventID        string
+	ChatJid        string
+	ChatName       sql.NullString
+	MsgID          string
+	SenderJid      sql.NullString
+	SenderName     sql.NullString
+	Ts             int64
+	FromMe         int64
+	Text           sql.NullString
+	RawType        int64
+	MessageType    sql.NullString
+	MediaType      sql.NullString
+	MediaTitle     sql.NullString
+	MediaPath      sql.NullString
+	MediaUrl       sql.NullString
+	MediaSize      sql.NullInt64
+	Starred        int64
+	DeletedAt      sql.NullInt64
+	DeletionSource sql.NullString
+	DeletionReason sql.NullString
+	LastSeenAt     int64
+}
+
+type MessageRevision struct {
+	ID          int64
+	EventID     string
+	PayloadJson string
+	RecordedAt  int64
+	EventSource string
+	Reason      string
 }
 
 type MessagesFt struct {

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const countChats = `-- name: CountChats :one
-select count(*) from chats
+select count(*) from chats where deleted_at is null
 `
 
 func (q *Queries) CountChats(ctx context.Context) (int64, error) {
@@ -22,7 +22,7 @@ func (q *Queries) CountChats(ctx context.Context) (int64, error) {
 }
 
 const countContacts = `-- name: CountContacts :one
-select count(*) from contacts
+select count(*) from contacts where deleted_at is null
 `
 
 func (q *Queries) CountContacts(ctx context.Context) (int64, error) {
@@ -33,7 +33,7 @@ func (q *Queries) CountContacts(ctx context.Context) (int64, error) {
 }
 
 const countGroups = `-- name: CountGroups :one
-select count(*) from groups
+select count(*) from groups where deleted_at is null
 `
 
 func (q *Queries) CountGroups(ctx context.Context) (int64, error) {
@@ -44,7 +44,7 @@ func (q *Queries) CountGroups(ctx context.Context) (int64, error) {
 }
 
 const countMediaMessages = `-- name: CountMediaMessages :one
-select count(*) from messages where media_type <> '' or media_path <> '' or media_url <> ''
+select count(*) from messages where deleted_at is null and (media_type <> '' or media_path <> '' or media_url <> '')
 `
 
 func (q *Queries) CountMediaMessages(ctx context.Context) (int64, error) {
@@ -55,7 +55,7 @@ func (q *Queries) CountMediaMessages(ctx context.Context) (int64, error) {
 }
 
 const countMessages = `-- name: CountMessages :one
-select count(*) from messages
+select count(*) from messages where deleted_at is null
 `
 
 func (q *Queries) CountMessages(ctx context.Context) (int64, error) {
@@ -66,7 +66,7 @@ func (q *Queries) CountMessages(ctx context.Context) (int64, error) {
 }
 
 const countParticipants = `-- name: CountParticipants :one
-select count(*) from group_participants
+select count(*) from group_participants where deleted_at is null
 `
 
 func (q *Queries) CountParticipants(ctx context.Context) (int64, error) {
@@ -77,7 +77,7 @@ func (q *Queries) CountParticipants(ctx context.Context) (int64, error) {
 }
 
 const countUnreadChats = `-- name: CountUnreadChats :one
-select count(*) from chats where unread_count > 0
+select count(*) from chats where deleted_at is null and unread_count > 0
 `
 
 func (q *Queries) CountUnreadChats(ctx context.Context) (int64, error) {
@@ -88,7 +88,7 @@ func (q *Queries) CountUnreadChats(ctx context.Context) (int64, error) {
 }
 
 const countUnreadMessages = `-- name: CountUnreadMessages :one
-select cast(coalesce(sum(unread_count), 0) as integer) as unread_messages from chats
+select cast(coalesce(sum(unread_count), 0) as integer) as unread_messages from chats where deleted_at is null
 `
 
 func (q *Queries) CountUnreadMessages(ctx context.Context) (int64, error) {
@@ -171,7 +171,11 @@ select
 	archived,
 	removed,
 	hidden,
-	raw_session_type
+	raw_session_type,
+	coalesce(deleted_at, 0) as deleted_at,
+	coalesce(deletion_source, '') as deletion_source,
+	coalesce(deletion_reason, '') as deletion_reason,
+	last_seen_at
 from chats
 order by jid
 `
@@ -186,6 +190,10 @@ type ExportChatsRow struct {
 	Removed        int64
 	Hidden         int64
 	RawSessionType int64
+	DeletedAt      int64
+	DeletionSource string
+	DeletionReason string
+	LastSeenAt     int64
 }
 
 func (q *Queries) ExportChats(ctx context.Context) ([]ExportChatsRow, error) {
@@ -207,6 +215,10 @@ func (q *Queries) ExportChats(ctx context.Context) ([]ExportChatsRow, error) {
 			&i.Removed,
 			&i.Hidden,
 			&i.RawSessionType,
+			&i.DeletedAt,
+			&i.DeletionSource,
+			&i.DeletionReason,
+			&i.LastSeenAt,
 		); err != nil {
 			return nil, err
 		}
@@ -232,22 +244,30 @@ select
 	coalesce(username, '') as username,
 	coalesce(lid, '') as lid,
 	coalesce(about_text, '') as about_text,
-	coalesce(updated_at, 0) as updated_at
+	coalesce(updated_at, 0) as updated_at,
+	coalesce(deleted_at, 0) as deleted_at,
+	coalesce(deletion_source, '') as deletion_source,
+	coalesce(deletion_reason, '') as deletion_reason,
+	last_seen_at
 from contacts
 order by jid
 `
 
 type ExportContactsRow struct {
-	Jid          string
-	Phone        string
-	FullName     string
-	FirstName    string
-	LastName     string
-	BusinessName string
-	Username     string
-	Lid          string
-	AboutText    string
-	UpdatedAt    int64
+	Jid            string
+	Phone          string
+	FullName       string
+	FirstName      string
+	LastName       string
+	BusinessName   string
+	Username       string
+	Lid            string
+	AboutText      string
+	UpdatedAt      int64
+	DeletedAt      int64
+	DeletionSource string
+	DeletionReason string
+	LastSeenAt     int64
 }
 
 func (q *Queries) ExportContacts(ctx context.Context) ([]ExportContactsRow, error) {
@@ -270,6 +290,10 @@ func (q *Queries) ExportContacts(ctx context.Context) ([]ExportContactsRow, erro
 			&i.Lid,
 			&i.AboutText,
 			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.DeletionSource,
+			&i.DeletionReason,
+			&i.LastSeenAt,
 		); err != nil {
 			return nil, err
 		}
@@ -289,16 +313,24 @@ select
 	jid,
 	coalesce(name, '') as name,
 	coalesce(owner_jid, '') as owner_jid,
-	coalesce(created_at, 0) as created_at
+	coalesce(created_at, 0) as created_at,
+	coalesce(deleted_at, 0) as deleted_at,
+	coalesce(deletion_source, '') as deletion_source,
+	coalesce(deletion_reason, '') as deletion_reason,
+	last_seen_at
 from groups
 order by jid
 `
 
 type ExportGroupsRow struct {
-	Jid       string
-	Name      string
-	OwnerJid  string
-	CreatedAt int64
+	Jid            string
+	Name           string
+	OwnerJid       string
+	CreatedAt      int64
+	DeletedAt      int64
+	DeletionSource string
+	DeletionReason string
+	LastSeenAt     int64
 }
 
 func (q *Queries) ExportGroups(ctx context.Context) ([]ExportGroupsRow, error) {
@@ -315,6 +347,10 @@ func (q *Queries) ExportGroups(ctx context.Context) ([]ExportGroupsRow, error) {
 			&i.Name,
 			&i.OwnerJid,
 			&i.CreatedAt,
+			&i.DeletedAt,
+			&i.DeletionSource,
+			&i.DeletionReason,
+			&i.LastSeenAt,
 		); err != nil {
 			return nil, err
 		}
@@ -336,18 +372,26 @@ select
 	coalesce(contact_name, '') as contact_name,
 	coalesce(first_name, '') as first_name,
 	is_admin,
-	is_active
+	is_active,
+	coalesce(deleted_at, 0) as deleted_at,
+	coalesce(deletion_source, '') as deletion_source,
+	coalesce(deletion_reason, '') as deletion_reason,
+	last_seen_at
 from group_participants
 order by group_jid, user_jid
 `
 
 type ExportParticipantsRow struct {
-	GroupJid    string
-	UserJid     string
-	ContactName string
-	FirstName   string
-	IsAdmin     int64
-	IsActive    int64
+	GroupJid       string
+	UserJid        string
+	ContactName    string
+	FirstName      string
+	IsAdmin        int64
+	IsActive       int64
+	DeletedAt      int64
+	DeletionSource string
+	DeletionReason string
+	LastSeenAt     int64
 }
 
 func (q *Queries) ExportParticipants(ctx context.Context) ([]ExportParticipantsRow, error) {
@@ -366,6 +410,10 @@ func (q *Queries) ExportParticipants(ctx context.Context) ([]ExportParticipantsR
 			&i.FirstName,
 			&i.IsAdmin,
 			&i.IsActive,
+			&i.DeletedAt,
+			&i.DeletionSource,
+			&i.DeletionReason,
+			&i.LastSeenAt,
 		); err != nil {
 			return nil, err
 		}
@@ -385,6 +433,7 @@ select
 	cast(coalesce(min(case when ts > 0 and ts <= 253402300799 then ts end), 0) as integer) as oldest_ts,
 	cast(coalesce(max(case when ts > 0 and ts <= 253402300799 then ts end), 0) as integer) as newest_ts
 from messages
+where deleted_at is null
 `
 
 type GetMessageTimeBoundsRow struct {
@@ -499,12 +548,13 @@ func (q *Queries) InsertGroup(ctx context.Context, arg InsertGroupParams) error 
 }
 
 const insertMessage = `-- name: InsertMessage :exec
-insert into messages(source_pk, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
-values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+insert into messages(source_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
+values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
 `
 
 type InsertMessageParams struct {
 	SourcePk    int64
+	EventID     string
 	ChatJid     string
 	ChatName    sql.NullString
 	MsgID       string
@@ -526,6 +576,7 @@ type InsertMessageParams struct {
 func (q *Queries) InsertMessage(ctx context.Context, arg InsertMessageParams) error {
 	_, err := q.db.ExecContext(ctx, insertMessage,
 		arg.SourcePk,
+		arg.EventID,
 		arg.ChatJid,
 		arg.ChatName,
 		arg.MsgID,
@@ -625,7 +676,8 @@ select
 	c.raw_session_type,
 	count(m.rowid) as message_count
 from chats c
-left join messages m on m.chat_jid = c.jid
+left join messages m on m.chat_jid = c.jid and m.deleted_at is null
+where c.deleted_at is null
 group by c.jid, c.kind, c.name, c.last_message_at, c.unread_count, c.archived, c.removed, c.hidden, c.raw_session_type
 order by case when c.last_message_at > 0 and c.last_message_at <= 253402300799 then c.last_message_at else 0 end desc
 limit ?1
@@ -691,8 +743,8 @@ select
 	c.raw_session_type,
 	count(m.rowid) as message_count
 from chats c
-left join messages m on m.chat_jid = c.jid
-where c.unread_count > 0
+left join messages m on m.chat_jid = c.jid and m.deleted_at is null
+where c.deleted_at is null and c.unread_count > 0
 group by c.jid, c.kind, c.name, c.last_message_at, c.unread_count, c.archived, c.removed, c.hidden, c.raw_session_type
 order by case when c.last_message_at > 0 and c.last_message_at <= 253402300799 then c.last_message_at else 0 end desc
 limit ?1

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -2,6 +2,7 @@ package whatsappdb
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -23,25 +24,29 @@ import (
 const (
 	chatDBName                  = "ChatStorage.sqlite"
 	contactsDBName              = "ContactsV2.sqlite"
+	axolotlDBName               = "Axolotl.sqlite"
+	axolotlBeforeDBName         = "Axolotl.before.sqlite"
 	appleEpoch                  = 978307200
 	maxJSONUnixSecond           = 253402300799
 	maxJSONAppleSecondExclusive = maxJSONUnixSecond - appleEpoch + 1
 )
 
 type Source struct {
-	Path          string   `json:"path"`
-	Available     bool     `json:"available"`
-	ChatDB        string   `json:"chat_db,omitempty"`
-	ContactsDB    string   `json:"contacts_db,omitempty"`
-	MediaDir      string   `json:"media_dir,omitempty"`
-	SupportingDBs []string `json:"supporting_dbs,omitempty"`
-	MessageRows   int      `json:"message_rows,omitempty"`
-	ChatRows      int      `json:"chat_rows,omitempty"`
-	ContactRows   int      `json:"contact_rows,omitempty"`
-	MediaRows     int      `json:"media_rows,omitempty"`
-	OldestMessage string   `json:"oldest_message,omitempty"`
-	NewestMessage string   `json:"newest_message,omitempty"`
-	SchemaNotes   []string `json:"schema_notes,omitempty"`
+	Path             string   `json:"path"`
+	Available        bool     `json:"available"`
+	ChatDB           string   `json:"chat_db,omitempty"`
+	ContactsDB       string   `json:"contacts_db,omitempty"`
+	MediaDir         string   `json:"media_dir,omitempty"`
+	SupportingDBs    []string `json:"supporting_dbs,omitempty"`
+	MessageRows      int      `json:"message_rows,omitempty"`
+	MessageRowsKnown bool     `json:"-"`
+	ChatRows         int      `json:"chat_rows,omitempty"`
+	ContactRows      int      `json:"contact_rows,omitempty"`
+	ContactRowsKnown bool     `json:"-"`
+	MediaRows        int      `json:"media_rows,omitempty"`
+	OldestMessage    string   `json:"oldest_message,omitempty"`
+	NewestMessage    string   `json:"newest_message,omitempty"`
+	SchemaNotes      []string `json:"schema_notes,omitempty"`
 }
 
 type Snapshot struct {
@@ -50,18 +55,22 @@ type Snapshot struct {
 }
 
 type Data struct {
-	Contacts     []store.Contact
-	Chats        []store.Chat
-	Groups       []store.Group
-	Participants []store.GroupParticipant
-	Messages     []store.Message
-	MediaCount   int
+	Contacts            []store.Contact
+	Chats               []store.Chat
+	Groups              []store.Group
+	Participants        []store.GroupParticipant
+	Messages            []store.Message
+	MediaCount          int
+	SourceStoreIdentity string
+	AccountIdentity     string
 }
 
 type ImportOptions struct {
-	SourcePath string
-	CopyMedia  bool
-	MediaRoot  string
+	SourcePath  string
+	CopyMedia   bool
+	MediaRoot   string
+	Restore     bool
+	AdoptSource bool
 }
 
 func DefaultPath() string {
@@ -107,7 +116,9 @@ func Discover(ctx context.Context, path string) (Source, error) {
 	chatDB, closeChat, err := openReadOnly(source.ChatDB)
 	if err == nil {
 		defer closeChat()
-		_ = chatDB.QueryRowContext(ctx, "select count(*) from ZWAMESSAGE").Scan(&source.MessageRows)
+		if err := chatDB.QueryRowContext(ctx, "select count(*) from ZWAMESSAGE").Scan(&source.MessageRows); err == nil {
+			source.MessageRowsKnown = true
+		}
 		_ = chatDB.QueryRowContext(ctx, "select count(*) from ZWACHATSESSION").Scan(&source.ChatRows)
 		_ = chatDB.QueryRowContext(ctx, "select count(*) from ZWAMEDIAITEM").Scan(&source.MediaRows)
 		var minDate, maxDate sql.NullFloat64
@@ -129,7 +140,9 @@ func Discover(ctx context.Context, path string) (Source, error) {
 	contactsDB, closeContacts, err := openReadOnly(source.ContactsDB)
 	if err == nil {
 		defer closeContacts()
-		_ = contactsDB.QueryRowContext(ctx, "select count(*) from ZWAADDRESSBOOKCONTACT").Scan(&source.ContactRows)
+		if err := contactsDB.QueryRowContext(ctx, "select count(*) from ZWAADDRESSBOOKCONTACT").Scan(&source.ContactRows); err == nil {
+			source.ContactRowsKnown = true
+		}
 	}
 	return source, nil
 }
@@ -143,11 +156,19 @@ func SnapshotPath(path string) (Snapshot, error) {
 	if err != nil {
 		return Snapshot{}, err
 	}
+	if _, err := cache.SnapshotSQLite(cache.SQLiteSnapshotOptions{SourcePath: filepath.Join(path, axolotlDBName), DestinationDir: root, Name: axolotlBeforeDBName}); err != nil && !errors.Is(err, os.ErrNotExist) {
+		_ = os.RemoveAll(root)
+		return Snapshot{}, err
+	}
 	if _, err := cache.SnapshotSQLite(cache.SQLiteSnapshotOptions{SourcePath: filepath.Join(path, chatDBName), DestinationDir: root, Name: chatDBName}); err != nil {
 		_ = os.RemoveAll(root)
 		return Snapshot{}, err
 	}
 	if _, err := cache.SnapshotSQLite(cache.SQLiteSnapshotOptions{SourcePath: filepath.Join(path, contactsDBName), DestinationDir: root, Name: contactsDBName}); err != nil && !errors.Is(err, os.ErrNotExist) {
+		_ = os.RemoveAll(root)
+		return Snapshot{}, err
+	}
+	if _, err := cache.SnapshotSQLite(cache.SQLiteSnapshotOptions{SourcePath: filepath.Join(path, axolotlDBName), DestinationDir: root, Name: axolotlDBName}); err != nil && !errors.Is(err, os.ErrNotExist) {
 		_ = os.RemoveAll(root)
 		return Snapshot{}, err
 	}
@@ -163,7 +184,148 @@ func Extract(ctx context.Context, snap Snapshot) (Data, error) {
 	if err != nil {
 		return Data{}, err
 	}
-	return Data{Contacts: contacts, Chats: chats, Groups: groups, Participants: participants, Messages: messages, MediaCount: mediaCount}, nil
+	sourceStoreIdentity, err := readSourceIdentity(ctx, filepath.Join(snap.Root, chatDBName))
+	if err != nil {
+		return Data{}, err
+	}
+	accountIdentity, err := readAccountIdentity(ctx, filepath.Join(snap.Root, axolotlDBName))
+	if err != nil {
+		return Data{}, err
+	}
+	accountIdentityBefore, err := readAccountIdentity(ctx, filepath.Join(snap.Root, axolotlBeforeDBName))
+	if err != nil {
+		return Data{}, err
+	}
+	if accountIdentity != accountIdentityBefore {
+		return Data{}, errors.New("WhatsApp account changed while the Desktop snapshot was being captured; retry the import")
+	}
+	return Data{Contacts: contacts, Chats: chats, Groups: groups, Participants: participants, Messages: messages, MediaCount: mediaCount, SourceStoreIdentity: sourceStoreIdentity, AccountIdentity: accountIdentity}, nil
+}
+
+func readSourceIdentity(ctx context.Context, chatDBPath string) (string, error) {
+	db, closeDB, err := openReadOnly(chatDBPath)
+	if err != nil {
+		return "", err
+	}
+	defer closeDB()
+	var metadataTables int
+	if err := db.QueryRowContext(ctx, `select count(*) from sqlite_master where type='table' and name='Z_METADATA'`).Scan(&metadataTables); err != nil {
+		return "", err
+	}
+	if metadataTables == 0 {
+		return "", nil
+	}
+	var storeUUID string
+	if err := db.QueryRowContext(ctx, `select coalesce(Z_UUID,'') from Z_METADATA limit 1`).Scan(&storeUUID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read WhatsApp store identity: %w", err)
+	}
+	storeUUID = strings.TrimSpace(storeUUID)
+	if storeUUID == "" {
+		return "", nil
+	}
+	fingerprint := sha256.Sum256([]byte("chat-store\x00" + storeUUID))
+	return fmt.Sprintf("wa-store:%x", fingerprint), nil
+}
+
+func readAccountIdentity(ctx context.Context, axolotlDBPath string) (string, error) {
+	if _, err := os.Stat(axolotlDBPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", err
+	}
+	db, closeDB, err := openReadOnly(axolotlDBPath)
+	if err != nil {
+		return "", err
+	}
+	defer closeDB()
+
+	preferred, err := accountIDs(ctx, db, "ZWAZMDACCOUNT", "ZUSERJIDSTRING")
+	if err != nil {
+		return "", err
+	}
+	if len(preferred) > 0 {
+		return accountFingerprint(preferred)
+	}
+	preferred, err = accountIDs(ctx, db, "ZWAZMDACCOUNT", "ZACCOUNTJIDSTRING")
+	if err != nil {
+		return "", err
+	}
+	if len(preferred) > 0 {
+		return accountFingerprint(preferred)
+	}
+	fallback := make(map[string]struct{})
+	for _, table := range []string{"ZWAAXOLOTLIDENTITY", "ZWAAXOLOTLSESSION", "ZWASENDERKEY"} {
+		ids, err := accountIDs(ctx, db, table, "ZACCOUNTJIDSTRING")
+		if err != nil {
+			return "", err
+		}
+		for id := range ids {
+			fallback[id] = struct{}{}
+		}
+	}
+	return accountFingerprint(fallback)
+}
+
+func accountIDs(ctx context.Context, db *sql.DB, table string, columns ...string) (map[string]struct{}, error) {
+	ids := make(map[string]struct{})
+	var tables int
+	if err := db.QueryRowContext(ctx, `select count(*) from sqlite_master where type='table' and name=?`, table).Scan(&tables); err != nil {
+		return nil, err
+	}
+	if tables == 0 {
+		return ids, nil
+	}
+	for _, column := range columns {
+		var present int
+		if err := db.QueryRowContext(ctx, `select count(*) from pragma_table_info(?) where name=?`, table, column).Scan(&present); err != nil {
+			return nil, err
+		}
+		if present == 0 {
+			continue
+		}
+		query := fmt.Sprintf("select coalesce(%s,'') from %s", column, table) //nolint:gosec // names come from fixed internal lists.
+		if err := collectAccountIDs(ctx, db, query, ids); err != nil {
+			return nil, err
+		}
+	}
+	return ids, nil
+}
+
+func collectAccountIDs(ctx context.Context, db *sql.DB, query string, ids map[string]struct{}) error {
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return err
+		}
+		id = strings.ToLower(strings.TrimSpace(id))
+		if id != "" {
+			ids[id] = struct{}{}
+		}
+	}
+	return rows.Err()
+}
+
+func accountFingerprint(ids map[string]struct{}) (string, error) {
+	if len(ids) == 0 {
+		return "", nil
+	}
+	if len(ids) != 1 {
+		return "", errors.New("source contains multiple WhatsApp account identities and cannot be imported safely")
+	}
+	var id string
+	for id = range ids {
+	}
+	fingerprint := sha256.Sum256([]byte("account-jid\x00" + id))
+	return fmt.Sprintf("wa-account:%x", fingerprint), nil
 }
 
 func Import(ctx context.Context, st *store.Store, path string) (store.ImportStats, error) {
@@ -172,7 +334,12 @@ func Import(ctx context.Context, st *store.Store, path string) (store.ImportStat
 
 func ImportWithOptions(ctx context.Context, st *store.Store, opts ImportOptions) (store.ImportStats, error) {
 	sourcePath := defaultedPath(opts.SourcePath)
-	stats := store.ImportStats{SourcePath: sourcePath, DBPath: st.Path(), StartedAt: time.Now().UTC()}
+	sourceIdentity, err := canonicalSourcePath(sourcePath)
+	if err != nil {
+		return store.ImportStats{}, err
+	}
+	stats := store.ImportStats{SourcePath: sourcePath, SourceIdentity: sourceIdentity, AdoptSource: opts.AdoptSource, DBPath: st.Path(), StartedAt: time.Now().UTC()}
+	stats.SourceSnapshotAt = stats.StartedAt
 	snap, err := SnapshotPath(sourcePath)
 	if err != nil {
 		return stats, err
@@ -180,6 +347,27 @@ func ImportWithOptions(ctx context.Context, st *store.Store, opts ImportOptions)
 	defer func() { _ = os.RemoveAll(snap.Root) }()
 	data, err := Extract(ctx, snap)
 	if err != nil {
+		return stats, err
+	}
+	stats.SourceStoreIdentity = data.SourceStoreIdentity
+	stats.AccountIdentity = data.AccountIdentity
+	stats.Chats = len(data.Chats)
+	stats.Contacts = len(data.Contacts)
+	stats.Groups = len(data.Groups)
+	stats.Participants = len(data.Participants)
+	stats.Messages = len(data.Messages)
+	for _, message := range data.Messages {
+		if message.Timestamp.After(stats.SourceNewestMessage) {
+			stats.SourceNewestMessage = message.Timestamp
+		}
+	}
+	stats.MediaMessages = data.MediaCount
+	stats.FinishedAt = time.Now().UTC()
+	stats.Mode = "merge"
+	if opts.Restore {
+		stats.Mode = "restore"
+	}
+	if err := st.ValidateImport(ctx, stats, data.Messages, opts.Restore); err != nil {
 		return stats, err
 	}
 	if opts.CopyMedia {
@@ -194,17 +382,28 @@ func ImportWithOptions(ctx context.Context, st *store.Store, opts ImportOptions)
 		stats.MediaCopied = copied
 		stats.MediaMissing = missing
 	}
-	stats.Chats = len(data.Chats)
-	stats.Contacts = len(data.Contacts)
-	stats.Groups = len(data.Groups)
-	stats.Participants = len(data.Participants)
-	stats.Messages = len(data.Messages)
-	stats.MediaMessages = data.MediaCount
-	stats.FinishedAt = time.Now().UTC()
-	if err := st.ReplaceAll(ctx, stats, data.Contacts, data.Chats, data.Groups, data.Participants, data.Messages); err != nil {
+	importArchive := st.MergeAll
+	if opts.Restore {
+		importArchive = st.ReplaceAll
+	}
+	if err := importArchive(ctx, stats, data.Contacts, data.Chats, data.Groups, data.Participants, data.Messages); err != nil {
 		return stats, err
 	}
 	return stats, nil
+}
+
+func canonicalSourcePath(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", nil
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve desktop path: %w", err)
+	}
+	if evaluated, err := filepath.EvalSymlinks(absolute); err == nil {
+		absolute = evaluated
+	}
+	return filepath.Clean(absolute), nil
 }
 
 func copyArchiveMedia(messages []store.Message, sourceRoot, mediaRoot string) (int, int, error) {
@@ -550,7 +749,7 @@ func mergeParticipantRows(existing, candidate store.GroupParticipant) store.Grou
 func readMessageRows(ctx context.Context, db *sql.DB, sourceRoot string, names map[string]string) ([]store.Message, int, error) {
 	rows, err := db.QueryContext(ctx, `
 select m.Z_PK, coalesce(c.ZCONTACTJID,''), coalesce(c.ZPARTNERNAME,''), coalesce(m.ZSTANZAID,''), coalesce(m.ZISFROMME,0), m.ZMESSAGEDATE,
-       coalesce(m.ZTEXT,''), coalesce(m.ZMESSAGETYPE,0), coalesce(m.ZSTARRED,0), coalesce(m.ZFROMJID,''), coalesce(m.ZTOJID,''), coalesce(m.ZPUSHNAME,''),
+       m.ZTEXT, coalesce(m.ZMESSAGETYPE,0), coalesce(m.ZSTARRED,0), coalesce(m.ZFROMJID,''), coalesce(m.ZTOJID,''), coalesce(m.ZPUSHNAME,''),
        coalesce(gm.ZMEMBERJID,''), coalesce(gm.ZCONTACTNAME,''), coalesce(gm.ZFIRSTNAME,''),
        coalesce(mi.ZMEDIALOCALPATH,''), coalesce(mi.ZMEDIAURL,''), coalesce(mi.ZTITLE,''), coalesce(mi.ZVCARDNAME,''), coalesce(mi.ZFILESIZE,0)
 from ZWAMESSAGE m
@@ -567,15 +766,18 @@ order by m.ZMESSAGEDATE asc, m.Z_PK asc`)
 	for rows.Next() {
 		var m store.Message
 		var msgDate sql.NullFloat64
+		var text sql.NullString
 		var fromMe, starred int
 		var fromJID, toJID, pushName, memberJID, memberName, memberFirst, mediaPath, mediaURL, mediaTitle, vcardName string
-		if err := rows.Scan(&m.SourcePK, &m.ChatJID, &m.ChatName, &m.MessageID, &fromMe, &msgDate, &m.Text, &m.RawType, &starred, &fromJID, &toJID, &pushName, &memberJID, &memberName, &memberFirst, &mediaPath, &mediaURL, &mediaTitle, &vcardName, &m.MediaSize); err != nil {
+		if err := rows.Scan(&m.SourcePK, &m.ChatJID, &m.ChatName, &m.MessageID, &fromMe, &msgDate, &text, &m.RawType, &starred, &fromJID, &toJID, &pushName, &memberJID, &memberName, &memberFirst, &mediaPath, &mediaURL, &mediaTitle, &vcardName, &m.MediaSize); err != nil {
 			return nil, 0, err
 		}
 		if m.ChatJID == "" || m.MessageID == "" {
 			continue
 		}
 		m.Timestamp = appleNullTime(msgDate)
+		m.Text = text.String
+		m.SourceTextNull = !text.Valid
 		m.FromMe = fromMe != 0
 		m.Starred = starred != 0
 		m.MessageType = messageType(m.RawType)

--- a/internal/whatsappdb/desktop_test.go
+++ b/internal/whatsappdb/desktop_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,6 +40,9 @@ func TestImportDesktopCoreDataShape(t *testing.T) {
 	if status.Messages != 4 || status.MediaMessages != 1 || status.UnreadChats != 1 || status.UnreadMessages != 2 {
 		t.Fatalf("unexpected status: %+v", status)
 	}
+	if stats.SourceIdentity == "" || stats.SourceStoreIdentity == "" || stats.AccountIdentity == "" || stats.SourceSnapshotAt.IsZero() || stats.SourceSnapshotAt.After(stats.FinishedAt) || status.LastSourceSnapshot.IsZero() || status.LastSourceNewest.IsZero() || !status.LastSourceNewest.Equal(time.Unix(appleEpoch+700000003, 0).UTC()) {
+		t.Fatalf("missing source identity or watermark: stats=%+v status=%+v", stats, status)
+	}
 
 	results, err := archive.Search(ctx, store.MessageFilter{Query: "launch", Limit: 10})
 	if err != nil {
@@ -66,6 +70,366 @@ func TestImportDesktopCoreDataShape(t *testing.T) {
 	}
 	if !dms[1].FromMe || dms[1].SenderName != "me" {
 		t.Fatalf("outgoing dm sender wrong: %+v", dms[1])
+	}
+}
+
+func TestImportDesktopTurnsNullTextTransitionIntoTombstone(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createFixtureDBs(t, source)
+	archive, err := store.Open(ctx, filepath.Join(t.TempDir(), "wacrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = archive.Close() }()
+	if _, err := Import(ctx, archive, source); err != nil {
+		t.Fatal(err)
+	}
+
+	chatDB, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := chatDB.ExecContext(ctx, `update ZWAMESSAGE set ZTEXT=null where Z_PK=1`); err != nil {
+		_ = chatDB.Close()
+		t.Fatal(err)
+	}
+	if err := chatDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(ctx, archive, source); err != nil {
+		t.Fatal(err)
+	}
+	status, err := archive.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Messages != 3 || status.DeletedMessages != 1 || status.MessageRevisions != 1 {
+		t.Fatalf("null-text import status = %+v", status)
+	}
+	var reason, revision string
+	if err := archive.DB().QueryRowContext(ctx, `select deletion_reason from messages where source_pk=1`).Scan(&reason); err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.DB().QueryRowContext(ctx, `select payload_json from message_revisions where event_id='wa:1'`).Scan(&revision); err != nil {
+		t.Fatal(err)
+	}
+	if reason != "whatsapp_payload_cleared" || !strings.Contains(revision, `"text":"hello"`) {
+		t.Fatalf("reason=%q revision=%s", reason, revision)
+	}
+}
+
+func TestImportDesktopRejectsAccountSwitchAtSameStore(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createFixtureDBs(t, source)
+	archive, err := store.Open(ctx, filepath.Join(t.TempDir(), "wacrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = archive.Close() }()
+	if _, err := Import(ctx, archive, source); err != nil {
+		t.Fatal(err)
+	}
+	chatDB, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, chatDB, `
+delete from ZWAMESSAGE;
+insert into ZWAMEDIAITEM values (2, 10, 'foreign.bin', '', 'foreign', '', 7);
+insert into ZWAMESSAGE values (10, 1, null, 2, 'account-b', 0, 700000010, 'other account', 1, 0, '111@s.whatsapp.net', '', 'Other');`)
+	if err := chatDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	axolotlDB, err := sql.Open("sqlite", filepath.Join(source, axolotlDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, axolotlDB, `update ZWAZMDACCOUNT set ZACCOUNTJIDSTRING='other-owner@s.whatsapp.net', ZUSERJIDSTRING='other-owner@s.whatsapp.net'`)
+	if err := axolotlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "foreign.bin"), []byte("foreign"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(ctx, archive, source); err == nil || !strings.Contains(err.Error(), "different WhatsApp account") {
+		t.Fatalf("same-path account switch error = %v", err)
+	}
+	mediaRoot := filepath.Join(t.TempDir(), "media")
+	if _, err := ImportWithOptions(ctx, archive, ImportOptions{SourcePath: source, CopyMedia: true, MediaRoot: mediaRoot}); err == nil || !strings.Contains(err.Error(), "different WhatsApp account") {
+		t.Fatalf("copy-media account switch error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(mediaRoot, "foreign.bin")); !os.IsNotExist(err) {
+		t.Fatalf("rejected import wrote foreign media: %v", err)
+	}
+	if _, err := ImportWithOptions(ctx, archive, ImportOptions{SourcePath: source, Restore: true}); err != nil {
+		t.Fatalf("explicit restore should switch accounts: %v", err)
+	}
+	if _, err := Import(ctx, archive, source); err != nil {
+		t.Fatalf("merge after restore should have event continuity: %v", err)
+	}
+}
+
+func TestReadSourceIdentity(t *testing.T) {
+	ctx := context.Background()
+	t.Run("message churn does not rotate", func(t *testing.T) {
+		source := t.TempDir()
+		createFixtureDBs(t, source)
+		before, err := readSourceIdentity(ctx, filepath.Join(source, chatDBName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		db, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustExec(t, db, `update ZWAMESSAGE set ZFROMJID='owner@s.whatsapp.net' where ZISFROMME=1`)
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		identity, err := readSourceIdentity(ctx, filepath.Join(source, chatDBName))
+		if err != nil || identity != before || !strings.HasPrefix(identity, "wa-store:") {
+			t.Fatalf("identity rotated: before=%q after=%q err=%v", before, identity, err)
+		}
+	})
+	t.Run("missing marker", func(t *testing.T) {
+		source := t.TempDir()
+		createFixtureDBs(t, source)
+		db, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustExec(t, db, `drop table Z_METADATA`)
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		identity, err := readSourceIdentity(ctx, filepath.Join(source, chatDBName))
+		if err != nil || identity != "" {
+			t.Fatalf("missing identity = %q, %v", identity, err)
+		}
+	})
+	t.Run("empty store uuid", func(t *testing.T) {
+		source := t.TempDir()
+		createFixtureDBs(t, source)
+		db, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustExec(t, db, `update Z_METADATA set Z_UUID=''`)
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		identity, err := readSourceIdentity(ctx, filepath.Join(source, chatDBName))
+		if err != nil || identity != "" {
+			t.Fatalf("empty identity = %q, %v", identity, err)
+		}
+	})
+	t.Run("missing metadata row", func(t *testing.T) {
+		source := t.TempDir()
+		createFixtureDBs(t, source)
+		db, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustExec(t, db, `delete from Z_METADATA`)
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		identity, err := readSourceIdentity(ctx, filepath.Join(source, chatDBName))
+		if err != nil || identity != "" {
+			t.Fatalf("missing metadata identity = %q, %v", identity, err)
+		}
+	})
+}
+
+func TestReadAccountIdentity(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createFixtureDBs(t, source)
+	path := filepath.Join(source, axolotlDBName)
+	before, err := readAccountIdentity(ctx, path)
+	if err != nil || !strings.HasPrefix(before, "wa-account:") {
+		t.Fatalf("account identity = %q, %v", before, err)
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, db, `update ZWAZMDACCOUNT set ZUSERJIDSTRING='other-owner@s.whatsapp.net'`)
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	after, err := readAccountIdentity(ctx, path)
+	if err != nil || after == before || !strings.HasPrefix(after, "wa-account:") {
+		t.Fatalf("account switch identity: before=%q after=%q err=%v", before, after, err)
+	}
+	if identity, err := readAccountIdentity(ctx, filepath.Join(t.TempDir(), axolotlDBName)); err != nil || identity != "" {
+		t.Fatalf("missing account database identity = %q, %v", identity, err)
+	}
+
+	ambiguous := t.TempDir()
+	createFixtureDBs(t, ambiguous)
+	db, err = sql.Open("sqlite", filepath.Join(ambiguous, axolotlDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, db, `insert into ZWAZMDACCOUNT values (2, 'second@s.whatsapp.net', 'second@s.whatsapp.net')`)
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readAccountIdentity(ctx, filepath.Join(ambiguous, axolotlDBName)); err == nil || !strings.Contains(err.Error(), "multiple WhatsApp account identities") || strings.Contains(err.Error(), "--restore") {
+		t.Fatalf("ambiguous account identity error = %v", err)
+	}
+}
+
+func TestReadAccountIdentityFallbacks(t *testing.T) {
+	ctx := context.Background()
+	t.Run("ZMD account JID", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), axolotlDBName)
+		db, err := sql.Open("sqlite", path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustExec(t, db, `create table ZWAZMDACCOUNT (ZACCOUNTJIDSTRING varchar, ZUSERJIDSTRING varchar); insert into ZWAZMDACCOUNT values ('owner@s.whatsapp.net', '')`)
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		identity, err := readAccountIdentity(ctx, path)
+		if err != nil || !strings.HasPrefix(identity, "wa-account:") {
+			t.Fatalf("ZMD account fallback = %q, %v", identity, err)
+		}
+	})
+	t.Run("signal account columns", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), axolotlDBName)
+		db, err := sql.Open("sqlite", path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustExec(t, db, `
+create table ZWAAXOLOTLIDENTITY (ZACCOUNTJIDSTRING varchar);
+create table ZWAAXOLOTLSESSION (ZACCOUNTJIDSTRING varchar);
+create table ZWASENDERKEY (ZACCOUNTJIDSTRING varchar);
+insert into ZWAAXOLOTLIDENTITY values ('OWNER@S.WHATSAPP.NET');
+insert into ZWAAXOLOTLSESSION values ('owner@s.whatsapp.net');
+insert into ZWASENDERKEY values ('owner@s.whatsapp.net');`)
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		identity, err := readAccountIdentity(ctx, path)
+		if err != nil || !strings.HasPrefix(identity, "wa-account:") {
+			t.Fatalf("signal fallback = %q, %v", identity, err)
+		}
+	})
+	t.Run("empty schema", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), axolotlDBName)
+		db, err := sql.Open("sqlite", path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustExec(t, db, `create table unrelated (value text)`)
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		identity, err := readAccountIdentity(ctx, path)
+		if err != nil || identity != "" {
+			t.Fatalf("empty schema identity = %q, %v", identity, err)
+		}
+	})
+}
+
+func TestExtractRejectsAccountChangeDuringSnapshot(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createFixtureDBs(t, source)
+	snap, err := SnapshotPath(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(snap.Root) }()
+	db, err := sql.Open("sqlite", filepath.Join(snap.Root, axolotlDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, db, `update ZWAZMDACCOUNT set ZUSERJIDSTRING='other@s.whatsapp.net'`)
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Extract(ctx, snap); err == nil || !strings.Contains(err.Error(), "changed while") {
+		t.Fatalf("snapshot account change error = %v", err)
+	}
+}
+
+func TestImportDesktopUpgradesPathBindingToStoreFingerprint(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createFixtureDBs(t, source)
+	db, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, db, `drop table Z_METADATA`)
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := store.Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = archive.Close() }()
+	stats, err := Import(ctx, archive, source)
+	if err != nil || stats.SourceStoreIdentity != "" {
+		t.Fatalf("path-bound import = %+v, %v", stats, err)
+	}
+	db, err = sql.Open("sqlite", filepath.Join(source, chatDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, db, `create table Z_METADATA (Z_VERSION integer primary key, Z_UUID varchar(255), Z_PLIST blob); insert into Z_METADATA values (1, 'late-store-marker', null)`)
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stats, err = Import(ctx, archive, source)
+	if err != nil || stats.SourceStoreIdentity == "" {
+		t.Fatalf("store fingerprint upgrade = %+v, %v", stats, err)
+	}
+	var binding string
+	if err := archive.DB().QueryRowContext(ctx, `select value from sync_state where key='merge_source_store_identity'`).Scan(&binding); err != nil || binding != stats.SourceStoreIdentity {
+		t.Fatalf("store fingerprint binding = %q, %v", binding, err)
+	}
+	db, err = sql.Open("sqlite", filepath.Join(source, chatDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, db, `drop table Z_METADATA`)
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Import(ctx, archive, source); err == nil || !strings.Contains(err.Error(), "different WhatsApp Desktop store") {
+		t.Fatalf("missing established store marker error = %v", err)
+	}
+}
+
+func TestImportDesktopWithoutAccountIdentityCannotMergeNonemptyArchive(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createFixtureDBs(t, source)
+	if err := os.Remove(filepath.Join(source, axolotlDBName)); err != nil {
+		t.Fatal(err)
+	}
+	archive, err := store.Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = archive.Close() }()
+	if _, err := Import(ctx, archive, source); err != nil {
+		t.Fatalf("initial unbound import: %v", err)
+	}
+	if _, err := Import(ctx, archive, source); err == nil || !strings.Contains(err.Error(), "--adopt-source") {
+		t.Fatalf("unbound merge error = %v", err)
+	}
+	if _, err := ImportWithOptions(ctx, archive, ImportOptions{SourcePath: source, AdoptSource: true}); err == nil || !strings.Contains(err.Error(), "--adopt-source") {
+		t.Fatalf("adoption without account identity error = %v", err)
 	}
 }
 
@@ -554,6 +918,36 @@ func TestClassifiers(t *testing.T) {
 	}
 }
 
+func TestCanonicalSourcePath(t *testing.T) {
+	if path, err := canonicalSourcePath(""); err != nil || path != "" {
+		t.Fatalf("empty canonical path = %q, %v", path, err)
+	}
+	real := t.TempDir()
+	link := filepath.Join(t.TempDir(), "source-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	path, err := canonicalSourcePath(link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(real)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != want {
+		t.Fatalf("canonical path = %q, want %q", path, want)
+	}
+	missing := filepath.Join(t.TempDir(), "missing")
+	path, err = canonicalSourcePath(missing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != missing {
+		t.Fatalf("missing canonical path = %q, want %q", path, missing)
+	}
+}
+
 func createFixtureDBs(t *testing.T, dir string) {
 	t.Helper()
 	chat, err := sql.Open("sqlite", filepath.Join(dir, chatDBName))
@@ -567,6 +961,8 @@ create table ZWAGROUPINFO (Z_PK integer primary key, ZCHATSESSION integer, ZOWNE
 create table ZWAGROUPMEMBER (Z_PK integer primary key, ZCHATSESSION integer, ZMEMBERJID varchar, ZCONTACTNAME varchar, ZFIRSTNAME varchar, ZISADMIN integer, ZISACTIVE integer);
 create table ZWAMEDIAITEM (Z_PK integer primary key, ZMESSAGE integer, ZMEDIALOCALPATH varchar, ZMEDIAURL varchar, ZTITLE varchar, ZVCARDNAME varchar, ZFILESIZE integer);
 create table ZWAMESSAGE (Z_PK integer primary key, ZCHATSESSION integer, ZGROUPMEMBER integer, ZMEDIAITEM integer, ZSTANZAID varchar, ZISFROMME integer, ZMESSAGEDATE timestamp, ZTEXT varchar, ZMESSAGETYPE integer, ZSTARRED integer, ZFROMJID varchar, ZTOJID varchar, ZPUSHNAME varchar);
+create table Z_METADATA (Z_VERSION integer primary key, Z_UUID varchar(255), Z_PLIST blob);
+insert into Z_METADATA values (1, 'fixture-account-a', null);
 insert into ZWACHATSESSION values (1, '111@s.whatsapp.net', 'Bob', 700000020, 0, 0, 0, 0, 0);
 insert into ZWACHATSESSION values (2, '123@g.us', 'Launch Group', 700000010, 2, 0, 0, 0, 1);
 insert into ZWAGROUPINFO values (1, 2, 'owner@s.whatsapp.net', 699999000);
@@ -587,6 +983,15 @@ insert into ZWAMESSAGE values (4, 1, null, null, 'dm-in', 0, 700000003, 'duplica
 create table ZWAADDRESSBOOKCONTACT (ZWHATSAPPID varchar, ZPHONENUMBER varchar, ZFULLNAME varchar, ZGIVENNAME varchar, ZLASTNAME varchar, ZBUSINESSNAME varchar, ZUSERNAME varchar, ZLID varchar, ZABOUTTEXT varchar, ZLASTUPDATED timestamp);
 insert into ZWAADDRESSBOOKCONTACT values ('111@s.whatsapp.net', '+111', 'Bob', 'Bob', '', '', '', '', '', 700000000);
 insert into ZWAADDRESSBOOKCONTACT values ('222@s.whatsapp.net', '+222', 'Alice Contact', 'Alice', '', '', '', '222', '', 700000000);
+`)
+	axolotl, err := sql.Open("sqlite", filepath.Join(dir, axolotlDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = axolotl.Close() }()
+	mustExec(t, axolotl, `
+create table ZWAZMDACCOUNT (Z_PK integer primary key, ZACCOUNTJIDSTRING varchar, ZUSERJIDSTRING varchar);
+insert into ZWAZMDACCOUNT values (1, 'fixture-owner@s.whatsapp.net', 'fixture-owner@s.whatsapp.net');
 `)
 }
 


### PR DESCRIPTION
## Summary

- convert the archive to the family tombstone contract across contacts, chats, groups, participants, messages, and subordinate rows
- make routine Desktop imports cumulative merges while reserving exact replacement for `--restore`
- add stable per-store message event IDs and append-only message revisions for observable edits and deletes
- keep account archives separate with hashed account/store bindings, explicit one-time legacy adoption, strict source transitions, and encrypted binding backup
- preserve normal read/search behavior by excluding tombstones while retaining explicit include-deleted forensic access

This follows the maintainer decision to solve cumulative history with tombstone conversion rather than a multi-account archive restructure; accounts remain separate.

## Proof

- `make check` (lint, 85.2% aggregate coverage, build)
- `go test -count=1 -race ./...`
- source-blind real-binary behavior contract: merge retention, exact restore, stable edit identity/revision, observable delete, first-seen NULL safety, account/store isolation, explicit adoption, and subordinate tombstones all passed
- fresh schema-v1 real-archive copy migrated to schema v2 with every legacy entity/message/FTS count and canonical hash unchanged, SQLite `quick_check` clean, unique generated event IDs, and zero fabricated tombstones or revisions
- AutoReview clean on the exact committed tree after resolving its account-boundary, source-watermark, source-upgrade, and backup-provenance findings

resolves #38
