### PR TITLE
docs: credit Desktop account import fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixed
 
 - Verify unified release archives with normalized `./` tar members.
+- Import current single-account WhatsApp Desktop stores when the dedicated account table is empty, while preserving account-mixing safeguards (#54, thanks @vincentkoc).
+
 ### Changed
 
 - Rewrite the README to the house standard and move detailed commands, backups, data model, and release guidance into `docs/`.


### PR DESCRIPTION
## Summary

- add the missing `0.3.6` changelog entry for the current WhatsApp Desktop account-import fix landed in #54
- credit contributor `@vincentkoc`

## Context

This PR originally implemented the same fresh-store fix independently. During rebase, #54 had already landed with a more complete implementation, including metadata mismatch checks and safe migration of legacy account bindings. The duplicate code was dropped; only the maintainer-owned changelog follow-up remains.

## Proof

- built current `main` and imported the affected fresh Desktop source twice into a new archive with stable counts
- `go test ./...`
- autoreview: clean, no accepted/actionable findings
