### PR TITLE
fix(import): derive local account from message recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Verify unified release archives with normalized `./` tar members.
+- Derive the local WhatsApp account identity from incoming message recipients when current account metadata is absent, instead of mistaking remote Signal session peers for local accounts.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@
 ### Fixed
 
 - Verify unified release archives with normalized `./` tar members.
-- Derive the local WhatsApp account identity from incoming message recipients when current account metadata is absent, instead of mistaking remote Signal session peers for local accounts.
-
 ### Changed
 
 - Rewrite the README to the house standard and move detailed commands, backups, data model, and release guidance into `docs/`.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -37,6 +37,7 @@ type ImportStats struct {
 	SourceIdentity      string    `json:"-"`
 	SourceStoreIdentity string    `json:"-"`
 	AccountIdentity     string    `json:"-"`
+	LegacyAccountIDs    []string  `json:"-"`
 	AdoptSource         bool      `json:"-"`
 	SourceSnapshotAt    time.Time `json:"-"`
 	SourceNewestMessage time.Time `json:"-"`
@@ -554,6 +555,7 @@ func validateImportSource(ctx context.Context, tx *sql.Tx, restore bool, stats I
 	if existingStrong == "" && existingWeak != "" && weakSource != existingWeak {
 		return "", fmt.Errorf("archive is bound to WhatsApp source path %q, not %q; use a separate --db or import --restore", existingWeak, weakSource)
 	}
+	matchingMessages := 0
 	for _, message := range messages {
 		existing, found, err := messageBySourcePK(ctx, tx, message.SourcePK)
 		if err != nil {
@@ -561,6 +563,9 @@ func validateImportSource(ctx context.Context, tx *sql.Tx, restore bool, stats I
 		}
 		if found && messageIdentityConflict(existing, message) {
 			return "", fmt.Errorf("message source_pk %d belongs to a different event; use a separate archive or import --restore", message.SourcePK)
+		}
+		if found {
+			matchingMessages++
 		}
 	}
 	accountIdentity := strings.TrimSpace(stats.AccountIdentity)
@@ -577,7 +582,14 @@ func validateImportSource(ctx context.Context, tx *sql.Tx, restore bool, stats I
 		existingAccount = ""
 	}
 	if existingAccount != "" {
-		if accountIdentity == "" || existingAccount != accountIdentity {
+		legacyMatch := false
+		for _, candidate := range stats.LegacyAccountIDs {
+			if strings.TrimSpace(candidate) == existingAccount {
+				legacyMatch = true
+				break
+			}
+		}
+		if accountIdentity == "" || (existingAccount != accountIdentity && (!legacyMatch || matchingMessages == 0)) {
 			return "", errors.New("archive is bound to a different WhatsApp account; use a separate --db or import --restore")
 		}
 	} else {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -462,6 +462,40 @@ func TestMergeAdoptsEarlyStoreUUIDAccountBinding(t *testing.T) {
 	}
 }
 
+func TestMergeMigratesLegacyAccountBindingWithEventContinuity(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "legacy-account.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+	now := time.Date(2026, 8, 3, 4, 30, 0, 0, time.UTC)
+	existing := Message{SourcePK: 1, ChatJID: "chat", MessageID: "one", Timestamp: now, Text: "body", RawType: 0}
+	base := ImportStats{SourceIdentity: "/source", SourceStoreIdentity: "wa-store:fixture", AccountIdentity: "wa-account:legacy", FinishedAt: now, Messages: 1}
+	if err := st.MergeAll(ctx, base, nil, []Chat{{JID: "chat", Kind: "dm"}}, nil, nil, []Message{existing}); err != nil {
+		t.Fatal(err)
+	}
+	upgrade := ImportStats{
+		SourceIdentity:      base.SourceIdentity,
+		SourceStoreIdentity: base.SourceStoreIdentity,
+		AccountIdentity:     "wa-account:recipient",
+		LegacyAccountIDs:    []string{base.AccountIdentity},
+		FinishedAt:          now.Add(time.Minute),
+		Messages:            1,
+	}
+	disjoint := Message{SourcePK: 2, ChatJID: "chat", MessageID: "two", Timestamp: now, Text: "other", RawType: 0}
+	if err := st.ValidateImport(ctx, upgrade, []Message{disjoint}, false); err == nil || !strings.Contains(err.Error(), "different WhatsApp account") {
+		t.Fatalf("legacy candidate without event continuity error = %v", err)
+	}
+	if err := st.MergeAll(ctx, upgrade, nil, nil, nil, nil, []Message{existing}); err != nil {
+		t.Fatalf("legacy account migration: %v", err)
+	}
+	var binding string
+	if err := st.DB().QueryRowContext(ctx, `select value from sync_state where key='merge_account_identity'`).Scan(&binding); err != nil || binding != upgrade.AccountIdentity {
+		t.Fatalf("migrated account binding = %q, %v", binding, err)
+	}
+}
+
 func TestStrongSourceIdentityRequiresAccountContinuity(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(ctx, filepath.Join(t.TempDir(), "continuity.db"))

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -63,6 +63,7 @@ type Data struct {
 	MediaCount          int
 	SourceStoreIdentity string
 	AccountIdentity     string
+	LegacyAccountIDs    []string
 }
 
 type ImportOptions struct {
@@ -189,18 +190,19 @@ func Extract(ctx context.Context, snap Snapshot) (Data, error) {
 		return Data{}, err
 	}
 	chatDBPath := filepath.Join(snap.Root, chatDBName)
-	accountIdentity, err := readAccountIdentity(ctx, filepath.Join(snap.Root, axolotlDBName), chatDBPath)
+	accountIdentity, legacyAccountIDs, err := readAccountIdentity(ctx, filepath.Join(snap.Root, axolotlDBName), chatDBPath)
 	if err != nil {
 		return Data{}, err
 	}
-	accountIdentityBefore, err := readAccountIdentity(ctx, filepath.Join(snap.Root, axolotlBeforeDBName), chatDBPath)
+	accountIdentityBefore, legacyAccountIDsBefore, err := readAccountIdentity(ctx, filepath.Join(snap.Root, axolotlBeforeDBName), chatDBPath)
 	if err != nil {
 		return Data{}, err
 	}
 	if accountIdentity != accountIdentityBefore {
 		return Data{}, errors.New("WhatsApp account changed while the Desktop snapshot was being captured; retry the import")
 	}
-	return Data{Contacts: contacts, Chats: chats, Groups: groups, Participants: participants, Messages: messages, MediaCount: mediaCount, SourceStoreIdentity: sourceStoreIdentity, AccountIdentity: accountIdentity}, nil
+	legacyAccountIDs = sharedIdentities(legacyAccountIDs, legacyAccountIDsBefore)
+	return Data{Contacts: contacts, Chats: chats, Groups: groups, Participants: participants, Messages: messages, MediaCount: mediaCount, SourceStoreIdentity: sourceStoreIdentity, AccountIdentity: accountIdentity, LegacyAccountIDs: legacyAccountIDs}, nil
 }
 
 func readSourceIdentity(ctx context.Context, chatDBPath string) (string, error) {
@@ -231,48 +233,84 @@ func readSourceIdentity(ctx context.Context, chatDBPath string) (string, error) 
 	return fmt.Sprintf("wa-store:%x", fingerprint), nil
 }
 
-func readAccountIdentity(ctx context.Context, axolotlDBPath, chatDBPath string) (string, error) {
+func readAccountIdentity(ctx context.Context, axolotlDBPath, chatDBPath string) (string, []string, error) {
 	var metadataIDs map[string]struct{}
+	legacyIDs := make(map[string]struct{})
 	if _, err := os.Stat(axolotlDBPath); err == nil {
 		db, closeDB, err := openReadOnly(axolotlDBPath)
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
 		defer closeDB()
 
 		metadataIDs, err = accountIDs(ctx, db, "ZWAZMDACCOUNT", "ZUSERJIDSTRING")
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
 		if len(metadataIDs) == 0 {
 			metadataIDs, err = accountIDs(ctx, db, "ZWAZMDACCOUNT", "ZACCOUNTJIDSTRING")
 			if err != nil {
-				return "", err
+				return "", nil, err
+			}
+		}
+		if len(metadataIDs) == 0 {
+			for _, table := range []string{"ZWAAXOLOTLIDENTITY", "ZWAAXOLOTLSESSION", "ZWASENDERKEY"} {
+				ids, err := accountIDs(ctx, db, table, "ZACCOUNTJIDSTRING")
+				if err != nil {
+					return "", nil, err
+				}
+				for id := range ids {
+					legacyIDs[id] = struct{}{}
+				}
 			}
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
-		return "", err
+		return "", nil, err
 	}
 
 	messageIDs, err := incomingMessageAccountIDs(ctx, chatDBPath)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	metadataIdentity, err := accountFingerprint(metadataIDs)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	messageIdentity, err := accountFingerprint(messageIDs)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if metadataIdentity != "" && messageIdentity != "" && metadataIdentity != messageIdentity {
-		return "", errors.New("WhatsApp account metadata does not match the imported message store")
+		return "", nil, errors.New("WhatsApp account metadata does not match the imported message store")
 	}
 	if metadataIdentity != "" {
-		return metadataIdentity, nil
+		return metadataIdentity, nil, nil
 	}
-	return messageIdentity, nil
+	return messageIdentity, accountFingerprints(legacyIDs), nil
+}
+
+func accountFingerprints(ids map[string]struct{}) []string {
+	fingerprints := make([]string, 0, len(ids))
+	for id := range ids {
+		fingerprint := sha256.Sum256([]byte("account-jid\x00" + id))
+		fingerprints = append(fingerprints, fmt.Sprintf("wa-account:%x", fingerprint))
+	}
+	sort.Strings(fingerprints)
+	return fingerprints
+}
+
+func sharedIdentities(current, before []string) []string {
+	beforeSet := make(map[string]struct{}, len(before))
+	for _, identity := range before {
+		beforeSet[identity] = struct{}{}
+	}
+	shared := make([]string, 0, len(current))
+	for _, identity := range current {
+		if _, ok := beforeSet[identity]; ok {
+			shared = append(shared, identity)
+		}
+	}
+	return shared
 }
 
 func incomingMessageAccountIDs(ctx context.Context, chatDBPath string) (map[string]struct{}, error) {
@@ -389,6 +427,7 @@ func ImportWithOptions(ctx context.Context, st *store.Store, opts ImportOptions)
 	}
 	stats.SourceStoreIdentity = data.SourceStoreIdentity
 	stats.AccountIdentity = data.AccountIdentity
+	stats.LegacyAccountIDs = data.LegacyAccountIDs
 	stats.Chats = len(data.Chats)
 	stats.Contacts = len(data.Contacts)
 	stats.Groups = len(data.Groups)

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -253,15 +253,13 @@ func readAccountIdentity(ctx context.Context, axolotlDBPath, chatDBPath string) 
 				return "", nil, err
 			}
 		}
-		if len(metadataIDs) == 0 {
-			for _, table := range []string{"ZWAAXOLOTLIDENTITY", "ZWAAXOLOTLSESSION", "ZWASENDERKEY"} {
-				ids, err := accountIDs(ctx, db, table, "ZACCOUNTJIDSTRING")
-				if err != nil {
-					return "", nil, err
-				}
-				for id := range ids {
-					legacyIDs[id] = struct{}{}
-				}
+		for _, table := range []string{"ZWAAXOLOTLIDENTITY", "ZWAAXOLOTLSESSION", "ZWASENDERKEY"} {
+			ids, err := accountIDs(ctx, db, table, "ZACCOUNTJIDSTRING")
+			if err != nil {
+				return "", nil, err
+			}
+			for id := range ids {
+				legacyIDs[id] = struct{}{}
 			}
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -284,7 +282,7 @@ func readAccountIdentity(ctx context.Context, axolotlDBPath, chatDBPath string) 
 		return "", nil, errors.New("WhatsApp account metadata does not match the imported message store")
 	}
 	if metadataIdentity != "" {
-		return metadataIdentity, nil, nil
+		return metadataIdentity, accountFingerprints(legacyIDs), nil
 	}
 	return messageIdentity, accountFingerprints(legacyIDs), nil
 }

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -188,11 +188,12 @@ func Extract(ctx context.Context, snap Snapshot) (Data, error) {
 	if err != nil {
 		return Data{}, err
 	}
-	accountIdentity, err := readAccountIdentity(ctx, filepath.Join(snap.Root, axolotlDBName))
+	chatDBPath := filepath.Join(snap.Root, chatDBName)
+	accountIdentity, err := readAccountIdentity(ctx, filepath.Join(snap.Root, axolotlDBName), chatDBPath)
 	if err != nil {
 		return Data{}, err
 	}
-	accountIdentityBefore, err := readAccountIdentity(ctx, filepath.Join(snap.Root, axolotlBeforeDBName))
+	accountIdentityBefore, err := readAccountIdentity(ctx, filepath.Join(snap.Root, axolotlBeforeDBName), chatDBPath)
 	if err != nil {
 		return Data{}, err
 	}
@@ -230,44 +231,81 @@ func readSourceIdentity(ctx context.Context, chatDBPath string) (string, error) 
 	return fmt.Sprintf("wa-store:%x", fingerprint), nil
 }
 
-func readAccountIdentity(ctx context.Context, axolotlDBPath string) (string, error) {
-	if _, err := os.Stat(axolotlDBPath); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", nil
-		}
-		return "", err
-	}
-	db, closeDB, err := openReadOnly(axolotlDBPath)
-	if err != nil {
-		return "", err
-	}
-	defer closeDB()
-
-	preferred, err := accountIDs(ctx, db, "ZWAZMDACCOUNT", "ZUSERJIDSTRING")
-	if err != nil {
-		return "", err
-	}
-	if len(preferred) > 0 {
-		return accountFingerprint(preferred)
-	}
-	preferred, err = accountIDs(ctx, db, "ZWAZMDACCOUNT", "ZACCOUNTJIDSTRING")
-	if err != nil {
-		return "", err
-	}
-	if len(preferred) > 0 {
-		return accountFingerprint(preferred)
-	}
-	fallback := make(map[string]struct{})
-	for _, table := range []string{"ZWAAXOLOTLIDENTITY", "ZWAAXOLOTLSESSION", "ZWASENDERKEY"} {
-		ids, err := accountIDs(ctx, db, table, "ZACCOUNTJIDSTRING")
+func readAccountIdentity(ctx context.Context, axolotlDBPath, chatDBPath string) (string, error) {
+	var metadataIDs map[string]struct{}
+	if _, err := os.Stat(axolotlDBPath); err == nil {
+		db, closeDB, err := openReadOnly(axolotlDBPath)
 		if err != nil {
 			return "", err
 		}
-		for id := range ids {
-			fallback[id] = struct{}{}
+		defer closeDB()
+
+		metadataIDs, err = accountIDs(ctx, db, "ZWAZMDACCOUNT", "ZUSERJIDSTRING")
+		if err != nil {
+			return "", err
+		}
+		if len(metadataIDs) == 0 {
+			metadataIDs, err = accountIDs(ctx, db, "ZWAZMDACCOUNT", "ZACCOUNTJIDSTRING")
+			if err != nil {
+				return "", err
+			}
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+
+	messageIDs, err := incomingMessageAccountIDs(ctx, chatDBPath)
+	if err != nil {
+		return "", err
+	}
+	metadataIdentity, err := accountFingerprint(metadataIDs)
+	if err != nil {
+		return "", err
+	}
+	messageIdentity, err := accountFingerprint(messageIDs)
+	if err != nil {
+		return "", err
+	}
+	if metadataIdentity != "" && messageIdentity != "" && metadataIdentity != messageIdentity {
+		return "", errors.New("WhatsApp account metadata does not match the imported message store")
+	}
+	if metadataIdentity != "" {
+		return metadataIdentity, nil
+	}
+	return messageIdentity, nil
+}
+
+func incomingMessageAccountIDs(ctx context.Context, chatDBPath string) (map[string]struct{}, error) {
+	ids := make(map[string]struct{})
+	if _, err := os.Stat(chatDBPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return ids, nil
+		}
+		return nil, err
+	}
+	db, closeDB, err := openReadOnly(chatDBPath)
+	if err != nil {
+		return nil, err
+	}
+	defer closeDB()
+
+	for _, column := range []string{"ZISFROMME", "ZTOJID"} {
+		var present int
+		if err := db.QueryRowContext(ctx, `select count(*) from pragma_table_info('ZWAMESSAGE') where name=?`, column).Scan(&present); err != nil {
+			return nil, err
+		}
+		if present == 0 {
+			return ids, nil
 		}
 	}
-	return accountFingerprint(fallback)
+	if err := collectAccountIDs(ctx, db, `
+select coalesce(ZTOJID,'')
+from ZWAMESSAGE
+where coalesce(ZISFROMME,0)=0
+  and trim(coalesce(ZTOJID,''))<>''`, ids); err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 func accountIDs(ctx context.Context, db *sql.DB, table string, columns ...string) (map[string]struct{}, error) {

--- a/internal/whatsappdb/desktop_test.go
+++ b/internal/whatsappdb/desktop_test.go
@@ -248,7 +248,8 @@ func TestReadAccountIdentity(t *testing.T) {
 	source := t.TempDir()
 	createFixtureDBs(t, source)
 	path := filepath.Join(source, axolotlDBName)
-	before, err := readAccountIdentity(ctx, path)
+	chatPath := filepath.Join(source, chatDBName)
+	before, err := readAccountIdentity(ctx, path, chatPath)
 	if err != nil || !strings.HasPrefix(before, "wa-account:") {
 		t.Fatalf("account identity = %q, %v", before, err)
 	}
@@ -260,11 +261,11 @@ func TestReadAccountIdentity(t *testing.T) {
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
 	}
-	after, err := readAccountIdentity(ctx, path)
+	after, err := readAccountIdentity(ctx, path, chatPath)
 	if err != nil || after == before || !strings.HasPrefix(after, "wa-account:") {
 		t.Fatalf("account switch identity: before=%q after=%q err=%v", before, after, err)
 	}
-	if identity, err := readAccountIdentity(ctx, filepath.Join(t.TempDir(), axolotlDBName)); err != nil || identity != "" {
+	if identity, err := readAccountIdentity(ctx, filepath.Join(t.TempDir(), axolotlDBName), filepath.Join(t.TempDir(), chatDBName)); err != nil || identity != "" {
 		t.Fatalf("missing account database identity = %q, %v", identity, err)
 	}
 
@@ -278,7 +279,7 @@ func TestReadAccountIdentity(t *testing.T) {
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readAccountIdentity(ctx, filepath.Join(ambiguous, axolotlDBName)); err == nil || !strings.Contains(err.Error(), "multiple WhatsApp account identities") || strings.Contains(err.Error(), "--restore") {
+	if _, err := readAccountIdentity(ctx, filepath.Join(ambiguous, axolotlDBName), filepath.Join(ambiguous, chatDBName)); err == nil || !strings.Contains(err.Error(), "multiple WhatsApp account identities") || strings.Contains(err.Error(), "--restore") {
 		t.Fatalf("ambiguous account identity error = %v", err)
 	}
 }
@@ -295,30 +296,86 @@ func TestReadAccountIdentityFallbacks(t *testing.T) {
 		if err := db.Close(); err != nil {
 			t.Fatal(err)
 		}
-		identity, err := readAccountIdentity(ctx, path)
+		identity, err := readAccountIdentity(ctx, path, filepath.Join(t.TempDir(), chatDBName))
 		if err != nil || !strings.HasPrefix(identity, "wa-account:") {
 			t.Fatalf("ZMD account fallback = %q, %v", identity, err)
 		}
 	})
-	t.Run("signal account columns", func(t *testing.T) {
-		path := filepath.Join(t.TempDir(), axolotlDBName)
-		db, err := sql.Open("sqlite", path)
+	t.Run("incoming message recipient", func(t *testing.T) {
+		dir := t.TempDir()
+		axolotlPath := filepath.Join(dir, axolotlDBName)
+		db, err := sql.Open("sqlite", axolotlPath)
 		if err != nil {
 			t.Fatal(err)
 		}
 		mustExec(t, db, `
+create table ZWAZMDACCOUNT (ZACCOUNTJIDSTRING varchar, ZUSERJIDSTRING varchar);
 create table ZWAAXOLOTLIDENTITY (ZACCOUNTJIDSTRING varchar);
 create table ZWAAXOLOTLSESSION (ZACCOUNTJIDSTRING varchar);
 create table ZWASENDERKEY (ZACCOUNTJIDSTRING varchar);
-insert into ZWAAXOLOTLIDENTITY values ('OWNER@S.WHATSAPP.NET');
-insert into ZWAAXOLOTLSESSION values ('owner@s.whatsapp.net');
-insert into ZWASENDERKEY values ('owner@s.whatsapp.net');`)
+insert into ZWAAXOLOTLIDENTITY values ('remote-a@s.whatsapp.net');
+insert into ZWAAXOLOTLSESSION values ('remote-b@s.whatsapp.net');
+insert into ZWASENDERKEY values ('remote-c@s.whatsapp.net');`)
 		if err := db.Close(); err != nil {
 			t.Fatal(err)
 		}
-		identity, err := readAccountIdentity(ctx, path)
+		chatPath := filepath.Join(dir, chatDBName)
+		db, err = sql.Open("sqlite", chatPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustExec(t, db, `
+create table ZWAMESSAGE (ZISFROMME integer, ZTOJID varchar);
+insert into ZWAMESSAGE values (0, 'OWNER@S.WHATSAPP.NET');
+insert into ZWAMESSAGE values (0, 'owner@s.whatsapp.net');
+insert into ZWAMESSAGE values (1, 'remote@s.whatsapp.net');`)
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		identity, err := readAccountIdentity(ctx, axolotlPath, chatPath)
 		if err != nil || !strings.HasPrefix(identity, "wa-account:") {
-			t.Fatalf("signal fallback = %q, %v", identity, err)
+			t.Fatalf("message recipient fallback = %q, %v", identity, err)
+		}
+	})
+	t.Run("message recipients are ambiguous", func(t *testing.T) {
+		chatPath := filepath.Join(t.TempDir(), chatDBName)
+		db, err := sql.Open("sqlite", chatPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustExec(t, db, `
+create table ZWAMESSAGE (ZISFROMME integer, ZTOJID varchar);
+insert into ZWAMESSAGE values (0, 'owner-a@s.whatsapp.net');
+insert into ZWAMESSAGE values (0, 'owner-b@s.whatsapp.net');`)
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := readAccountIdentity(ctx, filepath.Join(t.TempDir(), axolotlDBName), chatPath); err == nil || !strings.Contains(err.Error(), "multiple WhatsApp account identities") {
+			t.Fatalf("ambiguous message recipients error = %v", err)
+		}
+	})
+	t.Run("metadata and messages disagree", func(t *testing.T) {
+		dir := t.TempDir()
+		axolotlPath := filepath.Join(dir, axolotlDBName)
+		db, err := sql.Open("sqlite", axolotlPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustExec(t, db, `create table ZWAZMDACCOUNT (ZUSERJIDSTRING varchar); insert into ZWAZMDACCOUNT values ('owner-a@s.whatsapp.net')`)
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		chatPath := filepath.Join(dir, chatDBName)
+		db, err = sql.Open("sqlite", chatPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustExec(t, db, `create table ZWAMESSAGE (ZISFROMME integer, ZTOJID varchar); insert into ZWAMESSAGE values (0, 'owner-b@s.whatsapp.net')`)
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := readAccountIdentity(ctx, axolotlPath, chatPath); err == nil || !strings.Contains(err.Error(), "does not match") {
+			t.Fatalf("account metadata mismatch error = %v", err)
 		}
 	})
 	t.Run("empty schema", func(t *testing.T) {
@@ -331,7 +388,7 @@ insert into ZWASENDERKEY values ('owner@s.whatsapp.net');`)
 		if err := db.Close(); err != nil {
 			t.Fatal(err)
 		}
-		identity, err := readAccountIdentity(ctx, path)
+		identity, err := readAccountIdentity(ctx, path, filepath.Join(t.TempDir(), chatDBName))
 		if err != nil || identity != "" {
 			t.Fatalf("empty schema identity = %q, %v", identity, err)
 		}

--- a/internal/whatsappdb/desktop_test.go
+++ b/internal/whatsappdb/desktop_test.go
@@ -249,7 +249,7 @@ func TestReadAccountIdentity(t *testing.T) {
 	createFixtureDBs(t, source)
 	path := filepath.Join(source, axolotlDBName)
 	chatPath := filepath.Join(source, chatDBName)
-	before, err := readAccountIdentity(ctx, path, chatPath)
+	before, _, err := readAccountIdentity(ctx, path, chatPath)
 	if err != nil || !strings.HasPrefix(before, "wa-account:") {
 		t.Fatalf("account identity = %q, %v", before, err)
 	}
@@ -261,11 +261,11 @@ func TestReadAccountIdentity(t *testing.T) {
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
 	}
-	after, err := readAccountIdentity(ctx, path, chatPath)
+	after, _, err := readAccountIdentity(ctx, path, chatPath)
 	if err != nil || after == before || !strings.HasPrefix(after, "wa-account:") {
 		t.Fatalf("account switch identity: before=%q after=%q err=%v", before, after, err)
 	}
-	if identity, err := readAccountIdentity(ctx, filepath.Join(t.TempDir(), axolotlDBName), filepath.Join(t.TempDir(), chatDBName)); err != nil || identity != "" {
+	if identity, _, err := readAccountIdentity(ctx, filepath.Join(t.TempDir(), axolotlDBName), filepath.Join(t.TempDir(), chatDBName)); err != nil || identity != "" {
 		t.Fatalf("missing account database identity = %q, %v", identity, err)
 	}
 
@@ -279,7 +279,7 @@ func TestReadAccountIdentity(t *testing.T) {
 	if err := db.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := readAccountIdentity(ctx, filepath.Join(ambiguous, axolotlDBName), filepath.Join(ambiguous, chatDBName)); err == nil || !strings.Contains(err.Error(), "multiple WhatsApp account identities") || strings.Contains(err.Error(), "--restore") {
+	if _, _, err := readAccountIdentity(ctx, filepath.Join(ambiguous, axolotlDBName), filepath.Join(ambiguous, chatDBName)); err == nil || !strings.Contains(err.Error(), "multiple WhatsApp account identities") || strings.Contains(err.Error(), "--restore") {
 		t.Fatalf("ambiguous account identity error = %v", err)
 	}
 }
@@ -296,7 +296,7 @@ func TestReadAccountIdentityFallbacks(t *testing.T) {
 		if err := db.Close(); err != nil {
 			t.Fatal(err)
 		}
-		identity, err := readAccountIdentity(ctx, path, filepath.Join(t.TempDir(), chatDBName))
+		identity, _, err := readAccountIdentity(ctx, path, filepath.Join(t.TempDir(), chatDBName))
 		if err != nil || !strings.HasPrefix(identity, "wa-account:") {
 			t.Fatalf("ZMD account fallback = %q, %v", identity, err)
 		}
@@ -332,9 +332,12 @@ insert into ZWAMESSAGE values (1, 'remote@s.whatsapp.net');`)
 		if err := db.Close(); err != nil {
 			t.Fatal(err)
 		}
-		identity, err := readAccountIdentity(ctx, axolotlPath, chatPath)
+		identity, legacy, err := readAccountIdentity(ctx, axolotlPath, chatPath)
 		if err != nil || !strings.HasPrefix(identity, "wa-account:") {
 			t.Fatalf("message recipient fallback = %q, %v", identity, err)
+		}
+		if len(legacy) != 3 {
+			t.Fatalf("legacy account candidates = %d, want 3", len(legacy))
 		}
 	})
 	t.Run("message recipients are ambiguous", func(t *testing.T) {
@@ -350,7 +353,7 @@ insert into ZWAMESSAGE values (0, 'owner-b@s.whatsapp.net');`)
 		if err := db.Close(); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := readAccountIdentity(ctx, filepath.Join(t.TempDir(), axolotlDBName), chatPath); err == nil || !strings.Contains(err.Error(), "multiple WhatsApp account identities") {
+		if _, _, err := readAccountIdentity(ctx, filepath.Join(t.TempDir(), axolotlDBName), chatPath); err == nil || !strings.Contains(err.Error(), "multiple WhatsApp account identities") {
 			t.Fatalf("ambiguous message recipients error = %v", err)
 		}
 	})
@@ -374,7 +377,7 @@ insert into ZWAMESSAGE values (0, 'owner-b@s.whatsapp.net');`)
 		if err := db.Close(); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := readAccountIdentity(ctx, axolotlPath, chatPath); err == nil || !strings.Contains(err.Error(), "does not match") {
+		if _, _, err := readAccountIdentity(ctx, axolotlPath, chatPath); err == nil || !strings.Contains(err.Error(), "does not match") {
 			t.Fatalf("account metadata mismatch error = %v", err)
 		}
 	})
@@ -388,7 +391,7 @@ insert into ZWAMESSAGE values (0, 'owner-b@s.whatsapp.net');`)
 		if err := db.Close(); err != nil {
 			t.Fatal(err)
 		}
-		identity, err := readAccountIdentity(ctx, path, filepath.Join(t.TempDir(), chatDBName))
+		identity, _, err := readAccountIdentity(ctx, path, filepath.Join(t.TempDir(), chatDBName))
 		if err != nil || identity != "" {
 			t.Fatalf("empty schema identity = %q, %v", identity, err)
 		}
@@ -487,6 +490,61 @@ func TestImportDesktopWithoutAccountIdentityCannotMergeNonemptyArchive(t *testin
 	}
 	if _, err := ImportWithOptions(ctx, archive, ImportOptions{SourcePath: source, AdoptSource: true}); err == nil || !strings.Contains(err.Error(), "--adopt-source") {
 		t.Fatalf("adoption without account identity error = %v", err)
+	}
+}
+
+func TestImportDesktopMigratesLegacyAccountBinding(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createFixtureDBs(t, source)
+
+	chatDB, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, chatDB, `update ZWAMESSAGE set ZTOJID='fixture-owner@s.whatsapp.net' where ZISFROMME=0`)
+	if err := chatDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+	axolotlDB, err := sql.Open("sqlite", filepath.Join(source, axolotlDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, axolotlDB, `
+delete from ZWAZMDACCOUNT;
+create table ZWAAXOLOTLSESSION (ZACCOUNTJIDSTRING varchar);
+insert into ZWAAXOLOTLSESSION values ('legacy-peer@s.whatsapp.net');`)
+	if err := axolotlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	archive, err := store.Open(ctx, filepath.Join(t.TempDir(), "archive.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = archive.Close() }()
+	stats, err := Import(ctx, archive, source)
+	if err != nil || stats.AccountIdentity == "" || len(stats.LegacyAccountIDs) != 1 {
+		t.Fatalf("initial import = %+v, %v", stats, err)
+	}
+	legacyIdentity := stats.LegacyAccountIDs[0]
+	if legacyIdentity == stats.AccountIdentity {
+		t.Fatal("legacy and recipient account identities unexpectedly match")
+	}
+	if _, err := archive.DB().ExecContext(ctx, `update sync_state set value=? where key='merge_account_identity'`, legacyIdentity); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err = Import(ctx, archive, source)
+	if err != nil {
+		t.Fatalf("legacy binding upgrade: %v", err)
+	}
+	var binding string
+	if err := archive.DB().QueryRowContext(ctx, `select value from sync_state where key='merge_account_identity'`).Scan(&binding); err != nil || binding != stats.AccountIdentity {
+		t.Fatalf("migrated account binding = %q, want %q: %v", binding, stats.AccountIdentity, err)
+	}
+	if _, err := Import(ctx, archive, source); err != nil {
+		t.Fatalf("post-migration merge: %v", err)
 	}
 }
 

--- a/internal/whatsappdb/desktop_test.go
+++ b/internal/whatsappdb/desktop_test.go
@@ -534,10 +534,21 @@ insert into ZWAAXOLOTLSESSION values ('legacy-peer@s.whatsapp.net');`)
 	if _, err := archive.DB().ExecContext(ctx, `update sync_state set value=? where key='merge_account_identity'`, legacyIdentity); err != nil {
 		t.Fatal(err)
 	}
+	axolotlDB, err = sql.Open("sqlite", filepath.Join(source, axolotlDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, axolotlDB, `insert into ZWAZMDACCOUNT values (1, 'fixture-owner@s.whatsapp.net', 'fixture-owner@s.whatsapp.net')`)
+	if err := axolotlDB.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	stats, err = Import(ctx, archive, source)
 	if err != nil {
-		t.Fatalf("legacy binding upgrade: %v", err)
+		t.Fatalf("legacy binding upgrade after metadata appears: %v", err)
+	}
+	if len(stats.LegacyAccountIDs) != 1 || stats.LegacyAccountIDs[0] != legacyIdentity {
+		t.Fatalf("metadata transition legacy candidates = %v, want %q", stats.LegacyAccountIDs, legacyIdentity)
 	}
 	var binding string
 	if err := archive.DB().QueryRowContext(ctx, `select value from sync_state where key='merge_account_identity'`).Scan(&binding); err != nil || binding != stats.AccountIdentity {


### PR DESCRIPTION
## Summary

- stop treating remote Signal session peers as candidate local WhatsApp account identities
- derive the local account fingerprint from incoming message recipients when explicit account metadata is absent
- migrate a verified legacy archive binding only when the same source events overlap, then persist the corrected identity
- keep ambiguity and metadata/message mismatches fail-closed, with upgrade and second-merge regression coverage

## Validation

- `PATH="/tmp/wacrawl-tools:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin" make check` with GoReleaser v2.17.1
- live macOS WhatsApp Desktop sync against a fresh archive, followed by a second merge
- SQLite integrity returned `ok`
- metadata, empty-result search, and authenticated loopback web viewer smoke (`HTTP 200`)
- no message content, account identifiers, or private paths were logged or added to the change
