### PR TITLE
fix(deps): ignore moving release workflow tag

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      # release-workflows owns and advances this moving major tag within v1.
+      - dependency-name: openclaw/release-workflows/.github/workflows/release-go-cli.yml
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch


### PR DESCRIPTION
## Summary

- keep the intentional `openclaw/release-workflows` moving `@v1` reference under upstream release ownership
- suppress only semver minor and patch proposals for that workflow, preserving visibility for a future `v2`

## Reproduction

Dependabot opened #56 immediately after GitHub Actions updates were enabled, changing `@v1` to `@v1.4.1` even though the current upstream release is newer.

## Validation

Validated the committed blob at `b06b45084fd788511bb67963b617680b8d01c132`:

```text
committed Dependabot policy ok: minor/patch ignored; major remains eligible
```

- parsed `git show HEAD:.github/dependabot.yml` with Ruby Psych
- asserted the committed ignore rule contains only `version-update:semver-minor` and `version-update:semver-patch`
- asserted `version-update:semver-major` remains eligible
- `git diff --check origin/main...HEAD`

Fixes #56