### PR TITLE
chore(deps): refresh dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      - uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: go
-      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      - uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
-	github.com/openclaw/crawlkit v0.14.6
+	github.com/openclaw/crawlkit v0.14.7
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsRe
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/openclaw/crawlkit v0.14.6 h1:NUEC9xu/IDzUv1rO/27aWNuTblvd3eYSooLfDn1RDvA=
-github.com/openclaw/crawlkit v0.14.6/go.mod h1:rLf+LwCKA4qSXD5JdKv0CDVJv8zMnhUH17tHxvKdd0U=
+github.com/openclaw/crawlkit v0.14.7 h1:Kvceob5WyEtrGt4YkwKRcepU77g7FX/HPTRIiCe+ArQ=
+github.com/openclaw/crawlkit v0.14.7/go.mod h1:iDnctBAFtqB5l2sHREfpyjQwifToeebDVdVJvZWVLn0=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=

--- a/internal/webui/server_test.go
+++ b/internal/webui/server_test.go
@@ -390,7 +390,7 @@ func TestServeLifecycleAndPrivateURL(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Serve returned %v", err)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("Serve did not stop after context cancellation")
 	}
 }


### PR DESCRIPTION
## Summary

- Refresh `github.com/openclaw/crawlkit` 0.14.6 → 0.14.7.
- Refresh SHA-pinned `github/codeql-action/init` and `github/codeql-action/analyze` 4.37.6 → 4.37.7 while preserving immutable action pins.
- Fix an independently reproduced flaky web-viewer lifecycle test: its previous five-second assertion deadline exactly matched the server’s five-second graceful-shutdown budget, so valid shutdowns failed at 5.01 seconds. Give the assertion ten seconds while keeping production shutdown behavior unchanged.
- Held: none.
- Supersedes Dependabot PRs #75, #76, and #77.

## Verification

- Reproduced the original flaky lifecycle failure twice with `go test -count=5 ./internal/webui -run TestServeLifecycleAndPrivateURL -v`; after the one-line test fix, all five runs passed, including several legitimate 5.01-second graceful shutdowns.
- `go mod tidy`
- `go vet ./...`
- `go test -count=1 ./...` — all packages passed.
- `go build -o /private/tmp/t30-wacrawl ./cmd/wacrawl`
- Real compiled CLI smokes: `--help`, `--version`, `--json metadata`, and `--db /private/tmp/t30-wacrawl-smoke.db --json --sync never status` all exited 0; the status smoke uses an isolated temporary archive.
- `go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...` — no reachable vulnerabilities.
- Structured pre-commit Codex review: clean.
