### PR TITLE
build: move Go floor to 1.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Refresh modernc SQLite's transitive libc, memory, and C compiler runtime dependencies.
+- Update the minimum Go toolchain to 1.26.6 to resolve GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
 
 ## [0.3.7] - 2026-08-08
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ brew install openclaw/tap/wacrawl
 
 Upgrade later with `brew upgrade openclaw/tap/wacrawl`.
 
-Or install from source with Go 1.26.5 or newer:
+Or install from source with Go 1.26.6 or newer:
 
 ```bash
 go install github.com/openclaw/wacrawl/cmd/wacrawl@latest
@@ -130,7 +130,7 @@ Run `wacrawl help <command>` or open the [full command reference](docs/commands.
 
 ## Development
 
-Requires Go 1.26.5 or newer.
+Requires Go 1.26.6 or newer.
 
 ```bash
 make build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/wacrawl
 
-go 1.26.5
+go 1.26.6
 
 require (
 	filippo.io/age v1.3.1


### PR DESCRIPTION
Raises the minimum Go toolchain and active build documentation to 1.26.6. The existing workflows inherit the version from go.mod. This clears GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218. Verified with the exact Go 1.26.6 build and test suite, govulncheck, and a live CLI metadata smoke.