### PR TITLE
fix(import): preserve reused-row reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Preserve both the original message and reaction when WhatsApp reuses a Core Data message row, with stable identities across repeat imports (#68).
+
 ### Changed
 
 - Refresh modernc SQLite's transitive libc, memory, and C compiler runtime dependencies.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -18,7 +18,8 @@ Axolotl.sqlite: ZWAZMDACCOUNT (account identity only)
 ## Identity and merge rules
 
 - WhatsApp timestamps are seconds since `2001-01-01T00:00:00Z`.
-- `ZWAMESSAGE.Z_PK` is stable inside one source archive and maps to `messages.event_id` as `wa:<source_pk>`.
+- `ZWAMESSAGE.Z_PK` is retained as `messages.source_row_pk`. Ordinary rows use the same value for the unique archive `source_pk` and map to `messages.event_id` as `wa:<source_pk>`.
+- When WhatsApp reuses an archived message row for a reaction, the original keeps its identity and the reaction receives a deterministic JSON-safe high-range `source_pk` plus a `wa-reaction:<source_row_pk>:<digest>` event ID. The digest covers the chat, reaction stanza, and reaction target, so repeat imports deduplicate without discarding either event; the raw reused row remains available in `source_row_pk` as provenance.
 - Routine merges bind the archive to the canonical source path, a hashed CoreData store fingerprint, and a separately hashed account JID. Event overlap is not an account-identity substitute.
 - Legacy archives without verified account binding require one explicit `--adopt-source`. Use a separate `--db` for another account or `--restore` for intentional source replacement.
 - `ZSTANZAID` is not unique enough to identify archived messages.

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -64,6 +64,7 @@ create table if not exists group_participants (
 create table if not exists messages (
 	rowid integer primary key autoincrement,
 	source_pk integer not null unique,
+	source_row_pk integer not null default 0,
 	event_id text not null,
 	chat_jid text not null,
 	chat_name text,

--- a/internal/store/sqlc/queries.sql
+++ b/internal/store/sqlc/queries.sql
@@ -173,8 +173,8 @@ insert into group_participants(group_jid, user_jid, contact_name, first_name, is
 values(sqlc.arg(group_jid), sqlc.arg(user_jid), sqlc.arg(contact_name), sqlc.arg(first_name), sqlc.arg(is_admin), sqlc.arg(is_active));
 
 -- name: InsertMessage :exec
-insert into messages(source_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
-values(sqlc.arg(source_pk), sqlc.arg(event_id), sqlc.arg(chat_jid), sqlc.arg(chat_name), sqlc.arg(msg_id), sqlc.arg(sender_jid), sqlc.arg(sender_name), sqlc.arg(ts), sqlc.arg(from_me), sqlc.arg(text), sqlc.arg(raw_type), sqlc.arg(message_type), sqlc.arg(media_type), sqlc.arg(media_title), sqlc.arg(media_path), sqlc.arg(media_url), sqlc.arg(media_size), sqlc.arg(starred));
+insert into messages(source_pk, source_row_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
+values(sqlc.arg(source_pk), sqlc.arg(source_row_pk), sqlc.arg(event_id), sqlc.arg(chat_jid), sqlc.arg(chat_name), sqlc.arg(msg_id), sqlc.arg(sender_jid), sqlc.arg(sender_name), sqlc.arg(ts), sqlc.arg(from_me), sqlc.arg(text), sqlc.arg(raw_type), sqlc.arg(message_type), sqlc.arg(media_type), sqlc.arg(media_title), sqlc.arg(media_path), sqlc.arg(media_url), sqlc.arg(media_size), sqlc.arg(starred));
 
 -- name: InsertMessageFTS :exec
 insert into messages_fts(rowid, text, chat, sender, media)

--- a/internal/store/sqlc/schema.sql
+++ b/internal/store/sqlc/schema.sql
@@ -62,6 +62,7 @@ create table group_participants (
 create table messages (
 	rowid integer primary key autoincrement,
 	source_pk integer not null unique,
+	source_row_pk integer not null default 0,
 	event_id text not null,
 	chat_jid text not null,
 	chat_name text,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,11 +21,15 @@ import (
 )
 
 const (
-	schemaVersion     = 2
-	maxJSONUnixSecond = 253402300799 // 9999-12-31T23:59:59Z, the largest time.Time JSON can marshal.
+	schemaVersion           = 3
+	whatsappReactionRawType = 14
+	// Keep synthetic keys in [2^52, 2^53) so they remain distinguishable from
+	// practical Core Data row IDs and exactly representable in web JSON.
+	syntheticMessagePKBoundary = int64(1 << 52)
+	maxJSONUnixSecond          = 253402300799 // 9999-12-31T23:59:59Z, the largest time.Time JSON can marshal.
 
-	messageSelectColumns = `source_pk, event_id, chat_jid, coalesce(chat_name,'') as chat_name, msg_id, coalesce(sender_jid,'') as sender_jid, coalesce(sender_name,'') as sender_name, ts, from_me, coalesce(text,'') as text, raw_type, coalesce(message_type,'') as message_type, coalesce(media_type,'') as media_type, coalesce(media_title,'') as media_title, coalesce(media_path,'') as media_path, coalesce(media_url,'') as media_url, coalesce(media_size,0) as media_size, starred, coalesce(deleted_at,0) as deleted_at, coalesce(deletion_source,'') as deletion_source, coalesce(deletion_reason,'') as deletion_reason, last_seen_at, '' as snippet`
-	messageScanColumns   = `source_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred, deleted_at, deletion_source, deletion_reason, last_seen_at, snippet`
+	messageSelectColumns = `source_pk, source_row_pk, event_id, chat_jid, coalesce(chat_name,'') as chat_name, msg_id, coalesce(sender_jid,'') as sender_jid, coalesce(sender_name,'') as sender_name, ts, from_me, coalesce(text,'') as text, raw_type, coalesce(message_type,'') as message_type, coalesce(media_type,'') as media_type, coalesce(media_title,'') as media_title, coalesce(media_path,'') as media_path, coalesce(media_url,'') as media_url, coalesce(media_size,0) as media_size, starred, coalesce(deleted_at,0) as deleted_at, coalesce(deletion_source,'') as deletion_source, coalesce(deletion_reason,'') as deletion_reason, last_seen_at, '' as snippet`
+	messageScanColumns   = `source_pk, source_row_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred, deleted_at, deletion_source, deletion_reason, last_seen_at, snippet`
 )
 
 type Store struct {
@@ -146,6 +152,7 @@ type GroupParticipant struct {
 type Message struct {
 	Tombstone
 	SourcePK       int64     `json:"source_pk"`
+	SourceRowPK    int64     `json:"source_row_pk"`
 	EventID        string    `json:"event_id"`
 	ChatJID        string    `json:"chat_jid"`
 	ChatName       string    `json:"chat_name,omitempty"`
@@ -280,6 +287,12 @@ func (s *Store) migrate(ctx context.Context) error {
 	if err := ensureColumn(ctx, tx, "messages", "event_id", "text"); err != nil {
 		return err
 	}
+	if err := ensureColumn(ctx, tx, "messages", "source_row_pk", "integer not null default 0"); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `update messages set source_row_pk = source_pk where source_row_pk = 0`); err != nil {
+		return fmt.Errorf("backfill message source-row provenance: %w", err)
+	}
 	if _, err := tx.ExecContext(ctx, `update messages set event_id = printf('wa:%lld', source_pk) where event_id is null or trim(event_id) = ''`); err != nil {
 		return fmt.Errorf("backfill message event identity: %w", err)
 	}
@@ -355,6 +368,10 @@ func (s *Store) ValidateImport(ctx context.Context, stats ImportStats, messages 
 		return err
 	}
 	defer rollback(tx)
+	messages, err = resolveReusedReactionIdentities(ctx, tx, restore, messages)
+	if err != nil {
+		return err
+	}
 	_, err = validateImportSource(ctx, tx, restore, stats, messages)
 	return err
 }
@@ -368,6 +385,10 @@ func (s *Store) importAll(ctx context.Context, restore bool, stats ImportStats, 
 		return err
 	}
 	defer rollback(tx)
+	messages, err = resolveReusedReactionIdentities(ctx, tx, restore, messages)
+	if err != nil {
+		return err
+	}
 	mergeSource, err := validateImportSource(ctx, tx, restore, stats, messages)
 	if err != nil {
 		return err
@@ -799,11 +820,65 @@ func messageEventID(sourcePK int64) string {
 	return fmt.Sprintf("wa:%d", sourcePK)
 }
 
+func resolveReusedReactionIdentities(ctx context.Context, tx *sql.Tx, restore bool, messages []Message) ([]Message, error) {
+	resolved := append([]Message(nil), messages...)
+	for i := range resolved {
+		message := &resolved[i]
+		if message.SourceRowPK == 0 {
+			message.SourceRowPK = message.SourcePK
+		}
+		if restore {
+			continue
+		}
+		existing, found, err := messageBySourcePK(ctx, tx, message.SourcePK)
+		if err != nil {
+			return nil, err
+		}
+		if !found || !reactionReusesSourceRow(existing, *message) {
+			continue
+		}
+		eventID, sourcePK := reusedReactionIdentity(*message)
+		collision, collisionFound, err := messageBySourcePK(ctx, tx, sourcePK)
+		if err != nil {
+			return nil, err
+		}
+		if collisionFound && collision.EventID != eventID {
+			return nil, fmt.Errorf("synthetic reaction source_pk %d belongs to a different event", sourcePK)
+		}
+		message.SourcePK = sourcePK
+		message.EventID = eventID
+	}
+	if err := validateImportMessages(resolved); err != nil {
+		return nil, err
+	}
+	return resolved, nil
+}
+
+func reactionReusesSourceRow(existing, incoming Message) bool {
+	return incoming.RawType == whatsappReactionRawType &&
+		incoming.SourceTextNull &&
+		incoming.MessageID != "" &&
+		incoming.MessageID != existing.MessageID &&
+		incoming.MediaTitle == existing.MessageID &&
+		incoming.ChatJID == existing.ChatJID
+}
+
+func reusedReactionIdentity(message Message) (string, int64) {
+	seed := fmt.Sprintf("%d\x00%s\x00%s\x00%s", message.SourceRowPK, message.ChatJID, message.MessageID, message.MediaTitle)
+	digest := sha256.Sum256([]byte(seed))
+	eventID := fmt.Sprintf("wa-reaction:%d:%x", message.SourceRowPK, digest[:16])
+	sourcePK := syntheticMessagePKBoundary | int64(binary.BigEndian.Uint64(digest[:8])&uint64(syntheticMessagePKBoundary-1))
+	return eventID, sourcePK
+}
+
 func upsertMessage(ctx context.Context, tx *sql.Tx, m Message, observedAt time.Time) error {
 	sourcePayloadCleared := m.SourceTextNull && m.RawType == 0 && m.MediaTitle == "" && m.MediaType == "" && m.MediaPath == "" && m.MediaURL == "" && m.DeletedAt.IsZero()
 	preserveExistingFTS := false
 	if m.EventID == "" {
 		m.EventID = messageEventID(m.SourcePK)
+	}
+	if m.SourceRowPK == 0 {
+		m.SourceRowPK = m.SourcePK
 	}
 	m.Tombstone = normalizedTombstone(m.Tombstone, observedAt)
 	existing, found, err := messageBySourcePK(ctx, tx, m.SourcePK)
@@ -842,11 +917,11 @@ func upsertMessage(ctx context.Context, tx *sql.Tx, m Message, observedAt time.T
 		}
 	}
 	if _, err := tx.ExecContext(ctx, `insert into messages(
-source_pk,event_id,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,
+source_pk,source_row_pk,event_id,chat_jid,chat_name,msg_id,sender_jid,sender_name,ts,from_me,text,
 raw_type,message_type,media_type,media_title,media_path,media_url,media_size,starred,
 deleted_at,deletion_source,deletion_reason,last_seen_at)
-values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-on conflict(source_pk) do update set event_id=excluded.event_id, chat_jid=excluded.chat_jid,
+values(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+on conflict(source_pk) do update set source_row_pk=excluded.source_row_pk, event_id=excluded.event_id, chat_jid=excluded.chat_jid,
 chat_name=excluded.chat_name, msg_id=excluded.msg_id, sender_jid=excluded.sender_jid,
 sender_name=excluded.sender_name, ts=excluded.ts, from_me=excluded.from_me, text=excluded.text,
 raw_type=excluded.raw_type, message_type=excluded.message_type, media_type=excluded.media_type,
@@ -854,7 +929,7 @@ media_title=excluded.media_title, media_path=excluded.media_path, media_url=excl
 media_size=excluded.media_size, starred=excluded.starred, deleted_at=excluded.deleted_at,
 deletion_source=excluded.deletion_source, deletion_reason=excluded.deletion_reason,
 last_seen_at=excluded.last_seen_at`,
-		m.SourcePK, m.EventID, m.ChatJID, m.ChatName, m.MessageID, m.SenderJID, m.SenderName, messageUnix(m), boolInt(m.FromMe), m.Text,
+		m.SourcePK, m.SourceRowPK, m.EventID, m.ChatJID, m.ChatName, m.MessageID, m.SenderJID, m.SenderName, messageUnix(m), boolInt(m.FromMe), m.Text,
 		m.RawType, m.MessageType, m.MediaType, m.MediaTitle, m.MediaPath, m.MediaURL, m.MediaSize, boolInt(m.Starred),
 		nullableUnix(m.DeletedAt), nullableString(m.DeletionSource), nullableString(m.DeletionReason), unix(m.LastSeenAt)); err != nil {
 		return err
@@ -932,6 +1007,7 @@ where deleted_at is null and exists(select 1 from groups where groups.jid=group_
 func canonicalMessageJSON(m Message) (string, error) {
 	payload := struct {
 		SourcePK       int64  `json:"source_pk"`
+		SourceRowPK    int64  `json:"source_row_pk"`
 		EventID        string `json:"event_id"`
 		ChatJID        string `json:"chat_jid"`
 		ChatName       string `json:"chat_name,omitempty"`
@@ -953,7 +1029,7 @@ func canonicalMessageJSON(m Message) (string, error) {
 		DeletionSource string `json:"deletion_source,omitempty"`
 		DeletionReason string `json:"deletion_reason,omitempty"`
 	}{
-		SourcePK: m.SourcePK, EventID: m.EventID, ChatJID: m.ChatJID, ChatName: m.ChatName,
+		SourcePK: m.SourcePK, SourceRowPK: m.SourceRowPK, EventID: m.EventID, ChatJID: m.ChatJID, ChatName: m.ChatName,
 		MessageID: m.MessageID, SenderJID: m.SenderJID, SenderName: m.SenderName,
 		Timestamp: messageUnix(m), FromMe: m.FromMe, Text: m.Text, RawType: m.RawType,
 		MessageType: m.MessageType, MediaType: m.MediaType, MediaTitle: m.MediaTitle,
@@ -1179,7 +1255,7 @@ func (s *Store) Search(ctx context.Context, filter MessageFilter) ([]Message, er
 	if snippetEnd == "" {
 		snippetEnd = "]"
 	}
-	query := `select m.source_pk, m.event_id, m.chat_jid, coalesce(m.chat_name,''), m.msg_id, coalesce(m.sender_jid,''), coalesce(m.sender_name,''), m.ts, m.from_me, coalesce(m.text,''), m.raw_type, coalesce(m.message_type,''), coalesce(m.media_type,''), coalesce(m.media_title,''), coalesce(m.media_path,''), coalesce(m.media_url,''), coalesce(m.media_size,0), m.starred, coalesce(m.deleted_at,0), coalesce(m.deletion_source,''), coalesce(m.deletion_reason,''), m.last_seen_at, snippet(messages_fts, 0, ?, ?, '...', 12) from messages_fts f join messages m on m.rowid=f.rowid where messages_fts match ?`
+	query := `select m.source_pk, m.source_row_pk, m.event_id, m.chat_jid, coalesce(m.chat_name,''), m.msg_id, coalesce(m.sender_jid,''), coalesce(m.sender_name,''), m.ts, m.from_me, coalesce(m.text,''), m.raw_type, coalesce(m.message_type,''), coalesce(m.media_type,''), coalesce(m.media_title,''), coalesce(m.media_path,''), coalesce(m.media_url,''), coalesce(m.media_size,0), m.starred, coalesce(m.deleted_at,0), coalesce(m.deletion_source,''), coalesce(m.deletion_reason,''), m.last_seen_at, snippet(messages_fts, 0, ?, ?, '...', 12) from messages_fts f join messages m on m.rowid=f.rowid where messages_fts match ?`
 	args := []any{snippetStart, snippetEnd, ftsQuery}
 	query, args = applyMessageFilters(query, args, filter, true)
 	query += " order by bm25(messages_fts) limit ?"
@@ -1251,7 +1327,7 @@ func scanMessage(row messageScanner) (Message, error) {
 	var m Message
 	var ts, deletedAt, lastSeenAt int64
 	var fromMe, starred int
-	if err := row.Scan(&m.SourcePK, &m.EventID, &m.ChatJID, &m.ChatName, &m.MessageID, &m.SenderJID, &m.SenderName,
+	if err := row.Scan(&m.SourcePK, &m.SourceRowPK, &m.EventID, &m.ChatJID, &m.ChatName, &m.MessageID, &m.SenderJID, &m.SenderName,
 		&ts, &fromMe, &m.Text, &m.RawType, &m.MessageType, &m.MediaType, &m.MediaTitle, &m.MediaPath, &m.MediaURL,
 		&m.MediaSize, &starred, &deletedAt, &m.DeletionSource, &m.DeletionReason, &lastSeenAt, &m.Snippet); err != nil {
 		return Message{}, err

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -313,6 +313,172 @@ func TestReplaceAllIsExplicitExactRestore(t *testing.T) {
 	}
 }
 
+func TestMergeAllPreservesOriginalAndReusedRowReaction(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Message)
+	}{
+		{
+			name: "matching fields from issue fixture",
+			mutate: func(*Message) {
+			},
+		},
+		{
+			name: "realistic later opposite direction",
+			mutate: func(message *Message) {
+				message.Timestamp = message.Timestamp.Add(5 * time.Minute)
+				message.FromMe = true
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			st, err := Open(ctx, filepath.Join(t.TempDir(), "reaction-reuse.db"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = st.Close() }()
+
+			now := time.Date(2026, 8, 3, 15, 52, 24, 0, time.UTC)
+			original := Message{
+				SourcePK: 42, ChatJID: "group@g.us", MessageID: "original-stanza", Timestamp: now,
+				Text: "original body", RawType: 0, MessageType: "text",
+			}
+			stats := ImportStats{SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: now, Messages: 1}
+			if err := st.MergeAll(ctx, stats, nil, []Chat{{JID: original.ChatJID, Kind: "group"}}, nil, nil, []Message{original}); err != nil {
+				t.Fatal(err)
+			}
+
+			reaction := original
+			reaction.MessageID = "reaction-stanza"
+			reaction.Text = ""
+			reaction.RawType = whatsappReactionRawType
+			reaction.MessageType = "reaction"
+			reaction.MediaTitle = original.MessageID
+			reaction.SourceTextNull = true
+			tt.mutate(&reaction)
+			stats.FinishedAt = now.Add(time.Minute)
+
+			var firstReactionPK int64
+			var firstEventID string
+			for attempt := 1; attempt <= 2; attempt++ {
+				stats.FinishedAt = stats.FinishedAt.Add(time.Minute)
+				if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, []Message{reaction}); err != nil {
+					t.Fatalf("reaction source-row reuse attempt %d: %v", attempt, err)
+				}
+
+				messages, err := st.Messages(ctx, MessageFilter{Limit: 10, Asc: true})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(messages) != 2 {
+					t.Fatalf("attempt %d stored %d messages, want original and reaction: %+v", attempt, len(messages), messages)
+				}
+				var storedOriginal, storedReaction *Message
+				for i := range messages {
+					switch messages[i].RawType {
+					case 0:
+						storedOriginal = &messages[i]
+					case whatsappReactionRawType:
+						storedReaction = &messages[i]
+					}
+				}
+				if storedOriginal == nil || storedReaction == nil {
+					t.Fatalf("attempt %d lost an event: %+v", attempt, messages)
+				}
+				if storedOriginal.SourcePK != original.SourcePK || storedOriginal.SourceRowPK != original.SourcePK || storedOriginal.EventID != "wa:42" || storedOriginal.MessageID != original.MessageID || storedOriginal.Text != original.Text {
+					t.Fatalf("attempt %d changed original: %+v", attempt, *storedOriginal)
+				}
+				if storedReaction.SourcePK < syntheticMessagePKBoundary || storedReaction.SourcePK >= 2*syntheticMessagePKBoundary || storedReaction.SourceRowPK != original.SourcePK || storedReaction.EventID == storedOriginal.EventID || storedReaction.MessageID != reaction.MessageID || storedReaction.MediaTitle != original.MessageID || !storedReaction.Timestamp.Equal(reaction.Timestamp) || storedReaction.FromMe != reaction.FromMe {
+					t.Fatalf("attempt %d reaction identity/provenance = %+v", attempt, *storedReaction)
+				}
+				if attempt == 1 {
+					firstReactionPK = storedReaction.SourcePK
+					firstEventID = storedReaction.EventID
+				} else if storedReaction.SourcePK != firstReactionPK || storedReaction.EventID != firstEventID {
+					t.Fatalf("re-import changed reaction identity: first=(%d,%q) second=(%d,%q)", firstReactionPK, firstEventID, storedReaction.SourcePK, storedReaction.EventID)
+				}
+			}
+
+			var revisions int
+			if err := st.DB().QueryRowContext(ctx, `select count(*) from message_revisions`).Scan(&revisions); err != nil {
+				t.Fatal(err)
+			}
+			if revisions != 0 {
+				t.Fatalf("idempotent reaction re-import created %d revisions", revisions)
+			}
+		})
+	}
+}
+
+func TestMergeAllRejectsUnrelatedReactionSourceRowCollision(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "unrelated-reaction.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	now := time.Date(2026, 8, 3, 15, 52, 24, 0, time.UTC)
+	original := Message{SourcePK: 42, ChatJID: "group@g.us", MessageID: "original-stanza", Timestamp: now, Text: "original body", RawType: 0}
+	stats := ImportStats{SourceIdentity: "fixture-store", AccountIdentity: "fixture-account", FinishedAt: now, Messages: 1}
+	if err := st.MergeAll(ctx, stats, nil, []Chat{{JID: original.ChatJID, Kind: "group"}}, nil, nil, []Message{original}); err != nil {
+		t.Fatal(err)
+	}
+
+	unrelated := original
+	unrelated.MessageID = "reaction-stanza"
+	unrelated.Text = ""
+	unrelated.RawType = whatsappReactionRawType
+	unrelated.MessageType = "reaction"
+	unrelated.MediaTitle = "another-stanza"
+	unrelated.SourceTextNull = true
+	stats.FinishedAt = now.Add(time.Minute)
+	if err := st.MergeAll(ctx, stats, nil, nil, nil, nil, []Message{unrelated}); err == nil || !strings.Contains(err.Error(), "different event") {
+		t.Fatalf("unrelated reaction collision error = %v", err)
+	}
+	var messages int
+	if err := st.DB().QueryRowContext(ctx, `select count(*) from messages`).Scan(&messages); err != nil {
+		t.Fatal(err)
+	}
+	if messages != 1 {
+		t.Fatalf("failed collision changed archive row count to %d", messages)
+	}
+}
+
+func TestReusedReactionDoesNotEstablishLegacyAccountContinuity(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open(ctx, filepath.Join(t.TempDir(), "reaction-account-continuity.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = st.Close() }()
+
+	now := time.Date(2026, 8, 3, 15, 52, 24, 0, time.UTC)
+	original := Message{SourcePK: 42, ChatJID: "group@g.us", MessageID: "original-stanza", Timestamp: now, Text: "body", RawType: 0}
+	base := ImportStats{SourceIdentity: "/source", SourceStoreIdentity: "wa-store:fixture", AccountIdentity: "wa-account:legacy", FinishedAt: now, Messages: 1}
+	if err := st.MergeAll(ctx, base, nil, []Chat{{JID: original.ChatJID, Kind: "group"}}, nil, nil, []Message{original}); err != nil {
+		t.Fatal(err)
+	}
+
+	reaction := original
+	reaction.MessageID = "reaction-stanza"
+	reaction.Text = ""
+	reaction.RawType = whatsappReactionRawType
+	reaction.MessageType = "reaction"
+	reaction.MediaTitle = original.MessageID
+	reaction.SourceTextNull = true
+	upgrade := base
+	upgrade.AccountIdentity = "wa-account:recipient"
+	upgrade.LegacyAccountIDs = []string{base.AccountIdentity}
+	upgrade.FinishedAt = now.Add(time.Minute)
+	if err := st.ValidateImport(ctx, upgrade, []Message{reaction}, false); err == nil || !strings.Contains(err.Error(), "different WhatsApp account") {
+		t.Fatalf("reused reaction row established account continuity: %v", err)
+	}
+}
+
 func TestMergeAllRejectsDifferentSourceAndIdentityCollision(t *testing.T) {
 	ctx := context.Background()
 	st, err := Open(ctx, filepath.Join(t.TempDir(), "identity.db"))
@@ -642,11 +808,12 @@ pragma user_version=1;`
 	if err := st.DB().QueryRowContext(ctx, `pragma user_version`).Scan(&version); err != nil {
 		t.Fatal(err)
 	}
-	if err := st.DB().QueryRowContext(ctx, `select rowid,event_id,(deleted_at is not null)+(deletion_source is not null)+(deletion_reason is not null) from messages where source_pk=7`).Scan(&migratedRowID, &eventID, &tombstones); err != nil {
+	var sourceRowPK int64
+	if err := st.DB().QueryRowContext(ctx, `select rowid,source_row_pk,event_id,(deleted_at is not null)+(deletion_source is not null)+(deletion_reason is not null) from messages where source_pk=7`).Scan(&migratedRowID, &sourceRowPK, &eventID, &tombstones); err != nil {
 		t.Fatal(err)
 	}
-	if version != schemaVersion || migratedRowID != rowID || eventID != "wa:7" || tombstones != 0 {
-		t.Fatalf("migration version=%d rowid=%d/%d event=%q tombstones=%d", version, migratedRowID, rowID, eventID, tombstones)
+	if version != schemaVersion || migratedRowID != rowID || sourceRowPK != 7 || eventID != "wa:7" || tombstones != 0 {
+		t.Fatalf("migration version=%d rowid=%d/%d source_row_pk=%d event=%q tombstones=%d", version, migratedRowID, rowID, sourceRowPK, eventID, tombstones)
 	}
 	status, err := st.Status(ctx)
 	if err != nil {

--- a/internal/store/storedb/models.go
+++ b/internal/store/storedb/models.go
@@ -68,6 +68,7 @@ type GroupParticipant struct {
 type Message struct {
 	Rowid          int64
 	SourcePk       int64
+	SourceRowPk    int64
 	EventID        string
 	ChatJid        string
 	ChatName       sql.NullString

--- a/internal/store/storedb/queries.sql.go
+++ b/internal/store/storedb/queries.sql.go
@@ -548,12 +548,13 @@ func (q *Queries) InsertGroup(ctx context.Context, arg InsertGroupParams) error 
 }
 
 const insertMessage = `-- name: InsertMessage :exec
-insert into messages(source_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
-values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+insert into messages(source_pk, source_row_pk, event_id, chat_jid, chat_name, msg_id, sender_jid, sender_name, ts, from_me, text, raw_type, message_type, media_type, media_title, media_path, media_url, media_size, starred)
+values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
 `
 
 type InsertMessageParams struct {
 	SourcePk    int64
+	SourceRowPk int64
 	EventID     string
 	ChatJid     string
 	ChatName    sql.NullString
@@ -576,6 +577,7 @@ type InsertMessageParams struct {
 func (q *Queries) InsertMessage(ctx context.Context, arg InsertMessageParams) error {
 	_, err := q.db.ExecContext(ctx, insertMessage,
 		arg.SourcePk,
+		arg.SourceRowPk,
 		arg.EventID,
 		arg.ChatJid,
 		arg.ChatName,

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -847,6 +847,7 @@ order by m.ZMESSAGEDATE asc, m.Z_PK asc`)
 		if err := rows.Scan(&m.SourcePK, &m.ChatJID, &m.ChatName, &m.MessageID, &fromMe, &msgDate, &text, &m.RawType, &starred, &fromJID, &toJID, &pushName, &memberJID, &memberName, &memberFirst, &mediaPath, &mediaURL, &mediaTitle, &vcardName, &m.MediaSize); err != nil {
 			return nil, 0, err
 		}
+		m.SourceRowPK = m.SourcePK
 		if m.ChatJID == "" || m.MessageID == "" {
 			continue
 		}

--- a/internal/whatsappdb/desktop_test.go
+++ b/internal/whatsappdb/desktop_test.go
@@ -73,6 +73,80 @@ func TestImportDesktopCoreDataShape(t *testing.T) {
 	}
 }
 
+func TestImportDesktopPreservesReusedRowReactionAcrossReimport(t *testing.T) {
+	ctx := context.Background()
+	source := t.TempDir()
+	createFixtureDBs(t, source)
+	archive, err := store.Open(ctx, filepath.Join(t.TempDir(), "wacrawl.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = archive.Close() }()
+	if _, err := Import(ctx, archive, source); err != nil {
+		t.Fatal(err)
+	}
+
+	chatDB, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustExec(t, chatDB, `
+insert into ZWAMEDIAITEM values (2, 1, '', '', 'dm-in', '', 0);
+update ZWAMESSAGE set ZMEDIAITEM=2, ZSTANZAID='reaction-stanza', ZISFROMME=1, ZMESSAGEDATE=700000300, ZTEXT=null, ZMESSAGETYPE=14, ZFROMJID='', ZTOJID='111@s.whatsapp.net', ZPUSHNAME='' where Z_PK=1;`)
+	if err := chatDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var reactionPK int64
+	var reactionEventID string
+	for attempt := 1; attempt <= 2; attempt++ {
+		if _, err := Import(ctx, archive, source); err != nil {
+			t.Fatalf("reaction import attempt %d: %v", attempt, err)
+		}
+		messages, err := archive.Messages(ctx, store.MessageFilter{ChatJID: "111@s.whatsapp.net", Limit: 10, Asc: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(messages) != 4 {
+			t.Fatalf("attempt %d direct messages = %d, want three originals plus reaction: %+v", attempt, len(messages), messages)
+		}
+		var original, reaction *store.Message
+		for i := range messages {
+			switch messages[i].MessageID {
+			case "dm-in":
+				if messages[i].SourcePK == 1 {
+					original = &messages[i]
+				}
+			case "reaction-stanza":
+				reaction = &messages[i]
+			}
+		}
+		if original == nil || reaction == nil {
+			t.Fatalf("attempt %d missing original or reaction: %+v", attempt, messages)
+		}
+		if original.Text != "hello" || original.EventID != "wa:1" || original.SourceRowPK != 1 {
+			t.Fatalf("attempt %d original changed: %+v", attempt, *original)
+		}
+		if reaction.RawType != 14 || reaction.SourceRowPK != 1 || reaction.MediaTitle != "dm-in" || !reaction.FromMe || !reaction.Timestamp.Equal(time.Unix(appleEpoch+700000300, 0).UTC()) {
+			t.Fatalf("attempt %d reaction fields/provenance = %+v", attempt, *reaction)
+		}
+		if attempt == 1 {
+			reactionPK = reaction.SourcePK
+			reactionEventID = reaction.EventID
+		} else if reaction.SourcePK != reactionPK || reaction.EventID != reactionEventID {
+			t.Fatalf("reaction identity changed across import: first=(%d,%q) second=(%d,%q)", reactionPK, reactionEventID, reaction.SourcePK, reaction.EventID)
+		}
+	}
+
+	status, err := archive.Status(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Messages != 5 || status.MessageRevisions != 0 {
+		t.Fatalf("reused reaction status = %+v", status)
+	}
+}
+
 func TestImportDesktopTurnsNullTextTransitionIntoTombstone(t *testing.T) {
 	ctx := context.Background()
 	source := t.TempDir()


### PR DESCRIPTION
## Summary

- preserve the archived original when WhatsApp reuses its Core Data message row for a reaction
- give the reaction a deterministic, JSON-safe archive key and stable event ID while retaining the raw reused row as provenance
- deduplicate repeated imports without treating unrelated reaction collisions as valid overlap
- migrate existing archives in place and document the new identity model

The row-reuse case was originally surfaced by @pasogott in #67.

## Identity model

Ordinary messages keep their existing `wa:<source_pk>` event identity. The new `source_row_pk` column records the raw `ZWAMESSAGE.Z_PK` for every message. A reaction proven to reuse an archived target row receives a deterministic high-range `source_pk` and a `wa-reaction:<source_row_pk>:<digest>` event ID derived from the row, chat, reaction stanza, and target stanza.

The original and reaction therefore remain separate canonical records, while repeated imports resolve to the same reaction record. A synthetic-key collision or unrelated source-row collision still aborts the transaction.

## Proof

- `make check`
  - lint and security analysis: 0 issues
  - unit, integration, and race suites: pass
  - aggregate coverage: 85.2% (85.0% floor)
  - reachable vulnerabilities: 0
  - six-target release snapshot and macOS release-script tests: pass
  - Git history and worktree secret scans: no leaks
- built CLI against a two-snapshot Desktop SQLite fixture, then imported the reaction twice:

```text
total  originals  reactions  identities  archive_keys  source_rows  revisions
2      1          1          2           2             1            0
quick_check: ok
```

- an unrelated reaction target still exits nonzero with the identity-conflict error; the archive remains one original, zero reactions, and passes `quick_check`
- structured source review: clean, no actionable findings
- source-blind CLI behavior validation: all contract clauses passed

Closes #68
