### PR TITLE
fix(test): restore native macOS verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,22 @@ jobs:
       - name: Build
         run: go build ./cmd/wacrawl
 
+  test-macos:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Test on macOS
+        run: go test -count=1 ./...
+
   deps:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -15,6 +15,7 @@ import (
 	"filippo.io/age"
 	ckbackup "github.com/openclaw/crawlkit/backup"
 	"github.com/openclaw/wacrawl/internal/store"
+	"github.com/openclaw/wacrawl/internal/testutil"
 )
 
 func TestEncryptedBackupPushPull(t *testing.T) {
@@ -52,7 +53,7 @@ func TestEncryptedBackupPushPull(t *testing.T) {
 
 	remote := filepath.Join(t.TempDir(), "remote.git")
 	initBareRemote(t, remote)
-	repo := filepath.Join(t.TempDir(), "backup")
+	repo := filepath.Join(testutil.TempDir(t), "backup")
 	identity := filepath.Join(t.TempDir(), "age.key")
 	configPath := filepath.Join(t.TempDir(), "backup.json")
 	cfg, recipient, err := Init(ctx, Options{ConfigPath: configPath, Repo: repo, Remote: remote, Identity: identity, Push: false})
@@ -356,7 +357,7 @@ func TestHistoricalSnapshotRestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	repo := filepath.Join(t.TempDir(), "backup")
+	repo := filepath.Join(testutil.TempDir(t), "backup")
 	remote := filepath.Join(t.TempDir(), "remote.git")
 	initBareRemote(t, remote)
 	identity := filepath.Join(t.TempDir(), "age.key")
@@ -1012,6 +1013,7 @@ func runGit(t *testing.T, dir string, args ...string) {
 }
 
 func gitOutput(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	args = append([]string{"-c", "commit.gpgsign=false", "-c", "tag.gpgsign=false"}, args...)
 	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- tests pass only fixed Git commands and temporary paths.
 	cmd.Dir = dir
 	cmd.Env = append(

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/openclaw/wacrawl/internal/store"
+	"github.com/openclaw/wacrawl/internal/testutil"
 	"github.com/openclaw/wacrawl/internal/whatsappdb"
 	_ "modernc.org/sqlite"
 )
@@ -741,7 +742,7 @@ func TestBackupCommands(t *testing.T) {
 		t.Fatal(err)
 	}
 	config := filepath.Join(t.TempDir(), "backup.json")
-	repo := filepath.Join(t.TempDir(), "backup")
+	repo := filepath.Join(testutil.TempDir(t), "backup")
 	identity := filepath.Join(t.TempDir(), "age.key")
 
 	var stdout, stderr bytes.Buffer

--- a/internal/mediafile/file_test.go
+++ b/internal/mediafile/file_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/openclaw/wacrawl/internal/testutil"
 )
 
 func TestConfinedMediaRead(t *testing.T) {
@@ -40,7 +42,7 @@ func TestConfinedMediaRead(t *testing.T) {
 }
 
 func TestResolvePreservesOSPathMeaning(t *testing.T) {
-	base := t.TempDir()
+	base := testutil.TempDir(t)
 	t.Chdir(base)
 	target := filepath.Join(base, "target")
 	if err := os.MkdirAll(filepath.Join(target, "child"), 0o700); err != nil {
@@ -103,7 +105,9 @@ func TestMediaRejectsAliasesAndSpecialFiles(t *testing.T) {
 	}
 	// A Unix socket exercises nonregular refusal without a blocking read.
 	socket := filepath.Join(root, "socket")
-	listener, err := net.Listen("unix", socket)
+	// Bind relatively so long test directories do not exceed sockaddr_un.
+	t.Chdir(root)
+	listener, err := net.Listen("unix", "socket")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testutil/tempdir.go
+++ b/internal/testutil/tempdir.go
@@ -1,0 +1,18 @@
+// Package testutil provides shared filesystem fixtures for tests.
+package testutil
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TempDir returns a canonical temporary directory for exact path assertions.
+// macOS commonly exposes its temporary root through the /var symlink.
+func TempDir(t testing.TB) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}

--- a/internal/whatsappdb/audit_media_test.go
+++ b/internal/whatsappdb/audit_media_test.go
@@ -19,6 +19,7 @@ import (
 	ckbackup "github.com/openclaw/crawlkit/backup"
 	"github.com/openclaw/wacrawl/internal/backup"
 	"github.com/openclaw/wacrawl/internal/store"
+	"github.com/openclaw/wacrawl/internal/testutil"
 )
 
 func TestAuditInvalidMediaPreservesMetadata(t *testing.T) {
@@ -246,7 +247,7 @@ func TestAuditMediaRejectsCaseEquivalentSourceRoot(t *testing.T) {
 
 func auditMediaFixture(t *testing.T) (*store.Store, string, string) {
 	t.Helper()
-	source := t.TempDir()
+	source := testutil.TempDir(t)
 	createFixtureDBs(t, source)
 	path := filepath.Join(source, "Message", "Media", "123@g.us", "a", "test.jpg")
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -255,7 +256,7 @@ func auditMediaFixture(t *testing.T) (*store.Store, string, string) {
 	if err := os.WriteFile(path, []byte("image"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	st, err := store.Open(context.Background(), filepath.Join(t.TempDir(), "archive.db"))
+	st, err := store.Open(context.Background(), filepath.Join(testutil.TempDir(t), "archive.db"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/whatsappdb/desktop_test.go
+++ b/internal/whatsappdb/desktop_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/openclaw/wacrawl/internal/store"
+	"github.com/openclaw/wacrawl/internal/testutil"
 	_ "modernc.org/sqlite"
 )
 
@@ -767,7 +768,7 @@ insert into ZWAGROUPMEMBER values (2, 2, '222@lid', 'Alice Duplicate', 'Alicia',
 
 func TestImportDesktopReadsMediaLinkedByMessage(t *testing.T) {
 	ctx := context.Background()
-	source := t.TempDir()
+	source := testutil.TempDir(t)
 	createFixtureDBs(t, source)
 
 	chatDB, err := sql.Open("sqlite", filepath.Join(source, chatDBName))
@@ -899,7 +900,7 @@ func TestCleanDesktopMediaRel(t *testing.T) {
 
 func TestImportDesktopCopyMedia(t *testing.T) {
 	ctx := context.Background()
-	source := t.TempDir()
+	source := testutil.TempDir(t)
 	createFixtureDBs(t, source)
 	mediaPath := filepath.Join(source, "Message", "Media", "123@g.us", "a", "test.jpg")
 	if err := os.MkdirAll(filepath.Dir(mediaPath), 0o700); err != nil {
@@ -921,7 +922,7 @@ insert into ZWAMESSAGE values (5, 2, 1, 2, 'missing-media', 0, 700000004, 'missi
 		t.Fatal(err)
 	}
 
-	archivePath := filepath.Join(t.TempDir(), "archive.db")
+	archivePath := filepath.Join(testutil.TempDir(t), "archive.db")
 	archive, err := store.Open(ctx, archivePath)
 	if err != nil {
 		t.Fatal(err)
@@ -1004,8 +1005,8 @@ func TestResolveDesktopMediaPathPrefersMessageMedia(t *testing.T) {
 }
 
 func TestCopyArchiveMediaDeduplicatesAndConfinesPaths(t *testing.T) {
-	source := t.TempDir()
-	mediaRoot := filepath.Join(t.TempDir(), "media")
+	source := testutil.TempDir(t)
+	mediaRoot := filepath.Join(testutil.TempDir(t), "media")
 	mediaPath := filepath.Join(source, "Message", "Media", "chat", "photo.jpg")
 	if err := os.MkdirAll(filepath.Dir(mediaPath), 0o700); err != nil {
 		t.Fatal(err)
@@ -1339,7 +1340,7 @@ func TestCanonicalSourcePath(t *testing.T) {
 	if path != want {
 		t.Fatalf("canonical path = %q, want %q", path, want)
 	}
-	missing := filepath.Join(t.TempDir(), "missing")
+	missing := filepath.Join(testutil.TempDir(t), "missing")
 	path, err = canonicalSourcePath(missing)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/whatsappdb/media_materialized_darwin_test.go
+++ b/internal/whatsappdb/media_materialized_darwin_test.go
@@ -40,7 +40,7 @@ func TestFileMaterializedDatalessFlag(t *testing.T) {
 func TestCopyMediaFileTreatsNonblockingOpenAsMissing(t *testing.T) {
 	old := openMediaFileForCopy
 	t.Cleanup(func() { openMediaFileForCopy = old })
-	openMediaFileForCopy = func(string) (*os.File, error) { return nil, syscall.EAGAIN }
+	openMediaFileForCopy = func(string, string) (*os.File, error) { return nil, syscall.EAGAIN }
 
 	dir := t.TempDir()
 	src := filepath.Join(dir, "photo.jpg")
@@ -48,7 +48,7 @@ func TestCopyMediaFileTreatsNonblockingOpenAsMissing(t *testing.T) {
 	if err := os.WriteFile(src, []byte("image"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := copyMediaFile(src, dest); !errors.Is(err, errMediaNotDownloaded) {
+	if _, err := copyMediaFile(dir, src, dest); !errors.Is(err, errMediaNotDownloaded) {
 		t.Fatalf("nonblocking open error = %v, want media not downloaded", err)
 	}
 	if _, err := os.Stat(dest); !os.IsNotExist(err) {


### PR DESCRIPTION
The default Linux checks passed after #87, but the macOS test suite no longer compiled: its nonblocking-media fixture still used the old copier signatures. Native verification also exposed path fixtures comparing `/var` against canonical `/private/var`, an overlong Unix socket pathname, and Git fixtures inheriting the developer's tag-signing configuration.

Update the Darwin fixture, canonicalize only paths used in exact fixture assertions, bind the socket relatively, and disable signing for fixture Git commands. Keep the existing confinement, media-preservation, and tombstone assertions intact. Add a macOS job running the full Go suite so these failures are visible in CI.

The two Darwin signature corrections are also present in #88; credit to @alexph-dev. This PR can land independently of that feature's archive-format decision. Release notes remain centralized in #89; these changes affect tests and CI only.

Validation: native macOS suite, formatting/vet, isolated review, and a built-CLI import/search/encrypted backup/restore smoke with synthetic messages and attachment bytes. Exact check results will be recorded in the proof comment.
