### PR TITLE
fix(sync): skip iCloud dataless media during --copy-media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Fixed
-
-- Skip iCloud dataless WhatsApp media during `--copy-media` so sync returns instead of hanging on SF_DATALESS stubs.
-
 ## v0.3.8 - 2026-08-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Skip iCloud dataless WhatsApp media during `--copy-media` so sync returns instead of hanging on SF_DATALESS stubs.
+
 ## v0.3.8 - 2026-08-14
 
 ### Fixed

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -540,6 +540,7 @@ func archiveMediaPath(sourceRoot, mediaRoot, src string) (string, error) {
 // mediaMaterialized reports whether a media file's bytes are already on disk.
 // Tests replace this to simulate macOS SF_DATALESS (iCloud) stubs.
 var mediaMaterialized = fileMaterialized
+var openMediaFileForCopy = openMediaFile
 
 var errMediaNotDownloaded = errors.New("media not downloaded locally")
 
@@ -557,9 +558,9 @@ func copyMediaFile(src, dest string) error {
 	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
 		return err
 	}
-	in, err := os.Open(src) // #nosec G304 -- media path comes from the local WhatsApp DB and is copied only on explicit request.
+	in, err := openMediaFileForCopy(src)
 	if err != nil {
-		return err
+		return normalizeMediaReadError(src, err)
 	}
 	defer func() { _ = in.Close() }()
 	out, err := os.OpenFile(dest, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600) // #nosec G304 -- destination is confined under the archive media root.
@@ -568,9 +569,17 @@ func copyMediaFile(src, dest string) error {
 	}
 	if _, err := io.Copy(out, in); err != nil {
 		_ = out.Close()
-		return err
+		_ = os.Remove(dest)
+		return normalizeMediaReadError(src, err)
 	}
 	return out.Close()
+}
+
+func normalizeMediaReadError(src string, err error) error {
+	if mediaReadWouldBlock(err) {
+		return fmt.Errorf("%w: %s", errMediaNotDownloaded, src)
+	}
+	return err
 }
 
 func readContacts(ctx context.Context, path string) ([]store.Contact, map[string]string, error) {

--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -505,7 +505,7 @@ func copyArchiveMedia(messages []store.Message, sourceRoot, mediaRoot string) (i
 			return copied, missing, err
 		}
 		if err := copyMediaFile(src, dest); err != nil {
-			if os.IsNotExist(err) {
+			if os.IsNotExist(err) || errors.Is(err, errMediaNotDownloaded) {
 				missing++
 				seen[src] = result{missing: true}
 				continue
@@ -537,6 +537,12 @@ func archiveMediaPath(sourceRoot, mediaRoot, src string) (string, error) {
 	return cleanDest, nil
 }
 
+// mediaMaterialized reports whether a media file's bytes are already on disk.
+// Tests replace this to simulate macOS SF_DATALESS (iCloud) stubs.
+var mediaMaterialized = fileMaterialized
+
+var errMediaNotDownloaded = errors.New("media not downloaded locally")
+
 func copyMediaFile(src, dest string) error {
 	info, err := os.Stat(src)
 	if err != nil {
@@ -544,6 +550,9 @@ func copyMediaFile(src, dest string) error {
 	}
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("media source is not a regular file: %s", src)
+	}
+	if !mediaMaterialized(info) {
+		return fmt.Errorf("%w: %s", errMediaNotDownloaded, src)
 	}
 	if err := os.MkdirAll(filepath.Dir(dest), 0o700); err != nil {
 		return err

--- a/internal/whatsappdb/desktop_test.go
+++ b/internal/whatsappdb/desktop_test.go
@@ -3,6 +3,7 @@ package whatsappdb
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -969,6 +970,86 @@ func TestCopyArchiveMediaDeduplicatesAndConfinesPaths(t *testing.T) {
 	}
 	if _, err := archiveMediaPath(source, mediaRoot, source); err == nil {
 		t.Fatal("expected source root path to be rejected")
+	}
+}
+
+func TestFileMaterializedRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "photo.jpg")
+	if err := os.WriteFile(path, []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !fileMaterialized(info) {
+		t.Fatal("regular local file should be materialized")
+	}
+}
+
+func TestCopyMediaFileRejectsUnmaterialized(t *testing.T) {
+	old := mediaMaterialized
+	t.Cleanup(func() { mediaMaterialized = old })
+	mediaMaterialized = func(os.FileInfo) bool { return false }
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "photo.jpg")
+	dest := filepath.Join(dir, "out", "photo.jpg")
+	if err := os.WriteFile(src, []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := copyMediaFile(src, dest)
+	if !errors.Is(err, errMediaNotDownloaded) {
+		t.Fatalf("unmaterialized copyMediaFile error = %v", err)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("unmaterialized source must not be copied: dest stat=%v", statErr)
+	}
+}
+
+func TestCopyMediaFileCopiesWhenMaterialized(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "photo.jpg")
+	dest := filepath.Join(dir, "out", "photo.jpg")
+	if err := os.WriteFile(src, []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyMediaFile(src, dest); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(dest) // #nosec G304 -- dest is a path we just created under t.TempDir.
+	if err != nil || string(data) != "image" {
+		t.Fatalf("copied media = %q err=%v", data, err)
+	}
+}
+
+func TestCopyArchiveMediaSkipsUnmaterialized(t *testing.T) {
+	old := mediaMaterialized
+	t.Cleanup(func() { mediaMaterialized = old })
+	mediaMaterialized = func(os.FileInfo) bool { return false }
+
+	source := t.TempDir()
+	mediaRoot := filepath.Join(t.TempDir(), "media")
+	mediaPath := filepath.Join(source, "Message", "Media", "chat", "photo.jpg")
+	if err := os.MkdirAll(filepath.Dir(mediaPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mediaPath, []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	messages := []store.Message{{MediaPath: mediaPath}}
+	copied, missing, err := copyArchiveMedia(messages, source, mediaRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if copied != 0 || missing != 1 {
+		t.Fatalf("copy stats = %d/%d, want 0/1", copied, missing)
+	}
+	if messages[0].MediaPath != mediaPath {
+		t.Fatalf("unmaterialized path should stay original: %q", messages[0].MediaPath)
+	}
+	if _, statErr := os.Stat(filepath.Join(mediaRoot, "Message", "Media", "chat", "photo.jpg")); !os.IsNotExist(statErr) {
+		t.Fatal("unmaterialized source must not be copied into the archive")
 	}
 }
 

--- a/internal/whatsappdb/media_materialized_darwin.go
+++ b/internal/whatsappdb/media_materialized_darwin.go
@@ -1,0 +1,21 @@
+//go:build darwin
+
+package whatsappdb
+
+import (
+	"os"
+	"syscall"
+)
+
+// sfDataless mirrors SF_DATALESS from <sys/stat.h>: the file's bytes live with
+// a dataless-file provider (for WhatsApp media, content that has not been
+// downloaded yet) and reading it would block until macOS materializes it.
+const sfDataless = 0x40000000
+
+func fileMaterialized(info os.FileInfo) bool {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return true
+	}
+	return stat.Flags&sfDataless == 0
+}

--- a/internal/whatsappdb/media_materialized_darwin.go
+++ b/internal/whatsappdb/media_materialized_darwin.go
@@ -3,6 +3,7 @@
 package whatsappdb
 
 import (
+	"errors"
 	"os"
 	"syscall"
 )
@@ -18,4 +19,12 @@ func fileMaterialized(info os.FileInfo) bool {
 		return true
 	}
 	return stat.Flags&sfDataless == 0
+}
+
+func openMediaFile(path string) (*os.File, error) {
+	return os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0) // #nosec G304 -- explicit copy-media reads a path from the local WhatsApp database.
+}
+
+func mediaReadWouldBlock(err error) bool {
+	return errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.EWOULDBLOCK)
 }

--- a/internal/whatsappdb/media_materialized_darwin_test.go
+++ b/internal/whatsappdb/media_materialized_darwin_test.go
@@ -3,6 +3,7 @@
 package whatsappdb
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -33,5 +34,24 @@ func TestFileMaterializedDatalessFlag(t *testing.T) {
 	}
 	if !fileMaterialized(fakeFileInfo{FileInfo: info, sys: "not-a-stat"}) {
 		t.Fatal("unknown Sys should be treated as materialized")
+	}
+}
+
+func TestCopyMediaFileTreatsNonblockingOpenAsMissing(t *testing.T) {
+	old := openMediaFileForCopy
+	t.Cleanup(func() { openMediaFileForCopy = old })
+	openMediaFileForCopy = func(string) (*os.File, error) { return nil, syscall.EAGAIN }
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "photo.jpg")
+	dest := filepath.Join(dir, "out", "photo.jpg")
+	if err := os.WriteFile(src, []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyMediaFile(src, dest); !errors.Is(err, errMediaNotDownloaded) {
+		t.Fatalf("nonblocking open error = %v, want media not downloaded", err)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("destination should not exist: %v", err)
 	}
 }

--- a/internal/whatsappdb/media_materialized_darwin_test.go
+++ b/internal/whatsappdb/media_materialized_darwin_test.go
@@ -1,0 +1,37 @@
+//go:build darwin
+
+package whatsappdb
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+type fakeFileInfo struct {
+	os.FileInfo
+	sys any
+}
+
+func (f fakeFileInfo) Sys() any { return f.sys }
+
+func TestFileMaterializedDatalessFlag(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "photo.jpg")
+	if err := os.WriteFile(path, []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fileMaterialized(fakeFileInfo{FileInfo: info, sys: &syscall.Stat_t{Flags: sfDataless}}) {
+		t.Fatal("SF_DATALESS file should not be materialized")
+	}
+	if !fileMaterialized(fakeFileInfo{FileInfo: info, sys: &syscall.Stat_t{Flags: 0}}) {
+		t.Fatal("zero flags should be materialized")
+	}
+	if !fileMaterialized(fakeFileInfo{FileInfo: info, sys: "not-a-stat"}) {
+		t.Fatal("unknown Sys should be treated as materialized")
+	}
+}

--- a/internal/whatsappdb/media_materialized_other.go
+++ b/internal/whatsappdb/media_materialized_other.go
@@ -5,3 +5,9 @@ package whatsappdb
 import "os"
 
 func fileMaterialized(os.FileInfo) bool { return true }
+
+func openMediaFile(path string) (*os.File, error) {
+	return os.Open(path) // #nosec G304 -- explicit copy-media reads a path from the local WhatsApp database.
+}
+
+func mediaReadWouldBlock(error) bool { return false }

--- a/internal/whatsappdb/media_materialized_other.go
+++ b/internal/whatsappdb/media_materialized_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package whatsappdb
+
+import "os"
+
+func fileMaterialized(os.FileInfo) bool { return true }

--- a/internal/whatsappdb/media_materialized_other_test.go
+++ b/internal/whatsappdb/media_materialized_other_test.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+package whatsappdb
+
+import "testing"
+
+func TestFileMaterializedOther(t *testing.T) {
+	if !fileMaterialized(nil) {
+		t.Fatal("non-darwin fileMaterialized should treat every file as materialized")
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

`wacrawl sync --copy-media` hangs on macOS when WhatsApp media is still an iCloud / file-provider stub. Those files exist in the Desktop container and `os.Stat` succeeds, but they carry `SF_DATALESS` (`0x40000000`). `copyMediaFile` then calls `os.Open` and `io.Copy`, which block until macOS materializes the bytes. If the file is never downloaded, the import never returns.

The web viewer already refuses this class of file. After [#36](https://github.com/openclaw/wacrawl/pull/36) it checks `fileMaterialized` and returns `media not downloaded locally` instead of reading the stub:

```go
if !fileMaterialized(info) {
    http.Error(w, "media not downloaded locally", http.StatusNotFound)
    return
}
```

`--copy-media` is the remaining public path that still opens those stubs.

## Evidence

The hang sits in `copyMediaFile` (`internal/whatsappdb/desktop.go`), added in [`ce7f92b`](https://github.com/openclaw/wacrawl/commit/ce7f92b) (2026-05-07, `feat: copy media into wacrawl archives`). After `os.Stat` and the regular-file check it always opens and copies. There is no `SF_DATALESS` guard on that path.

This change adds the same flag check next to `desktop.go` (`media_materialized_darwin.go` / `media_materialized_other.go`) so `whatsappdb` does not import `webui`. On a dataless stub, `copyMediaFile` returns `media not downloaded locally` before `os.Open`. `copyArchiveMedia` counts that as missing media, matching the existing "file not on disk" policy, so the rest of the import continues.

terminal output from the patched copy path on this machine (macOS, Go 1.26.6):

```console
$ go test ./internal/whatsappdb/ -run 'TestFileMaterializedDatalessFlag|TestCopyMediaFileRejectsUnmaterialized|TestCopyArchiveMediaSkipsUnmaterialized' -v
=== RUN   TestCopyMediaFileRejectsUnmaterialized
--- PASS: TestCopyMediaFileRejectsUnmaterialized (0.00s)
=== RUN   TestCopyArchiveMediaSkipsUnmaterialized
--- PASS: TestCopyArchiveMediaSkipsUnmaterialized (0.00s)
=== RUN   TestFileMaterializedDatalessFlag
--- PASS: TestFileMaterializedDatalessFlag (0.00s)
PASS
ok  	github.com/openclaw/wacrawl/internal/whatsappdb	0.174s
```

A regular local file still copies. A FileInfo whose `Sys()` is `*syscall.Stat_t` with `Flags=0x40000000` is not treated as materialized. When the helper reports not materialized, `copyMediaFile` returns the sentinel error and writes no destination file; `copyArchiveMedia` reports `copied=0 missing=1` and leaves the original path on the message.

## Real behavior proof

- **Behavior or issue addressed:** `wacrawl sync --copy-media` no longer opens macOS WhatsApp media stubs with `SF_DATALESS`. It returns `media not downloaded locally` and counts the file as missing so the rest of the import can finish.
- **Real environment tested:** macOS, Go 1.26.6, full clone of `openclaw/wacrawl` at `/tmp/oc-impl-wacrawl-dataless` on branch `fix/copy-media-dataless-skip` from `upstream/main` (`d6eca0a`).
- **Exact steps or command run after this patch:**

  ```bash
  go test ./internal/whatsappdb/ -run 'TestFileMaterializedDatalessFlag|TestCopyMediaFileRejectsUnmaterialized|TestCopyArchiveMediaSkipsUnmaterialized' -v
  go test ./internal/whatsappdb/ ./internal/webui/
  go build ./...
  ```

- **Evidence after fix:** terminal output from the patched copy path is in the Evidence section above. The helper treats `SF_DATALESS` as not materialized. `copyMediaFile` errors before `os.Open`. `copyArchiveMedia` skips the file (`copied=0 missing=1`) and does not write under the archive media root.
- **Observed result after fix:** `copyMediaFile` returns `media not downloaded locally` for an unmaterialized source and leaves the destination absent. A regular file still copies. The web UI sibling already used this same flag check after [#36](https://github.com/openclaw/wacrawl/pull/36).
- **What was not tested:** a live WhatsApp Desktop container with a real iCloud-offloaded media file. This machine cannot mint an `SF_DATALESS` stub from user space, so the flag check uses a FileInfo whose `Sys()` is a `Stat_t` with `Flags=0x40000000`, and the copy path uses an injected helper.

## Summary

`copyMediaFile` now applies the same `SF_DATALESS` check the web viewer already uses, then skips those files as missing media during `--copy-media`.
