### PR TITLE
fix(import): preserve messages on reaction row reuse

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	schemaVersion     = 2
-	maxJSONUnixSecond = 253402300799 // 9999-12-31T23:59:59Z, the largest time.Time JSON can marshal.
+	schemaVersion           = 2
+	whatsappReactionRawType = 14
+	maxJSONUnixSecond       = 253402300799 // 9999-12-31T23:59:59Z, the largest time.Time JSON can marshal.
 
 	messageSelectColumns = `source_pk, event_id, chat_jid, coalesce(chat_name,'') as chat_name, msg_id, coalesce(sender_jid,'') as sender_jid, coalesce(sender_name,'') as sender_name, ts, from_me, coalesce(text,'') as text, raw_type, coalesce(message_type,'') as message_type, coalesce(media_type,'') as media_type, coalesce(media_title,'') as media_title, coalesce(media_path,'') as media_path, coalesce(media_url,'') as media_url, coalesce(media_size,0) as media_size, starred, coalesce(deleted_at,0) as deleted_at, coalesce(deletion_source,'') as deletion_source, coalesce(deletion_reason,'') as deletion_reason, last_seen_at, '' as snippet`
 	messageScanColumns   = `source_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred, deleted_at, deletion_source, deletion_reason, last_seen_at, snippet`
@@ -561,10 +562,11 @@ func validateImportSource(ctx context.Context, tx *sql.Tx, restore bool, stats I
 		if err != nil {
 			return "", err
 		}
-		if found && messageIdentityConflict(existing, message) {
+		reusedByReaction := found && reactionReusesSourceRow(existing, message)
+		if found && messageIdentityConflict(existing, message) && !reusedByReaction {
 			return "", fmt.Errorf("message source_pk %d belongs to a different event; use a separate archive or import --restore", message.SourcePK)
 		}
-		if found {
+		if found && !reusedByReaction {
 			matchingMessages++
 		}
 	}
@@ -811,6 +813,9 @@ func upsertMessage(ctx context.Context, tx *sql.Tx, m Message, observedAt time.T
 		return err
 	}
 	if found {
+		if reactionReusesSourceRow(existing, m) {
+			return nil
+		}
 		if messageIdentityConflict(existing, m) {
 			return fmt.Errorf("message source_pk %d belongs to a different event; use a separate archive or import --restore", m.SourcePK)
 		}
@@ -878,6 +883,17 @@ func messageHasPayload(message Message) bool {
 
 func messageIdentityConflict(existing, incoming Message) bool {
 	return existing.ChatJID != incoming.ChatJID || existing.MessageID != incoming.MessageID || existing.FromMe != incoming.FromMe || messageUnix(existing) != messageUnix(incoming)
+}
+
+func reactionReusesSourceRow(existing, incoming Message) bool {
+	// WhatsApp can reuse a deleted message's Core Data row for a reaction that
+	// points back to that message. Keep the archived event instead of replacing it.
+	return incoming.RawType == whatsappReactionRawType &&
+		incoming.SourceTextNull &&
+		incoming.MediaTitle == existing.MessageID &&
+		existing.ChatJID == incoming.ChatJID &&
+		existing.FromMe == incoming.FromMe &&
+		messageUnix(existing) == messageUnix(incoming)
 }
 
 func tombstoneSubordinates(ctx context.Context, tx *sql.Tx, observedAt time.Time) error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -313,6 +313,73 @@ func TestReplaceAllIsExplicitExactRestore(t *testing.T) {
 	}
 }
 
+func TestMergeAllPreservesMessageWhenWhatsAppReusesSourceRowForReaction(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "reaction-reuse.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	now := time.Date(2026, 8, 3, 15, 52, 24, 0, time.UTC)
+	original := Message{
+		SourcePK: 42, ChatJID: "group@g.us", MessageID: "original-stanza", Timestamp: now,
+		Text: "original body", RawType: 0, MessageType: "text",
+	}
+	stats := ImportStats{SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: now, Messages: 1}
+	if err := st.MergeAll(ctx, stats, nil, []Chat{{JID: original.ChatJID, Kind: "group"}}, nil, nil, []Message{original}); err != nil {
+		t.Fatal(err)
+	}
+
+	reaction := original
+	reaction.MessageID = "reaction-stanza"
+	reaction.Text = ""
+	reaction.RawType = 14
+	reaction.MessageType = "reaction"
+	reaction.MediaTitle = original.MessageID
+	reaction.SourceTextNull = true
+	stats.FinishedAt = now.Add(time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, []Message{reaction}); err != nil {
+		t.Fatalf("reaction source-row reuse: %v", err)
+	}
+
+	stored, err := st.MessageBySourcePK(ctx, original.SourcePK)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.MessageID != original.MessageID || stored.Text != original.Text || stored.MessageType != original.MessageType {
+		t.Fatalf("reaction replaced original message: %+v", stored)
+	}
+}
+
+func TestMergeAllRejectsReactionSourceRowCollisionWithoutOriginalTarget(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "unrelated-reaction.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	now := time.Date(2026, 8, 3, 15, 52, 24, 0, time.UTC)
+	original := Message{SourcePK: 42, ChatJID: "group@g.us", MessageID: "original-stanza", Timestamp: now, Text: "original body", RawType: 0}
+	stats := ImportStats{SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: now, Messages: 1}
+	if err := st.MergeAll(ctx, stats, nil, []Chat{{JID: original.ChatJID, Kind: "group"}}, nil, nil, []Message{original}); err != nil {
+		t.Fatal(err)
+	}
+
+	unrelated := original
+	unrelated.MessageID = "reaction-stanza"
+	unrelated.Text = ""
+	unrelated.RawType = 14
+	unrelated.MessageType = "reaction"
+	unrelated.MediaTitle = "another-stanza"
+	unrelated.SourceTextNull = true
+	stats.FinishedAt = now.Add(time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, []Message{unrelated}); err == nil || !strings.Contains(err.Error(), "different event") {
+		t.Fatalf("unrelated reaction collision error = %v", err)
+	}
+}
+
 func TestMergeAllRejectsDifferentSourceAndIdentityCollision(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(ctx, filepath.Join(t.TempDir(), "identity.db"))
@@ -493,6 +560,37 @@ func TestMergeMigratesLegacyAccountBindingWithEventContinuity(t *testing.T) {
 	var binding string
 	if err := st.DB().QueryRowContext(ctx, `select value from sync_state where key='merge_account_identity'`).Scan(&binding); err != nil || binding != upgrade.AccountIdentity {
 		t.Fatalf("migrated account binding = %q, %v", binding, err)
+	}
+}
+
+func TestMergeRejectsLegacyAccountMigrationWhenOnlyOverlapIsReusedReactionRow(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "reaction-account-continuity.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	now := time.Date(2026, 8, 3, 15, 52, 24, 0, time.UTC)
+	existing := Message{SourcePK: 42, ChatJID: "group@g.us", MessageID: "original-stanza", Timestamp: now, Text: "body", RawType: 0}
+	base := ImportStats{SourceIdentity: "/source", SourceStoreIdentity: "wa-store:fixture", AccountIdentity: "wa-account:legacy", FinishedAt: now, Messages: 1}
+	if err := st.MergeAll(ctx, base, nil, []Chat{{JID: existing.ChatJID, Kind: "group"}}, nil, nil, []Message{existing}); err != nil {
+		t.Fatal(err)
+	}
+
+	reaction := existing
+	reaction.MessageID = "reaction-stanza"
+	reaction.Text = ""
+	reaction.RawType = 14
+	reaction.MessageType = "reaction"
+	reaction.MediaTitle = existing.MessageID
+	reaction.SourceTextNull = true
+	upgrade := base
+	upgrade.AccountIdentity = "wa-account:recipient"
+	upgrade.LegacyAccountIDs = []string{base.AccountIdentity}
+	upgrade.FinishedAt = now.Add(time.Minute)
+	if err := st.ValidateImport(ctx, upgrade, []Message{reaction}, false); err == nil || !strings.Contains(err.Error(), "different WhatsApp account") {
+		t.Fatalf("reused reaction row established account continuity: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- recognize WhatsApp reaction rows that reuse an archived message's Core Data source row
- preserve the original archived event instead of rejecting the merge or overwriting history
- keep unrelated identity collisions and legacy account migration fail-closed
- cover the production-shaped reuse case, an unrelated reaction collision, and account-continuity behavior

## Root cause

WhatsApp can replace a deleted `ZWAMESSAGE` row with a reaction while retaining the same `Z_PK`. The reaction has a new stanza ID, but its media title points to the archived stanza. Wacrawl treated that as cross-event `source_pk` reuse and aborted before cumulative merge logic could preserve the older event.

## Validation

- `make test`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `staticcheck ./...`
- aggregate coverage: 85.3% (floor: 85.0%)
- live WhatsApp source smoke against a copied archive: merge succeeded, original event remained intact, SQLite `quick_check` returned `ok`

`make check` reached the lint stage but the local environment does not have the standalone `golangci-lint` binary.
