### PR TITLE
chore(release): prepare v0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.3.8 - 2026-08-14
 
 ### Fixed
 
@@ -10,7 +10,6 @@
 
 - Refresh modernc SQLite's transitive libc, memory, and C compiler runtime dependencies.
 - Update the minimum Go toolchain to 1.26.6 to resolve GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
-
 ## [0.3.7] - 2026-08-08
 
 ### Changed


### PR DESCRIPTION
Stamps the changelog for v0.3.8.