### PR TITLE
docs: rewrite README to house standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Verify unified release archives with normalized `./` tar members.
 
+### Changed
+
+- Rewrite the README to the house standard and move detailed commands, backups, data model, and release guidance into `docs/`.
+
 ## [0.3.5] - 2026-08-02
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -1,809 +1,142 @@
-# 🧾 wacrawl
+# wacrawl 🧾 — WhatsApp archaeology with encrypted receipts
 
 ![wacrawl banner](docs/assets/readme-banner.jpg)
 
-WhatsApp archaeology with encrypted receipts.
+[![CI](https://img.shields.io/github/actions/workflow/status/openclaw/wacrawl/ci.yml?branch=main&style=flat-square&label=ci)](https://github.com/openclaw/wacrawl/actions/workflows/ci.yml)
+[![GitHub release](https://img.shields.io/github/v/release/openclaw/wacrawl?style=flat-square)](https://github.com/openclaw/wacrawl/releases/latest)
+[![Go version](https://img.shields.io/github/go-mod/go-version/openclaw/wacrawl?style=flat-square&logo=go)](go.mod)
+[![License](https://img.shields.io/github/license/openclaw/wacrawl?style=flat-square)](LICENSE)
+[![Homebrew](https://img.shields.io/badge/Homebrew-openclaw%2Ftap%2Fwacrawl-FBB040?style=flat-square&logo=homebrew&logoColor=black)](https://github.com/openclaw/homebrew-tap/blob/main/Formula/wacrawl.rb)
 
-Read-only local archive and search for the macOS WhatsApp Desktop app.
+`wacrawl` makes a read-only snapshot of the macOS WhatsApp Desktop databases and imports chats, contacts, messages, and media metadata into a local SQLite archive. It is for people who want fast local search, structured exports, a private web viewer, or encrypted Git backups without connecting to WhatsApp's network protocol.
 
-`wacrawl` copies WhatsApp Desktop's local SQLite databases into a temporary
-snapshot, imports the useful chat data into its own SQLite archive, and gives
-you scriptable commands for status, chat listing, message listing, and full-text
-search.
-
-It is for local inspection. It does not send messages, decrypt backups, talk to
-WhatsApp Web, or write back into WhatsApp's app container.
+![wacrawl web viewer](docs/assets/webui-chat-dark.png)
 
 ## Install
 
-Homebrew is the easiest path. Install directly from the OpenClaw tap:
+Homebrew is the smallest path:
 
 ```bash
 brew install openclaw/tap/wacrawl
 ```
 
-After that, upgrades stay simple:
+Upgrade later with `brew upgrade openclaw/tap/wacrawl`.
 
-```bash
-brew update
-brew upgrade openclaw/tap/wacrawl
-```
-
-Or from source:
+Or install from source with Go 1.26.5 or newer:
 
 ```bash
 go install github.com/openclaw/wacrawl/cmd/wacrawl@latest
 ```
 
-Check the installed binary:
+Direct source discovery requires macOS and the desktop WhatsApp app. Release builds for macOS, Linux, and Windows can work with an existing archive or encrypted backup.
 
-```bash
-wacrawl --version
-```
+## Quick start
 
-## Quick Start
-
-First, check whether `wacrawl` can see the local WhatsApp Desktop data:
+Check the source, import it, then inspect the archive:
 
 ```bash
 wacrawl doctor
-```
-
-Sync a fresh local archive:
-
-```bash
 wacrawl sync
-wacrawl import --copy-media
-```
-
-Inspect what was imported. Read commands sync automatically by default, so
-`status`, `chats`, `messages`, and `search` refresh the archive before reading
-when the local WhatsApp Desktop source is newer:
-
-```bash
 wacrawl status
-wacrawl chats --limit 20
-wacrawl unread --limit 20
-wacrawl messages --limit 20
+wacrawl search "invoice"
 ```
 
-Search message text:
-
-```bash
-wacrawl search "release notes"
-```
-
-Browse the archive locally:
+Read commands refresh a stale archive when the WhatsApp source is newer. To browse instead:
 
 ```bash
 wacrawl web
 ```
 
-Use JSON for scripts:
+The viewer prints a private local URL, binds only to `127.0.0.1`, and stops with Ctrl-C.
 
-```bash
-wacrawl --json search "invoice" --from-them --after 2026-01-01
-```
+## What it reads
 
-## What It Reads
-
-On macOS, WhatsApp Desktop stores app data in:
+WhatsApp Desktop keeps its macOS data under:
 
 ```text
 ~/Library/Group Containers/group.net.whatsapp.WhatsApp.shared
 ```
 
-`wacrawl` currently imports from:
+`wacrawl` snapshots `ChatStorage.sqlite`, `ContactsV2.sqlite`, and their SQLite sidecars before reading. With `--copy-media`, it also copies referenced files from `Message/Media/`. Its own archive defaults to `~/.wacrawl/wacrawl.db`.
 
-```text
-ChatStorage.sqlite
-ContactsV2.sqlite
-Message/Media/
-```
+Imports merge by stable source identity, retain older history that has disappeared from the current desktop snapshot, and preserve explicit edits and deletions as revisions or tombstones. Use a separate `--db` for another WhatsApp account; source adoption and exact restore are deliberate operations described in the [command reference](docs/commands.md#import-and-sync).
 
-It writes its own archive to:
+## Search and automation
 
-```text
-~/.wacrawl/wacrawl.db
-```
-
-Override either path when needed:
+Search covers message text, chat and sender names, and media titles:
 
 ```bash
-wacrawl --source "$HOME/Library/Group Containers/group.net.whatsapp.WhatsApp.shared" doctor
-wacrawl --db /tmp/wacrawl.db import
+wacrawl search "release notes" --from-them --after 2026-01-01
+wacrawl messages --chat 1234567890@s.whatsapp.net --has-media
+wacrawl sql "SELECT count(*) FROM messages"
 ```
 
-## Safety
+Add `--json` for scripts and agents:
 
-- Opens WhatsApp data read-only.
-- Copies SQLite database, WAL, and SHM files into a temp snapshot before import.
-- Replaces only the `wacrawl` archive database.
-- Does not modify WhatsApp databases, settings, contacts, chats, or media.
-- Does not use the WhatsApp network protocol.
-- Serves the optional web viewer only on IPv4 loopback with a random per-run
-  access key; the viewer exposes no archive writes, configuration, or media files.
-- Does not upload data during normal archive/search commands. `backup push`
-  uploads only age-encrypted backup shards when you explicitly run it.
+```bash
+wacrawl --json --sync never search "invoice"
+wacrawl --json --sync never contacts export
+```
 
-The archive can contain private message data. Keep `~/.wacrawl/wacrawl.db`
-local and out of commits, backups, and shared logs unless that is intentional.
+See the [command reference](docs/commands.md) for filters, sync modes, SQL constraints, and every subcommand.
+
+## Encrypted backups
+
+`wacrawl backup` exports deterministic JSONL shards, compresses them, and encrypts them to one or more X25519 age recipients before Git sees the data. Copied media can travel in content-deduplicated encrypted blobs, and restores verify hashes and cross-table references before replacing the archive.
+
+```bash
+wacrawl backup init --repo ~/Projects/backup-wacrawl --remote <git-url>
+wacrawl backup push
+wacrawl backup snapshots
+wacrawl backup pull
+```
+
+The manifest remains cleartext and reveals backup timing, public recipients, counts, shard paths, encrypted sizes, and hashes. Read the [backup guide and threat model](docs/backups.md) before relying on it for recovery.
+
+## Safety boundary
+
+- The WhatsApp databases are opened read-only through a temporary SQLite snapshot.
+- Normal archive and search commands do not upload data or write into WhatsApp's app container.
+- The web viewer is loopback-only, read-only, protected by a random per-run access key, and restricts media reads to known roots.
+- `backup push` is the explicit networked path; it sends age-encrypted shards to the configured Git remote.
+
+The archive still contains private message data in plaintext. Keep `~/.wacrawl/wacrawl.db` and copied media out of commits, shared logs, and untrusted backups unless sharing them is intentional.
 
 ## Commands
 
-### `doctor`
-
-Inspect the source path and database shape:
-
-```bash
-wacrawl doctor
-wacrawl --json doctor
-```
-
-Reports source availability, discovered database files, row counts, message date
-range, and importer schema notes.
-
-### `import`
-
-Snapshot WhatsApp Desktop data and merge it into the local archive in one
-transaction:
-
-```bash
-wacrawl import
-wacrawl import --copy-media
-wacrawl import --restore
-```
-
-`sync` is the same command with a clearer name:
-
-```bash
-wacrawl sync
-wacrawl sync --copy-media
-```
-
-Routine imports merge by stable row identity. Rows absent from the current
-Desktop snapshot remain in the archive because absence is not a deletion
-signal. This preserves older history after WhatsApp evicts it from local
-storage. The archive binds both the canonical Desktop path and a hashed,
-portable CoreData store marker. That marker identifies the store, not the
-WhatsApp account inside it; the importer separately hashes the account-owned
-JID in `Axolotl.sqlite`. A nonempty archive without that verified account
-binding refuses routine merges, even when events overlap. Use a one-time
-`--adopt-source` to bind a legacy archive that has no verified account binding
-while retaining its rows. Established account and store fingerprints remain
-strict across encrypted backup restore.
-Replacing or repopulating the same store with a different account therefore
-cannot silently combine histories. Pass `--restore` only when the archive must
-exactly match the current snapshot or intentionally switch sources; exact
-restore removes destination-only rows and local revision history.
-
-Explicit WhatsApp signals create source-attributed tombstones instead of
-deleting rows. Removed chats tombstone their archived groups, participants,
-and messages; inactive group members are tombstoned; and an observed plain-text
-message payload changing to SQL `NULL` is retained as a deleted message with
-its previous payload in `message_revisions`. Message tombstones are sticky during
-merge imports; an exact `--restore` is authoritative if a source replacement
-must revive one. A removed chat can begin a new live lifecycle when WhatsApp
-reports post-tombstone activity, without reviving its historical messages.
-Normal list, search, status, and web reads exclude tombstones, while encrypted
-backups retain them.
-
-Imports:
-
-- chats
-- contacts
-- groups
-- group participants
-- messages
-- media metadata and local media paths
-
-By default, media paths continue to point at WhatsApp Desktop's app container.
-Pass `--copy-media` to copy referenced media files into `media/` next to the
-archive database and rewrite copied message media paths to that archive copy.
-Missing media files are counted in the import output and do not fail the import.
-
-### `status`
-
-Show archive counts and import metadata:
-
-```bash
-wacrawl status
-```
-
-Includes live and deleted entity counts, message revision count, unread counts,
-media-message count, oldest, newest, last-import, and source fields.
-
-By default, `status` first syncs the archive when the last sync is older than
-`--sync-max-age` and the WhatsApp Desktop source has newer data.
-
-### `chats`
-
-List chats ordered by newest message:
-
-```bash
-wacrawl chats
-wacrawl chats --limit 100
-wacrawl chats --unread
-```
-
-Unread state comes from WhatsApp Desktop's per-chat unread counter. Message
-rows do not expose a reliable incoming per-message "read by me" flag.
-
-### `unread`
-
-List only chats with unread messages:
-
-```bash
-wacrawl unread
-wacrawl unread --limit 100
-```
-
-### `messages`
-
-List archived messages:
-
-```bash
-wacrawl messages
-wacrawl messages --chat 1234567890@s.whatsapp.net
-wacrawl messages --after 2026-01-01 --from-them
-wacrawl messages --has-media --json
-```
-
-Filters:
-
-```text
---chat JID       Restrict to one chat.
---sender JID     Restrict to one sender.
---limit N        Max rows. Default: 50.
---after DATE     RFC3339 timestamp or YYYY-MM-DD.
---before DATE    RFC3339 timestamp or YYYY-MM-DD.
---from-me        Only outgoing messages.
---from-them      Only incoming messages.
---has-media      Only messages with media metadata.
---asc            Oldest first.
-```
-
-### `search`
-
-Search the archive with SQLite FTS5:
-
-```bash
-wacrawl search "launch"
-wacrawl search "invoice" --from-them --after 2026-01-01
-wacrawl --json search "restaurant"
-```
-
-Search uses message text, chat name, sender name, and media title fields. It
-accepts the same filters as `messages`.
-
-### `sql`
-
-Run a read-only SQL query against the archive database:
-
-```bash
-wacrawl sql "SELECT count(*) FROM messages"
-wacrawl sql "SELECT name FROM sqlite_master WHERE type='table'"
-wacrawl --json sql "SELECT chat_jid, count(*) FROM messages GROUP BY chat_jid ORDER BY 2 DESC LIMIT 10"
-```
-
-Only single read-only `SELECT` statements are accepted. Use `--db PATH` to query
-an alternate archive database.
-
-### `web`
-
-Browse archive status, recent chats, messages, and full-text search in a local
-web viewer styled after WhatsApp itself — two-pane layout, chat bubbles with
-day separators, deterministic contact avatars, dark/light themes, inline
-photo/sticker/GIF previews with a lightbox, and rendered WhatsApp formatting
-(`*bold*`, `_italic_`, `~strike~`, `` `code` ``, fenced blocks, quotes, lists,
-links):
-
-```bash
-wacrawl web
-```
-
-![wacrawl web viewer](docs/assets/webui-chat-dark.png)
-
-The command prints a private URL and keeps running until you press Ctrl-C. It
-binds only to `127.0.0.1`, chooses a free random port by default, and protects
-archive APIs with a random key stored in the URL fragment so browsers do not
-send it in requests or referrers. The page consumes the key into memory and
-removes it from the address bar. Use a fixed loopback port when useful:
-
-```bash
-wacrawl --sync never web --port 8787
-```
-
-The viewer is deliberately read-only. Photos, stickers, and GIFs render inline
-straight from your local files behind the same per-run key (content-sniffed,
-images only, size-capped); media paths are never exposed, other attachment
-types stay metadata-only, and the viewer cannot change archive or backup
-configuration, schedule syncs, or expose a non-local listen address. The
-normal global sync policy runs once before the viewer starts; use the CLI to
-sync again, then use the refresh button in the browser.
-
-## Sync Behavior
-
-`wacrawl` keeps normal reads fresh without a daemon or background service.
-Before `status`, `chats`, `messages`, `search`, or `sql`, it checks the archive's
-last import time. If the archive is stale, it inspects the WhatsApp Desktop
-source and imports a fresh snapshot only when the source is ahead.
-
-The default policy is:
-
-```text
---sync auto
---sync-max-age 15m
-```
-
-Sync modes:
-
-```text
---sync auto     Sync before reads when the archive is stale and source is ahead.
---sync always   Force a sync before every read command.
---sync never    Read only the existing archive.
-```
-
-Examples:
-
-```bash
-wacrawl search "release notes"
-wacrawl --sync always status
-wacrawl --sync never --json messages --limit 10
-wacrawl --sync-max-age 1h chats
-```
-
-If the WhatsApp Desktop source is unavailable and the archive already has data,
-`--sync auto` warns on stderr and continues with the existing archive.
-`--sync always` treats an unavailable source as an error.
-
-## Encrypted Git Backup
-
-`wacrawl` can back up the archive to a Git repository using age-encrypted JSONL
-shards. This is meant for a private repository such as
-`https://github.com/steipete/backup-wacrawl`, but the message data is encrypted
-before Git sees it.
-
-The backup repo contains:
-
-```text
-README.md
-manifest.json
-data/chats.jsonl.gz.age
-data/contacts.jsonl.gz.age
-data/groups.jsonl.gz.age
-data/group_participants.jsonl.gz.age
-data/messages/YYYY/MM.jsonl.gz.age
-data/message_revisions.jsonl.gz.age
-data/files/index*.jsonl.gz.age
-data/files/objects/OPAQUE_ID.gz.age
-```
-
-`manifest.json` is intentionally cleartext so a machine can inspect backup
-freshness, public age recipients, counts, shard paths, encrypted byte sizes, and
-plaintext hashes without decrypting backup contents. It does not contain
-message text, chat names, contacts, participant IDs, media metadata, filenames,
-or archive paths. Those fields live inside the `*.jsonl.gz.age` shards.
-
-Media previously copied with `wacrawl sync --copy-media` is included by default.
-Identical files share one encrypted blob with a random opaque object ID. Their
-content hashes remain inside the encrypted index. Use `backup push --no-media`
-or `backup pull --no-media` when only archive rows are wanted.
-
-### Command Cheat Sheet
-
-Use these most of the time:
-
-```bash
-# First-time setup on a machine.
-wacrawl backup init \
-  --repo ~/Projects/backup-wacrawl \
-  --remote https://github.com/steipete/backup-wacrawl.git
-
-# Refresh WhatsApp data if needed, encrypt, commit, and push to GitHub.
-wacrawl backup push
-
-# Pull the Git backup, decrypt, verify, and import into the local archive.
-wacrawl backup pull
-
-# List restorable commits and any snapshot tags.
-wacrawl backup snapshots
-
-# Inspect the backup manifest without decrypting message data.
-wacrawl backup status
-```
-
-Useful safety variants:
-
-```bash
-# Force a fresh WhatsApp import before writing the backup.
-wacrawl sync --copy-media
-wacrawl --sync never backup push
-
-# Write and commit locally, but do not push to GitHub.
-wacrawl backup push --no-push
-
-# Create a named checkpoint while pushing a backup.
-wacrawl backup push --tag snapshot/before-phone-migration
-
-# Restore into a throwaway database for testing.
-wacrawl --db /tmp/wacrawl-restore-test.db backup pull
-wacrawl --db /tmp/wacrawl-restore-test.db --sync never status
-
-# Restore a historical tag, commit, or branch without changing the backup checkout.
-wacrawl --db /tmp/wacrawl-history.db backup pull --ref snapshot/before-phone-migration
-```
-
-You should not need to run `git` manually for normal use. `backup push` handles
-the backup repo fetch/rebase, commit, and push. A normal `backup pull` syncs the
-current archive branch; `backup pull --ref` fetches refs and reads the requested
-Git objects without switching or rewriting the backup checkout.
-
-Every changed backup is already a Git commit. Use `--tag NAME` to add an
-optional named checkpoint without moving an existing tag. Tag names and commit
-metadata are visible to anyone who can inspect the Git repository, so keep tag
-names non-sensitive. `backup snapshots` lists the newest manifest-changing
-commits and their tags; use `--limit N` to control the history depth.
-
-### Encryption and Security Model
-
-Backups use the Go `filippo.io/age` library with X25519 age identities. There
-is no backup password. Each machine has an age identity file, usually:
-
-```text
-~/.wacrawl/age.key
-```
-
-That file contains an `AGE-SECRET-KEY-...` private identity and is written with
-0600 permissions. Its matching public recipient starts with `age1...` and is
-safe to place in `~/.wacrawl/backup.json`, `manifest.json`, or docs.
-
-For each shard, `wacrawl backup push`:
-
-1. Exports rows from the local archive as deterministic JSONL.
-2. Streams copied media through hashing, gzip, and age encryption in one pass.
-3. Content-deduplicates identical media and encrypts the private path index.
-4. Encrypts every compressed payload for each configured recipient.
-5. Writes only encrypted `*.jsonl.gz.age` payloads to Git.
-6. Writes `manifest.json` with cleartext metadata used for status, diffing, and restore verification.
-
-`wacrawl backup pull` does the reverse: it pulls/rebases the backup repo,
-checks manifest shard paths, decrypts each shard with the local age identity,
-verifies row and media hashes, restores copied media under `media/` next to the
-configured database, localizes portable media paths, validates cross-table
-references, and imports the snapshot in one transaction.
-
-What the backup protects:
-
-- A GitHub read-only compromise or accidental clone does not reveal message text,
-  contacts, chat names, participant IDs, media metadata, filenames, or archive paths.
-- Each encrypted shard can be decrypted by any listed age recipient, so multiple
-  machines can share one backup without sharing one private key.
-- Age provides encrypted-file integrity; corrupted or wrong-key shards fail to
-  decrypt, and `wacrawl` also checks manifest hashes after decrypting.
-
-What remains visible in Git:
-
-- `manifest.json` is cleartext.
-- The manifest reveals export time, public recipients, table names, row counts,
-  opaque shard paths, encrypted byte sizes, row/index hashes, and media counts.
-  Individual media paths, filenames, plaintext sizes, and content hashes remain encrypted.
-- Message shard paths reveal activity by year and month, for example
-  `data/messages/2026/04.jsonl.gz.age`.
-- Git history reveals backup cadence and which encrypted shards changed.
-
-Important limits:
-
-- This is not end-to-end provenance. Someone who can push to the backup repo can
-  replace the backup with different data encrypted to your public recipient.
-  Use normal GitHub access control and review unexpected backup commits.
-- If `~/.wacrawl/age.key` is lost and no other configured recipient exists, the
-  encrypted backup cannot be restored.
-- If an age identity is compromised, remove its public recipient, run
-  `wacrawl backup push` to re-encrypt current shards, and consider rewriting or
-  deleting old Git history because older commits may still be decryptable with
-  the compromised key.
-- X25519 age recipients are not post-quantum. They are a practical modern
-  default, but not a post-quantum archival guarantee.
-- The local archive database `~/.wacrawl/wacrawl.db` and the WhatsApp Desktop
-  source data remain plaintext on the machine. Protect the machine and local
-  backups accordingly.
-
-### Initial Setup
-
-Initialize the backup repository and local age identity:
-
-```bash
-wacrawl backup init \
-  --repo ~/Projects/backup-wacrawl \
-  --remote https://github.com/steipete/backup-wacrawl.git
-```
-
-This writes `~/.wacrawl/backup.json`, creates `~/.wacrawl/age.key` if needed,
-clones or initializes the local backup checkout, and prints the public age
-recipient.
-
-The generated config looks like this:
-
-```json
-{
-  "repo": "~/Projects/backup-wacrawl",
-  "remote": "https://github.com/steipete/backup-wacrawl.git",
-  "identity": "~/.wacrawl/age.key",
-  "recipients": ["age1..."]
-}
-```
-
-Keep `~/.wacrawl/age.key` private. The public `age1...` recipient can be stored
-in `backup.json`; the `AGE-SECRET-KEY-...` identity must stay local or in a
-password manager.
-
-### Push
-
-Push an encrypted backup:
-
-```bash
-wacrawl backup push
-```
-
-`backup push` first pulls/rebases the configured backup checkout, then uses the
-normal read-time sync policy. With the default `--sync auto --sync-max-age 15m`,
-it refreshes the local archive only when the WhatsApp Desktop source is stale
-and newer than the archive. Then it exports stable JSONL, gzip-compresses each
-shard, encrypts each shard for every configured recipient, updates
-`manifest.json`, removes stale encrypted shards, commits, and pushes the backup
-repo. Copied files already under the archive `media/` directory are included by
-default; run `wacrawl sync --copy-media` first to capture media bytes still
-available from WhatsApp Desktop. `backup push` never reads media directly from
-the WhatsApp container.
-
-Pass `--tag NAME` to tag the resulting snapshot commit. If the archive is
-unchanged, the tag points at the existing current snapshot. Existing tags are
-never moved to a different commit.
-
-Re-running `backup push` without archive changes leaves Git clean. The command
-prints the repo path, whether anything changed, whether the backup is encrypted,
-the shard count, message count, and copied-media count.
-
-Use `--no-push` for local dry runs that commit into the backup checkout but do
-not push to the remote:
-
-```bash
-wacrawl backup push --no-push
-```
-
-Use `--no-media` to omit copied media from a snapshot. The current backup then
-contains archive rows only; earlier Git commits still retain their media blobs.
-
-### Restore
-
-Restore from the backup repo:
-
-```bash
-wacrawl backup pull
-```
-
-`backup pull` pulls/rebases the configured backup repo, decrypts every shard with
-the local age identity, verifies each plaintext shard hash from the manifest,
-validates cross-table references, and replaces the configured `wacrawl` archive
-database in one import transaction. Copied media is restored alongside the
-database unless `--no-media` is set.
-
-Restore a historical tag, commit, or branch with `--ref`:
-
-```bash
-wacrawl --db /tmp/wacrawl-history.db backup pull --ref snapshot/before-phone-migration
-```
-
-Historical restore resolves the ref to a commit and reads its manifest and
-encrypted shards directly from Git objects. It does not checkout that commit or
-change the backup repository's current branch.
-
-To test a restore without touching your real archive:
-
-```bash
-wacrawl --db /tmp/wacrawl-restore-test.db backup pull
-wacrawl --db /tmp/wacrawl-restore-test.db --sync never status
-```
-
-### Status
-
-Inspect backup metadata:
-
-```bash
-wacrawl backup status
-```
-
-This reports encryption status, shard count, message count, export timestamp,
-and repo path. It reads `manifest.json`; it does not need to decrypt shards.
-
-### Multiple Machines
-
-Each machine that should restore needs its own age identity. On the new machine:
-
-```bash
-wacrawl backup init \
-  --repo ~/Projects/backup-wacrawl \
-  --remote https://github.com/steipete/backup-wacrawl.git
-```
-
-Copy the printed public recipient (`age1...`) into the `recipients` list in
-`~/.wacrawl/backup.json` on a machine that can already decrypt the backup, then
-run:
-
-```bash
-wacrawl backup push
-```
-
-After that push, newly written shards are encrypted for all configured
-recipients. If you added a recipient after data already existed, run a normal
-`wacrawl backup push`; unchanged plaintext shards are re-encrypted when the
-manifest/config changes.
-
-For personal setup, storing a copy of `~/.wacrawl/age.key` in 1Password is a
-good recovery path. Do not commit the identity file. Do not paste the
-`AGE-SECRET-KEY-...` value into issues, logs, docs, or chat.
-
-### Flags
-
-Useful flags:
-
-```text
---config PATH        Backup config path. Default: ~/.wacrawl/backup.json
---repo PATH          Local backup Git checkout.
---remote URL         Backup Git remote.
---identity PATH      Local age identity. Default: ~/.wacrawl/age.key
---recipient AGE      Public age recipient. Repeat for multiple machines.
---no-push            Commit locally but do not push.
-```
-
-### Recovery Checklist
-
-On a new Mac:
-
-```bash
-brew install openclaw/tap/wacrawl
-git clone https://github.com/steipete/backup-wacrawl.git ~/Projects/backup-wacrawl
-mkdir -p ~/.wacrawl
-```
-
-Then restore `~/.wacrawl/age.key` from your password manager and create
-`~/.wacrawl/backup.json` pointing at the clone:
-
-```json
-{
-  "repo": "~/Projects/backup-wacrawl",
-  "remote": "https://github.com/steipete/backup-wacrawl.git",
-  "identity": "~/.wacrawl/age.key",
-  "recipients": ["age1..."]
-}
-```
-
-Finally:
-
-```bash
-wacrawl backup pull
-wacrawl --sync never status
-```
-
-If decryption fails, the local `identity` does not match any recipient used for
-the encrypted shards. If Git push fails, fix normal GitHub permissions for the
-backup repository; the archive data is already encrypted before the push.
-
-## Global Flags
-
-```text
---db PATH               Archive database path. Default: ~/.wacrawl/wacrawl.db
---source PATH           WhatsApp Desktop source path.
---sync MODE             Read-time sync policy: auto, always, or never. Default: auto.
---sync-max-age DURATION Staleness window for --sync auto. Default: 15m.
---json                  Emit JSON instead of human-readable output.
---version               Print the CLI version.
-```
-
-Import/sync flags:
-
-```text
---copy-media            Copy referenced media during import/sync.
---adopt-source          Bind an unverified archive to this account and merge.
---restore               Exactly replace archive rows instead of merging.
-```
-
-## Data Format Notes
-
-WhatsApp Desktop uses CoreData-style SQLite tables. The importer currently knows
-about:
-
-```text
-ZWACHATSESSION
-ZWAMESSAGE
-ZWAMEDIAITEM
-ZWAGROUPINFO
-ZWAGROUPMEMBER
-Axolotl.sqlite: ZWAZMDACCOUNT (account identity only)
-```
-
-Important details:
-
-- WhatsApp timestamps are seconds since `2001-01-01T00:00:00Z`.
-- `ZWAMESSAGE.Z_PK` is the stable source row identity inside each separate
-  account archive and maps to `messages.event_id` as `wa:<source_pk>`.
-  Routine merges bind the archive to one canonical Desktop source path and a
-  hashed CoreData store fingerprint, then reject source changes and conflicting
-  event envelopes. A separate hashed account JID is the privacy boundary; event
-  overlap never substitutes for it. Existing archives without that binding
-  require a one-time explicit `--adopt-source`. Use a separate `--db`
-  for another account or `--restore` for an intentional source replacement.
-- `ZSTANZAID` is not unique enough for archive identity.
-- Every canonical entity carries `deleted_at`, `deletion_source`,
-  `deletion_reason`, and `last_seen_at`; an unobserved row is never implicitly
-  tombstoned.
-- Prior observable message payloads are append-only rows in
-  `message_revisions` keyed by stable `event_id`.
-- Group senders are resolved through `ZWAMESSAGE.ZGROUPMEMBER`.
-- Media is joined through both `ZWAMESSAGE.ZMEDIAITEM` and
-  `ZWAMEDIAITEM.ZMESSAGE`.
-- WhatsApp's own search database uses a custom `wa_tokenizer`; `wacrawl` builds
-  a portable FTS5 index instead.
+| Command | Purpose |
+| --- | --- |
+| `doctor` | Inspect source and archive paths |
+| `sync`, `import` | Snapshot and merge WhatsApp Desktop data |
+| `status`, `chats`, `unread`, `messages` | Inspect archived conversations |
+| `contacts export` | Export named contacts with phone numbers |
+| `search` | Search the portable SQLite FTS5 index |
+| `sql` | Run one read-only `SELECT` statement |
+| `web` | Open the private local viewer |
+| `backup` | Initialize, push, inspect, or restore encrypted Git backups |
+| `metadata` | Print CrawlKit control metadata for automation |
+
+Run `wacrawl help <command>` or open the [full command reference](docs/commands.md).
+
+## Documentation
+
+- [Commands, filters, paths, and sync behavior](docs/commands.md)
+- [Encrypted backups, recovery, and threat model](docs/backups.md)
+- [Archive identities and data model](docs/data-model.md)
+- [Release process](docs/releasing.md)
 
 ## Development
 
-Requires Go 1.26 or newer.
+Requires Go 1.26.5 or newer.
 
 ```bash
-make help
+make build
+make test
 make check
 ```
 
-`make check` runs every local gate enforced by CI, including formatting, static
-analysis, tests and the race detector, the 85% coverage floor, dependency and
-vulnerability checks, a credential-free GoReleaser snapshot, release-script
-tests, and secret scans.
-
-## Release
-
-Official releases run entirely in GitHub Actions through the shared OpenClaw
-release workflow. The workflow freezes the protected `main` commit, creates the
-annotated version tag, builds every platform archive, signs and notarizes the
-Darwin binaries with organization secrets, verifies the unpublished draft on
-both macOS architectures, publishes the exact verified bytes, and hands the
-release to the OpenClaw Homebrew tap.
-
-```bash
-gh workflow run release-unified.yml \
-  --repo openclaw/wacrawl \
-  --ref main \
-  -f version=0.3.5
-```
-
-The version's changelog section must be dated before dispatch. Release tags,
-Developer ID credentials, App Store Connect credentials, draft publication,
-artifact verification, and Homebrew dispatch are owned by the reusable
-workflow; no local signing key, notary profile, allowed-signers file, or release
-token is required. `make release VERSION=v0.3.5` intentionally refuses local
-publication and prints the official workflow command instead.
-
-Local builds and `make snapshot` do not require signing credentials. They
-remain suitable for development and cross-platform CI, but are not official
-macOS release artifacts.
-
-The official draft release contains artifacts for:
-
-```text
-darwin/amd64
-darwin/arm64
-linux/amd64
-linux/arm64
-windows/amd64
-windows/arm64
-```
-
-The Homebrew formula lives in:
-
-```text
-~/Projects/openclaw-homebrew-tap/Formula/wacrawl.rb
-```
+`make check` mirrors the local CI gates: formatting, analysis, tests, race and coverage checks, dependency and vulnerability checks, a credential-free GoReleaser snapshot, release-script tests, and secret scans.
 
 ## License
 
-MIT. See `LICENSE`.
+MIT. See [LICENSE](LICENSE).

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -1,0 +1,173 @@
+# Encrypted Git backups
+
+`wacrawl` can export its archive into age-encrypted JSONL shards stored in a Git repository. The message data and copied media are encrypted before Git sees them.
+
+## Repository layout
+
+```text
+README.md
+manifest.json
+data/chats.jsonl.gz.age
+data/contacts.jsonl.gz.age
+data/groups.jsonl.gz.age
+data/group_participants.jsonl.gz.age
+data/messages/YYYY/MM.jsonl.gz.age
+data/message_revisions.jsonl.gz.age
+data/files/index*.jsonl.gz.age
+data/files/objects/OPAQUE_ID.gz.age
+```
+
+`manifest.json` is intentionally cleartext so a machine can inspect freshness, public age recipients, counts, shard paths, encrypted byte sizes, and plaintext hashes without decrypting the payloads. It does not contain message text, chat names, contacts, participant IDs, media metadata, filenames, or archive paths.
+
+Copied media is included by default. Identical files share one encrypted blob with a random opaque object ID; content hashes and paths remain inside the encrypted index. Use `--no-media` when only archive rows are wanted.
+
+## Setup
+
+Initialize the backup checkout and a local age identity:
+
+```bash
+wacrawl backup init \
+  --repo ~/Projects/backup-wacrawl \
+  --remote <git-url>
+```
+
+When omitted, the current default remote is `https://github.com/steipete/backup-wacrawl.git`; pass `--remote` for another private repository.
+
+This writes `~/.wacrawl/backup.json`, creates `~/.wacrawl/age.key` if needed, clones or initializes the local checkout, and prints the public age recipient.
+
+```json
+{
+  "repo": "~/Projects/backup-wacrawl",
+  "remote": "<git-url>",
+  "identity": "~/.wacrawl/age.key",
+  "recipients": ["age1..."]
+}
+```
+
+Keep the `AGE-SECRET-KEY-...` identity private. The matching `age1...` recipient is public and can be stored in the config and manifest.
+
+## Push and inspect
+
+```bash
+wacrawl backup push
+wacrawl backup status
+wacrawl backup snapshots
+```
+
+`backup push` pulls and rebases the configured checkout, applies the normal read-time sync policy, exports stable JSONL, compresses and encrypts each shard for every recipient, updates the manifest, removes stale encrypted shards, commits, and pushes. It includes copied files already under the archive's `media/` directory; run `wacrawl sync --copy-media` first to capture media still available from WhatsApp Desktop. The backup command never reads media directly from the WhatsApp container.
+
+Useful variants:
+
+```bash
+# Commit locally without pushing.
+wacrawl backup push --no-push
+
+# Omit copied media from the current snapshot.
+wacrawl backup push --no-media
+
+# Name the resulting snapshot commit.
+wacrawl backup push --tag snapshot/before-phone-migration
+```
+
+Re-running `backup push` without archive changes leaves Git clean. When `--tag` is used without a data change, the tag points to the existing current snapshot; existing tags are never moved. The command reports the checkout path, whether data changed, encryption state, shard count, message count, and copied-media count. Tag names and commit metadata remain visible to anyone who can inspect the repository, so keep tag names non-sensitive.
+
+You do not need to run Git manually for the normal flow. Push handles fetch and rebase, while pull updates the current archive branch. `backup pull --ref` fetches refs and reads the selected Git objects without checking them out or rewriting the backup checkout.
+
+`backup status` reads only the cleartext manifest. `backup snapshots --limit N` lists the newest manifest-changing commits and their tags.
+
+## Restore
+
+```bash
+wacrawl backup pull
+```
+
+The pull command updates the configured checkout, decrypts every shard with the local identity, verifies plaintext hashes, restores copied media, validates cross-table references, and replaces the configured archive in one transaction.
+
+Test a restore without touching the primary archive:
+
+```bash
+wacrawl --db /tmp/wacrawl-restore-test.db backup pull
+wacrawl --db /tmp/wacrawl-restore-test.db --sync never status
+```
+
+Restore a historical tag, commit, or branch without changing the backup checkout:
+
+```bash
+wacrawl --db /tmp/wacrawl-history.db backup pull \
+  --ref snapshot/before-phone-migration
+```
+
+Pass `--no-media` to restore archive rows without copied media. On push, `--no-media` removes media from the current snapshot, but earlier Git commits still retain their encrypted media blobs.
+
+## Multiple machines
+
+Each machine that restores the backup should have its own age identity. On the new machine, run `backup init`, then copy its printed public recipient into the `recipients` list on a machine that can already decrypt the backup. The next `backup push` re-encrypts shards for all configured recipients, including unchanged plaintext shards when the recipient set changes.
+
+Keep a recovery copy of each `~/.wacrawl/age.key` in a password manager. Never commit the identity or paste it into issues, logs, documentation, or chat.
+
+## Recovery checklist
+
+On a new machine:
+
+```bash
+brew install openclaw/tap/wacrawl
+git clone <git-url> ~/Projects/backup-wacrawl
+mkdir -p ~/.wacrawl
+```
+
+Restore `~/.wacrawl/age.key` from the password manager and create `~/.wacrawl/backup.json` pointing at the clone. Then run:
+
+```bash
+wacrawl backup pull
+wacrawl --sync never status
+```
+
+If decryption fails, the configured identity does not match any recipient used for the shards. If Git push fails, fix the repository permissions; the archive payload is already encrypted before upload.
+
+## Encryption flow
+
+Backups use the Go `filippo.io/age` library with X25519 recipients. There is no backup password.
+
+For each push, `wacrawl`:
+
+1. Exports deterministic JSONL rows.
+2. Streams copied media through hashing, gzip, and age encryption.
+3. Deduplicates identical media by content and encrypts the private path index.
+4. Encrypts every compressed payload for each configured recipient.
+5. Writes only encrypted `*.jsonl.gz.age` payloads to Git.
+6. Writes cleartext manifest metadata for status, diffing, and restore verification.
+
+Pull performs the reverse, verifies hashes, localizes portable media paths, validates references, and imports the snapshot transactionally.
+
+## Threat model
+
+The backup protects message text, contacts, chat names, participant IDs, media metadata, filenames, archive paths, and copied media from a read-only Git compromise or accidental clone. Each listed recipient can decrypt every shard. Age detects encrypted-file corruption, and `wacrawl` also verifies manifest hashes after decryption.
+
+The Git repository still reveals:
+
+- Export time, public recipients, table names, row counts, shard paths, encrypted byte sizes, and row or index hashes in `manifest.json`.
+- Message activity by year and month through paths such as `data/messages/2026/04.jsonl.gz.age`.
+- Backup cadence and changed shards through Git history.
+
+Important limits:
+
+- This is confidentiality and integrity checking, not end-to-end provenance. A writer can replace the backup with different data encrypted to your public recipient.
+- Losing every matching private identity makes the backup unrecoverable.
+- Removing a compromised recipient and pushing re-encrypts current shards, but old Git history can remain decryptable until it is rewritten or deleted.
+- X25519 recipients are not post-quantum.
+- The local WhatsApp source, archive database, and copied media remain plaintext on the machine.
+
+## Flags
+
+| Flag | Commands | Meaning |
+| --- | --- | --- |
+| `--config PATH` | all | Config path; default `~/.wacrawl/backup.json` |
+| `--repo PATH` | all | Local backup checkout |
+| `--remote URL` | all | Git remote |
+| `--identity PATH` | init, push, pull, status | Local age identity |
+| `--recipient AGE` | init, push | Public recipient; repeatable |
+| `--no-push` | init, push | Commit locally without pushing |
+| `--no-media` | push, pull | Omit copied media |
+| `--tag NAME` | push | Tag the resulting snapshot |
+| `--ref REF` | pull | Restore a tag, commit, or branch |
+| `--limit N` | snapshots | Limit history results; default 20 |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,186 @@
+# Command reference
+
+`wacrawl` reads macOS WhatsApp Desktop data into its own local SQLite archive. This page covers paths, import behavior, commands, filters, and automatic sync.
+
+## Paths
+
+The default WhatsApp Desktop source is:
+
+```text
+~/Library/Group Containers/group.net.whatsapp.WhatsApp.shared
+```
+
+The importer reads:
+
+```text
+ChatStorage.sqlite
+ContactsV2.sqlite
+Axolotl.sqlite
+Message/Media/
+```
+
+The local archive defaults to:
+
+```text
+~/.wacrawl/wacrawl.db
+```
+
+Override either location with global flags:
+
+```bash
+wacrawl --source "/path/to/WhatsApp.shared" doctor
+wacrawl --db /tmp/wacrawl.db sync
+```
+
+## Import and sync
+
+`sync` and `import` are aliases. They copy the WhatsApp SQLite database, WAL, and SHM files into a temporary snapshot, then merge the useful records into the archive in one transaction.
+
+```bash
+wacrawl sync
+wacrawl sync --copy-media
+wacrawl import --adopt-source
+wacrawl import --restore
+```
+
+Routine imports merge by stable row identity. Rows absent from the current Desktop snapshot stay in the archive because absence alone is not a deletion signal. This preserves older history after WhatsApp evicts it locally.
+
+The archive binds the canonical Desktop source, a hashed portable CoreData store marker, and a separately hashed account-owned JID from `Axolotl.sqlite`. A nonempty legacy archive without that verified account binding refuses routine merges until an explicit `--adopt-source`. Established account and store fingerprints stay strict across encrypted backup restore. Use a separate `--db` for a different account, or `--restore` when the current snapshot must exactly replace the archive. `--adopt-source` and `--restore` are mutually exclusive.
+
+Explicit WhatsApp signals create source-attributed tombstones instead of deleting rows. Removed chats tombstone their archived groups, participants, and messages; inactive group members are tombstoned; and a message payload observed changing to SQL `NULL` is retained as a deleted message with its previous payload in `message_revisions`. Message tombstones remain sticky during later merges. An exact `--restore` is authoritative and can revive a source row; it also removes destination-only rows and local revision history. A removed chat can start a new live lifecycle when WhatsApp reports post-tombstone activity without reviving its historical messages. Normal list, search, status, and web reads exclude tombstones, while encrypted backups retain them.
+
+By default, media paths continue to point into WhatsApp Desktop's app container. `--copy-media` copies referenced files into `media/` beside the archive and rewrites the imported paths. Missing media is counted but does not fail the import.
+
+## Read commands
+
+### `doctor`
+
+Inspect source availability, discovered database files, row counts, date range, archive path, and schema notes:
+
+```bash
+wacrawl doctor
+wacrawl --json doctor
+```
+
+### `status`
+
+Show live and deleted entity counts, revisions, unread counts, media-message count, date range, last import, and source metadata:
+
+```bash
+wacrawl status
+wacrawl --sync never status
+```
+
+### `chats` and `unread`
+
+List chats by newest message, optionally filtering to chats with unread messages:
+
+```bash
+wacrawl chats --limit 100
+wacrawl chats --unread
+wacrawl unread --limit 20
+```
+
+Unread state comes from WhatsApp Desktop's per-chat counter; the message rows do not expose a reliable incoming per-message “read by me” flag.
+
+### `messages`
+
+```bash
+wacrawl messages --limit 20
+wacrawl messages --chat 1234567890@s.whatsapp.net --asc
+wacrawl messages --after 2026-01-01 --from-them
+wacrawl --json messages --has-media --limit 100
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--chat JID` | Restrict to one chat |
+| `--sender JID` | Restrict to one sender |
+| `--limit N` | Maximum rows; default 50 |
+| `--after TIME` | After an RFC 3339 timestamp or `YYYY-MM-DD` |
+| `--before TIME` | Before an RFC 3339 timestamp or `YYYY-MM-DD` |
+| `--from-me` | Outgoing messages only |
+| `--from-them` | Incoming messages only |
+| `--has-media` | Messages with media metadata only |
+| `--asc` | Oldest first |
+
+### `search`
+
+Search the portable SQLite FTS5 index across message text, chat name, sender name, and media title. Search accepts the same filters as `messages`, before or after the query.
+
+```bash
+wacrawl search "launch"
+wacrawl search "invoice" --from-them --after 2026-01-01
+wacrawl --json search --chat 1234567890@s.whatsapp.net "release notes"
+```
+
+### `contacts export`
+
+Export contacts that have a display name and phone number using the CrawlKit contact schema:
+
+```bash
+wacrawl --json --sync never contacts export
+```
+
+### `sql`
+
+Run a single read-only `SELECT` statement against the archive:
+
+```bash
+wacrawl sql "SELECT count(*) FROM messages"
+wacrawl --json sql "SELECT chat_jid, count(*) FROM messages GROUP BY chat_jid"
+```
+
+Use `--db PATH` to query another archive.
+
+### `web`
+
+```bash
+wacrawl web
+wacrawl --sync never web --port 8787
+```
+
+The viewer prints a private URL and runs until Ctrl-C. It binds to IPv4 loopback, chooses a random free port by default, and uses a random access key stored in the URL fragment. The page consumes the key into memory and removes it from the address bar.
+
+The read-only interface uses a two-pane chat layout with day separators, deterministic contact avatars, dark and light themes, search highlighting, older-message pagination, and WhatsApp-style formatting for emphasis, code, quotes, lists, and links. Photos, stickers, and GIFs can render from local files behind the same key; media reads are content-sniffed, size-capped, and restricted to the archive media directory and bound WhatsApp source. Other attachments stay metadata-only. The viewer cannot alter archives, backup configuration, or sync schedules, and it cannot listen on a non-loopback address.
+
+### `metadata`
+
+Print `crawlkit.control.v1` metadata for schedulers and local automation:
+
+```bash
+wacrawl metadata
+```
+
+## Automatic sync
+
+Before `status`, `chats`, `contacts export`, `unread`, `messages`, `search`, `sql`, `web`, or `backup push`, `wacrawl` checks the archive's last import time. If the archive is stale, it imports only when the WhatsApp Desktop source is newer.
+
+```text
+--sync auto     Sync when the archive is stale and the source is ahead. Default.
+--sync always   Force a sync before every read command.
+--sync never    Read only the existing archive.
+```
+
+The default staleness window is 15 minutes:
+
+```bash
+wacrawl --sync always status
+wacrawl --sync never --json messages --limit 10
+wacrawl --sync-max-age 1h chats
+```
+
+When the source is unavailable but an archive exists, `--sync auto` warns and continues with the archive. `--sync always` returns an error.
+
+## Global flags
+
+| Flag | Meaning |
+| --- | --- |
+| `--db PATH` | Archive database; default `~/.wacrawl/wacrawl.db` |
+| `--source PATH` | WhatsApp Desktop source |
+| `--sync MODE` | `auto`, `always`, or `never`; default `auto` |
+| `--sync-max-age DURATION` | Staleness window; default `15m` |
+| `--json` | Emit JSON instead of human-readable output |
+| `--version` | Print the CLI version |
+
+Run `wacrawl --help`, `wacrawl help <command>`, or `wacrawl backup help <command>` for the flags compiled into the installed binary.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,35 @@
+# Archive identities and data model
+
+WhatsApp Desktop stores CoreData-style records in SQLite. `wacrawl` imports the useful entities into a portable archive with an FTS5 search index.
+
+## Source tables
+
+The importer reads these WhatsApp tables:
+
+```text
+ZWACHATSESSION
+ZWAMESSAGE
+ZWAMEDIAITEM
+ZWAGROUPINFO
+ZWAGROUPMEMBER
+Axolotl.sqlite: ZWAZMDACCOUNT (account identity only)
+```
+
+## Identity and merge rules
+
+- WhatsApp timestamps are seconds since `2001-01-01T00:00:00Z`.
+- `ZWAMESSAGE.Z_PK` is stable inside one source archive and maps to `messages.event_id` as `wa:<source_pk>`.
+- Routine merges bind the archive to the canonical source path, a hashed CoreData store fingerprint, and a separately hashed account JID. Event overlap is not an account-identity substitute.
+- Legacy archives without verified account binding require one explicit `--adopt-source`. Use a separate `--db` for another account or `--restore` for intentional source replacement.
+- `ZSTANZAID` is not unique enough to identify archived messages.
+- Canonical entities carry `deleted_at`, `deletion_source`, `deletion_reason`, and `last_seen_at`; an unobserved row is never implicitly tombstoned.
+- Prior observable message payloads are append-only `message_revisions` rows keyed by stable event ID.
+- Group senders resolve through `ZWAMESSAGE.ZGROUPMEMBER`.
+- Media joins through both `ZWAMESSAGE.ZMEDIAITEM` and `ZWAMEDIAITEM.ZMESSAGE`.
+- WhatsApp's search database uses its own `wa_tokenizer`; `wacrawl` builds a portable SQLite FTS5 index instead.
+
+## Imported entities
+
+The archive contains contacts, chats, groups, group participants, messages, message revisions, media metadata and local media paths, source identities, and import metadata. Normal readers exclude tombstoned entities; encrypted backups retain them so exact restore does not discard source deletion history.
+
+See the [command reference](commands.md#import-and-sync) for merge, adoption, restore, and media-copy behavior.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,41 @@
+# Release process
+
+Official releases run in GitHub Actions through the shared OpenClaw release workflow. The workflow freezes the protected `main` commit, creates the annotated version tag, builds every archive, signs and notarizes the macOS binaries with organization credentials, verifies the unpublished draft on both macOS architectures, publishes the verified bytes, and dispatches the Homebrew update.
+
+## Dispatch
+
+The changelog section for the version must be dated before dispatch:
+
+```bash
+gh workflow run release-unified.yml \
+  --repo openclaw/wacrawl \
+  --ref main \
+  -f version=X.Y.Z
+```
+
+Tags, Developer ID and App Store Connect credentials, draft publication, artifact verification, and Homebrew handoff belong to the workflow. `make release VERSION=vX.Y.Z` deliberately refuses local publication and prints the official command.
+
+## Local verification
+
+Local builds and snapshots require no signing credentials:
+
+```bash
+make build
+make snapshot
+make verify-release VERSION=vX.Y.Z
+```
+
+They are suitable for development and cross-platform CI, but they are not official signed macOS artifacts.
+
+The release publishes archives for:
+
+```text
+darwin/amd64
+darwin/arm64
+linux/amd64
+linux/arm64
+windows/amd64
+windows/arm64
+```
+
+The Homebrew formula lives in the [`openclaw/homebrew-tap`](https://github.com/openclaw/homebrew-tap/blob/main/Formula/wacrawl.rb) repository.


### PR DESCRIPTION
## Summary

Rewrites the README to the shared house structure and reduces it from 809 to 142 lines. The new front door leads with the install path and a four-command quick start, keeps the banner and web-viewer screenshot near the top, adds dynamic flat-square badges, and progresses into search, automation, backup, safety, development, and license guidance.

## Moved and dropped

- Moved the full CLI, filter, path, import, and sync reference to `docs/commands.md`.
- Moved encrypted backup setup, restore, multi-machine recovery, flags, and threat model to `docs/backups.md`.
- Moved importer identity and archive-schema details to `docs/data-model.md`.
- Moved maintainer release instructions to `docs/releasing.md`.
- Dropped no substantive factual guidance. Repeated examples and duplicate explanations were consolidated; the hard-coded release version and machine-local tap path were replaced with durable placeholders and repository links.

## Verification

- `make build`: passed with Go 1.26.5.
- Temporary Go quick-start harness: compiled and passed for `doctor`, `sync`, `status`, `search`, and `web` help paths, then removed. The machine has no local WhatsApp Desktop container, so commands requiring live data were validated against the built CLI help rather than presented as live imports.
- `make test`: passed.
- `make check`: passed all formatting, lint, vet, staticcheck, deadcode, gosec, unit, race, 85% coverage (85.2%), dependency, vulnerability, snapshot, release-script, and secret-scan gates.
- Relative-link resolver: all README and `docs/*.md` targets exist.
- External links and all five badge URLs: HTTP 200; Shields SVGs contain no `invalid` or `not found` card.
- Distribution: `brew info openclaw/tap/wacrawl` reports stable 0.3.5; `go list -m -json github.com/openclaw/wacrawl@latest` resolves v0.3.5; GitHub Releases reports v0.3.5 latest.
- Autoreview: clean, with no accepted/actionable findings.
