### PR TITLE
fix(ci): restore gofumpt and coverage gates

### DIFF
--- a/internal/whatsappdb/desktop.go
+++ b/internal/whatsappdb/desktop.go
@@ -539,8 +539,10 @@ func archiveMediaPath(sourceRoot, mediaRoot, src string) (string, error) {
 
 // mediaMaterialized reports whether a media file's bytes are already on disk.
 // Tests replace this to simulate macOS SF_DATALESS (iCloud) stubs.
-var mediaMaterialized = fileMaterialized
-var openMediaFileForCopy = openMediaFile
+var (
+	mediaMaterialized    = fileMaterialized
+	openMediaFileForCopy = openMediaFile
+)
 
 var errMediaNotDownloaded = errors.New("media not downloaded locally")
 

--- a/internal/whatsappdb/desktop_test.go
+++ b/internal/whatsappdb/desktop_test.go
@@ -1023,6 +1023,50 @@ func TestCopyMediaFileCopiesWhenMaterialized(t *testing.T) {
 	}
 }
 
+func TestCopyMediaFileOpenErrorDoesNotCreateDestination(t *testing.T) {
+	old := openMediaFileForCopy
+	t.Cleanup(func() { openMediaFileForCopy = old })
+	wantErr := errors.New("open failed")
+	openMediaFileForCopy = func(string) (*os.File, error) { return nil, wantErr }
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "photo.jpg")
+	dest := filepath.Join(dir, "out", "photo.jpg")
+	if err := os.WriteFile(src, []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyMediaFile(src, dest); !errors.Is(err, wantErr) {
+		t.Fatalf("copyMediaFile error = %v, want %v", err, wantErr)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("destination should not exist after open failure: %v", err)
+	}
+}
+
+func TestCopyMediaFileReadErrorRemovesDestination(t *testing.T) {
+	old := openMediaFileForCopy
+	t.Cleanup(func() { openMediaFileForCopy = old })
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "photo.jpg")
+	dest := filepath.Join(dir, "out", "photo.jpg")
+	if err := os.WriteFile(src, []byte("image"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeOnly, err := os.OpenFile(filepath.Join(dir, "write-only"), os.O_CREATE|os.O_WRONLY, 0o600) // #nosec G304 -- test path is confined under t.TempDir.
+	if err != nil {
+		t.Fatal(err)
+	}
+	openMediaFileForCopy = func(string) (*os.File, error) { return writeOnly, nil }
+
+	if err := copyMediaFile(src, dest); err == nil {
+		t.Fatal("copyMediaFile should fail when the source cannot be read")
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Fatalf("partial destination should be removed after read failure: %v", err)
+	}
+}
+
 func TestCopyArchiveMediaSkipsUnmaterialized(t *testing.T) {
 	old := mediaMaterialized
 	t.Cleanup(func() { mediaMaterialized = old })


### PR DESCRIPTION
Main went red after #73 merged: the gofumpt gate failed, and the Linux coverage floor fell to 84.9% because the new dataless-media copy paths were not fully exercised cross-platform.

This PR:

- applies gofumpt to internal/whatsappdb/desktop.go
- adds cross-platform regression tests for media open failures and read failures
- proves failed reads remove partial destination files
- preserves the existing tests for skipped iCloud placeholders and successful materialized copies

Proof:

- ./scripts/coverage.sh 85.0: 85.3% on macOS
- ./scripts/coverage.sh 85.0: 85.2% in Linux with Go 1.26.6
- go test ./...
- golangci-lint run: 0 issues
- built binary doctor and status smoke checks
